### PR TITLE
Fix Admin SSO: allow incremental-deploy via tc admin session

### DIFF
--- a/netlify/functions/incremental-deploy.js
+++ b/netlify/functions/incremental-deploy.js
@@ -7,6 +7,7 @@
 
 const crypto = require('crypto');
 const { verifySession, createErrorResponse } = require('./_lib/token-utils');
+const { requireTeacher } = require('./_lib/auth');
 
 const GH_API = 'https://api.github.com';
 const DELETE = Symbol('DELETE');
@@ -181,52 +182,52 @@ async function handleDelete(body, remainingTTL){
 
 // ---------- Auth helper ----------
 async function requireAdmin(event){
+  // ✅ SSO path: Teacher Center cookie (tc) signed with SESSION_SECRET
+  const tcSecret = (process.env.SESSION_SECRET || '').trim();
+  if (tcSecret) {
+    const tc = requireTeacher(event, tcSecret);
+
+    // requireTeacher() accepts both teacher/admin — we ONLY allow admin into incremental deploy
+    if (tc.ok && tc.user && tc.user.role === 'admin') {
+      const now = Math.floor(Date.now() / 1000);
+      const remainingTTL = (tc.user.exp ? (tc.user.exp - now) : 0);
+      return { ok: true, remainingTTL: Math.max(0, remainingTTL) };
+    }
+
+    // Logged in but not admin → deny (this is NOT a "session expired" case)
+    if (tc.ok && tc.user && tc.user.role !== 'admin') {
+      return { ok: false, response: createErrorResponse('FORBIDDEN', 'Admin access required', false, 403) };
+    }
+  }
+
+  // Fallback: legacy admin cookies (rc_admin_session_v4) signed with ADMIN_SESSION_SECRET
   const secret = (process.env.ADMIN_SESSION_SECRET || '').trim();
-  
   if (!secret) {
-    return {
-      ok: false,
-      response: createErrorResponse('SERVER_ERROR', 'Server configuration error', false, 503)
-    };
+    return { ok: false, response: createErrorResponse('SERVER_ERROR', 'Server configuration error', false, 503) };
   }
 
   const sessionInfo = verifySession(event.headers, secret);
-  
+
+  // ADMIN_KEY header fallback (old tooling)
   if (!sessionInfo.valid) {
-    if (ENABLE_SESSION_LOG) {
-      console.log('[incremental-deploy] Session verification failed');
+    const requiredKey = process.env.ADMIN_KEY;
+    if (requiredKey) {
+      const hdrs = event.headers || {};
+      const sentKey = hdrs['x-admin-key'] || hdrs['X-Admin-Key'] || hdrs['x-Admin-Key'];
+      if (sentKey && sentKey === requiredKey) {
+        return { ok: true, remainingTTL: 3600 };
+      }
     }
-    return {
-      ok: false,
-      response: createErrorResponse('SESSION_EXPIRED', 'Session expired or invalid', true, 401)
-    };
+
+    if (ENABLE_SESSION_LOG) console.log('[incremental-deploy] Session verification failed');
+    return { ok: false, response: createErrorResponse('SESSION_EXPIRED', 'Session expired or invalid', true, 401) };
   }
 
   if (sessionInfo.needsUpgrade && ENABLE_SESSION_LOG) {
     console.log('[incremental-deploy] Legacy session detected (version:', sessionInfo.legacyVersion, ')');
   }
 
-  // Check for ADMIN_KEY fallback (legacy support)
-  const requiredKey = process.env.ADMIN_KEY;
-  if (!sessionInfo.valid && requiredKey) {
-    const hdrs = event.headers || {};
-    const sentKey = hdrs['x-admin-key'] || hdrs['X-Admin-Key'] || hdrs['x-Admin-Key'];
-    if (sentKey && sentKey === requiredKey) {
-      return { ok: true, remainingTTL: 3600 }; // Fallback TTL
-    }
-  }
-
-  if (!sessionInfo.valid) {
-    return {
-      ok: false,
-      response: createErrorResponse('SESSION_EXPIRED', 'Session expired or invalid', true, 401)
-    };
-  }
-
-  return { 
-    ok: true, 
-    remainingTTL: sessionInfo.remainingTTL || 0 
-  };
+  return { ok: true, remainingTTL: sessionInfo.remainingTTL || 0 };
 }
 
 // ---------- Units loader ----------

--- a/site/admin/gate.js
+++ b/site/admin/gate.js
@@ -3,18 +3,25 @@
 (function(){
   async function gate(){
     try{
-      // Check Teacher Center session instead of admin session
       const r = await fetch('/.netlify/functions/teacher-session', { cache:'no-store', credentials:'same-origin' });
       if (!r.ok) {
-        // If Teacher Center session not valid, redirect to hub
-        location.replace('/hub/');
+        location.replace('/hub/?reason=missing_teacher_session&next=%2Fadmin%2F');
         return;
       }
+
+      const data = await r.json().catch(() => null);
+      const raw = data && (data.raw_role || data.role);
+
+      // Only allow real admins into /admin/
+      if (raw !== 'admin') {
+        location.replace('/hub/?reason=not_admin&next=%2Fadmin%2F');
+        return;
+      }
+
       document.getElementById('app').style.display='block';
       document.getElementById('gate').style.display='none';
     }catch{
-      // On error, redirect to Teacher Center
-      location.replace('/hub/');
+      location.replace('/hub/?reason=gate_error&next=%2Fadmin%2F');
     }
   }
   gate();


### PR DESCRIPTION
## What this PR fixes
- incremental-deploy now accepts Teacher Center SSO ('tc' cookie) for admin users
- avoids 401 on Deploy Preview domains where 'rc_admin_session' cookies are not present

## Acceptance criteria
- In Deploy Preview: login via /hub as admin
- Navigate to /admin
- Any action that calls '/.netlify/functions/incremental-deploy' returns 200 (no 401)
- Non-admin users receive 403 from '/.netlify/functions/incremental-deploy'

## Notes
- Netlify auto-publishing is enabled (main publishes automatically after merge)

## Done Proof Pack (Required)
- Attach 20–90s screen recording:
  - Start on GitHub PR page with green checks (PR #352)
  - Click Deploy Preview link from PR
  - Hard reload
  - Login on /hub (admin)
  - Go to /admin
  - Select a category + slot, then click **Delete slot**
  - In DevTools → Network, click the request to `/.netlify/functions/incremental-deploy` and show:
    - **Status = 200**
    - the **Response** JSON briefly (proof it’s not a 401/redirect)
  - Show DevTools Console for 2–3 seconds (no relevant red errors)
  - “In DevTools → Network, click the incremental-deploy request and confirm Status = 200 (not 401).”

## Links
- Branch: fix/admin-sso-incremental-deploy
- Commit: 83d95b9
- Deploy Preview URL: https://deploy-preview-352--chipper-moonbeam-dbd329.netlify.app



