### PR TITLE
Show Admin link when authenticated as admin

### DIFF
--- a/site/assets/js/app-shell.js
+++ b/site/assets/js/app-shell.js
@@ -474,14 +474,14 @@
       // Phase 302C: Defensive - Update admin link visibility if present (only for admin role)
       const adminLink = rail.querySelector('[data-admin-only]');
       if (adminLink) {
-        // Only show admin link if current page role is admin (not just if user has admin auth)
-        if (pageRole === 'admin') {
+        // Show Admin link if authenticated as admin (or already on an admin page)
+        const isAdminAuthed = isAuthed && auth && auth.role === 'admin';
+        if (pageRole === 'admin' || isAdminAuthed) {
           adminLink.classList.remove('app-shell-hidden');
         } else {
           adminLink.classList.add('app-shell-hidden');
         }
       }
-
       // Phase 302C: Defensive - Update status if element present
       // PR-student-portal-fallback: Use page role for display (prevents "Signed in as Teacher" on student pages)
       const status = rail.querySelector('[data-shell-status]');


### PR DESCRIPTION
## What
- Show the Admin nav link when the user is authenticated as admin (not only when already on an admin page).

## Why
- Previously admins could be logged in but still not see the Admin entry point.

## Test
- Log in as admin
- Confirm Admin button appears in Teacher Center rail
- Click Admin → loads Admin module

## Notes
- No netlify.toml changes