### PR TITLE
Wire edge-ping edge function routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -146,3 +146,12 @@
   to = "/admin/"
   status = 302
 
+# Edge healthcheck
+[[edge_functions]]
+  path = "/edge-ping"
+  function = "edge-ping"
+
+[[edge_functions]]
+  path = "/edge-ping/*"
+  function = "edge-ping"
+


### PR DESCRIPTION
Adds Netlify Edge Function routing for /edge-ping and /edge-ping/* so the healthcheck endpoint returns 200 instead of 404.
  
How to test (Deploy Preview):
- curl -i https://<preview>/edge-ping
- curl -i https://<preview>/edge-ping/
Expected: 200 (not 404).