### PR TITLE
Chore: Add reason code to /admin-login redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -138,12 +138,12 @@
 # Redirect old admin-login URLs to admin area (which requires Teacher Center SSO)
 [[redirects]]
   from = "/admin-login"
-  to = "/hub/?next=%2Fadmin%2F"
+  to = "/hub/?reason=admin_login_deprecated&next=%2Fadmin%2F"
   status = 302
 
 [[redirects]]
   from = "/admin-login/*"
-  to = "/hub/?next=%2Fadmin%2F"
+  to = "/hub/?reason=admin_login_deprecated&next=%2Fadmin%2F"
   status = 302
 
 # Edge healthcheck


### PR DESCRIPTION
Keep redirects consistent: /admin-login now redirects to /hub with reason=admin_login_deprecated and next=/admin.