### PR TITLE
Fix Admin redirect loop: unauth -> /hub (SSO), not /admin-login

### DIFF
--- a/netlify/edge-functions/admin-auth-guard.js
+++ b/netlify/edge-functions/admin-auth-guard.js
@@ -13,7 +13,7 @@
 function redirectToAdminLogin() {
   return new Response(null, {
     status: 302,
-    headers: { Location: "/admin-login/?reason=missing_admin_session" },
+    headers: { Location: "/hub/?reason=missing_admin_session&next=%2Fadmin%2F" },
   });
 }
 

--- a/netlify/functions/admin-logout.js
+++ b/netlify/functions/admin-logout.js
@@ -5,7 +5,7 @@ exports.handler = async () => {
   return {
     statusCode: 302,
     headers: {
-      Location: '/admin-login',
+      Location: '/hub/?reason=admin_logged_out',
       'Set-Cookie': `${COOKIE_NAME}=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax`,
       'Cache-Control': 'no-store'
     }


### PR DESCRIPTION
## What changed
- Edge guard now redirects unauthenticated /admin/* requests to /hub/ (Teacher Center SSO) instead of /admin-login.
- admin-logout now redirects to /hub/ instead of /admin-login.

## Why
- /admin-login is a legacy URL with netlify redirects back to /admin, and the admin-login page no longer exists.
- This created an infinite 302 loop: /admin -> /admin-login -> /admin -> ...

## Guardrails
- netlify.toml untouched.

## How to test (Deploy Preview)
1) In a fresh/private window (no cookies), open /admin/.
   - Expected: 302 to /hub/?reason=missing_admin_session...
2) Log in via Teacher Center, then use the Admin button.
   - Expected: /admin loads normally.
3) Hit /.netlify/functions/admin-logout (or your logout UI).
   - Expected: ends on /hub/?reason=admin_logged_out
