### PR TITLE
Harden CORS: same-origin allow + env URL (no hardcoded prod domains)

### DIFF
--- a/netlify/functions/_lib/http.js
+++ b/netlify/functions/_lib/http.js
@@ -2,16 +2,13 @@
 // Provides security headers, CORS, and response utilities
 const crypto = require('crypto');
 
-// Trusted origins for CORS
-const TRUSTED_ORIGINS = [
-  'https://reinischclassroom.com',
-  'https://www.reinischclassroom.com',
+// Local dev origins for CORS (explicit)
+const LOCAL_TRUSTED_ORIGINS = [
   'http://localhost:8888',
   'http://localhost:3000',
   'http://127.0.0.1:8888',
   'http://127.0.0.1:3000',
 ];
-
 // Default security headers used across all responses
 const DEFAULT_SEC_HEADERS = {
   'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
@@ -21,6 +18,46 @@ const DEFAULT_SEC_HEADERS = {
   'X-Frame-Options': 'SAMEORIGIN',
 };
 
+
+function getRequestOrigin(event) {
+  const headers = (event && event.headers) || {};
+  const protoRaw = headers['x-forwarded-proto'] || headers['X-Forwarded-Proto'] || 'https';
+  const hostRaw = headers['x-forwarded-host'] || headers['X-Forwarded-Host'] || headers.host || headers.Host || '';
+  const proto = String(protoRaw).split(',')[0].trim() || 'https';
+  const host = String(hostRaw).split(',')[0].trim();
+  if (!host) return '';
+  return `${proto}://${host}`;
+}
+
+function getEnvSiteOrigins() {
+  const out = new Set();
+  const candidates = [
+    process.env.DEPLOY_PRIME_URL,
+    process.env.DEPLOY_URL,
+    process.env.URL,
+    process.env.SITE_URL,
+  ].filter(Boolean);
+
+  for (const raw of candidates) {
+    try {
+      const u = new URL(raw);
+      out.add(`${u.protocol}//${u.host}`);
+
+      // If this is a custom domain, allow the www/apex sibling too.
+      // Avoid generating nonsense like www.<site>.netlify.app.
+      if (!u.hostname.endsWith('.netlify.app')) {
+        if (u.hostname.startsWith('www.')) {
+          out.add(`${u.protocol}//${u.host.replace(/^www\./, '')}`);
+        } else {
+          out.add(`${u.protocol}//www.${u.host}`);
+        }
+      }
+    } catch (_) {
+      // ignore invalid URL
+    }
+  }
+  return out;
+}
 /**
  * Generate a unique request ID
  * @returns {string} UUID v4 format request ID
@@ -99,19 +136,26 @@ function htmlResponse(event, status, body, extraHeaders = {}, requestId = null) 
  * @param {string} origin - Origin header from request
  * @returns {boolean} True if origin is allowed
  */
-function isOriginAllowed(origin) {
+function isOriginAllowed(origin, event) {
   if (!origin) return false;
-  
-  // Check trusted origins
-  if (TRUSTED_ORIGINS.includes(origin)) {
+
+  // Local dev
+  if (LOCAL_TRUSTED_ORIGINS.includes(origin)) {
     return true;
   }
-  
-  // Allow Netlify deploy previews
-  if (origin.match(/^https:\/\/[a-z0-9-]+\.netlify\.app$/)) {
+
+  // Same-origin (deploy previews / branch deploys / custom domains)
+  const reqOrigin = getRequestOrigin(event);
+  if (reqOrigin && origin === reqOrigin) {
     return true;
   }
-  
+
+  // Env site origins (custom domain or netlify URL; includes www/apex sibling when applicable)
+  const envOrigins = getEnvSiteOrigins();
+  if (envOrigins.has(origin)) {
+    return true;
+  }
+
   return false;
 }
 
@@ -132,7 +176,7 @@ function getCorsHeaders(event, methods = ['GET', 'POST', 'OPTIONS'], headers = [
   };
   
   // Only echo origin if it's allowed
-  if (isOriginAllowed(origin)) {
+  if (isOriginAllowed(origin, event)) {
     corsHeaders['Access-Control-Allow-Origin'] = origin;
     // When allowing credentials, we must set this header
     corsHeaders['Access-Control-Allow-Credentials'] = 'true';
@@ -273,4 +317,5 @@ module.exports = {
   validateBodySize,
   safeJsonParse,
   validateStringField,
+  getRequestOrigin,
 };

--- a/tests/http-cors-origins.spec.js
+++ b/tests/http-cors-origins.spec.js
@@ -1,0 +1,54 @@
+/* eslint-env node */
+import { describe, it, expect, afterEach } from "vitest";
+import http from "../netlify/functions/_lib/http.js";
+
+const { isOriginAllowed } = http;
+
+function mkEvent({ origin, host = "deploy-preview-123--site.netlify.app", proto = "https" } = {}) {
+  return { headers: { origin, host, "x-forwarded-proto": proto } };
+}
+
+describe("http helpers: CORS origin hardening", () => {
+  const savedURL = process.env.URL;
+
+  afterEach(() => {
+    process.env.URL = savedURL;
+  });
+
+  it("allows local dev origins", () => {
+    expect(
+      isOriginAllowed(
+        "http://localhost:8888",
+        mkEvent({ origin: "http://localhost:8888", host: "localhost:8888", proto: "http" })
+      )
+    ).toBe(true);
+  });
+
+  it("allows same-origin derived from request host/proto", () => {
+    const o = "https://deploy-preview-123--site.netlify.app";
+    expect(isOriginAllowed(o, mkEvent({ origin: o, host: "deploy-preview-123--site.netlify.app" }))).toBe(true);
+  });
+
+  it("allows env URL origin and www/apex sibling for custom domains", () => {
+    process.env.URL = "https://reinischclassroom.com";
+    expect(
+      isOriginAllowed(
+        "https://www.reinischclassroom.com",
+        mkEvent({ origin: "https://www.reinischclassroom.com", host: "reinischclassroom.com" })
+      )
+    ).toBe(true);
+  });
+
+  it("rejects random third-party origins", () => {
+    expect(isOriginAllowed("https://evil.example", mkEvent({ origin: "https://evil.example" }))).toBe(false);
+  });
+
+  it("rejects other netlify.app origins when not same-origin", () => {
+    expect(
+      isOriginAllowed(
+        "https://someone-else.netlify.app",
+        mkEvent({ origin: "https://someone-else.netlify.app", host: "deploy-preview-123--site.netlify.app" })
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- Removed hardcoded production origins from Netlify function CORS helper.
- Allow origins when:
  - local dev (localhost / 127.0.0.1)
  - **same-origin** derived from request host/proto (deploy previews/branch deploys/custom domains)
  - env URLs (`DEPLOY_PRIME_URL`, `DEPLOY_URL`, `URL`, `SITE_URL`) + www/apex sibling for custom domains
- Added tests for allow/deny behavior.

## Guardrails
- **netlify.toml untouched**.

## How to test (Deploy Preview)
```bash
DEPLOY="<DEPLOY_PREVIEW_URL>"

# Allowed: same-origin preflight should echo Access-Control-Allow-Origin
curl -sSI -X OPTIONS "$DEPLOY/.netlify/functions/student-login" \
  -H "Origin: $DEPLOY" \
  -H "Access-Control-Request-Method: POST" \
  | egrep -i "HTTP/|access-control-allow-origin|access-control-allow-credentials|vary"

# Denied: random origin should NOT echo Access-Control-Allow-Origin
curl -sSI -X OPTIONS "$DEPLOY/.netlify/functions/student-login" \
  -H "Origin: https://evil.example" \
  -H "Access-Control-Request-Method: POST" \
  | egrep -i "HTTP/|access-control-allow-origin|vary"
```
