### PR TITLE
Remove stale Life Skills Presentation 32 from Lessons list

### DIFF
--- a/site/assets/content/lessons-index.json
+++ b/site/assets/content/lessons-index.json
@@ -12,72 +12,72 @@
           "presentations": [
             {
               "id": "presentation-03",
-              "name": "Presentation 3",
+              "name": "Week 03 - Chapters 8-10 - Setting Focus",
               "url": "/presentations/a-door-into-time/presentation-03/"
             },
             {
               "id": "presentation-04",
-              "name": "Presentation 4",
+              "name": "Week 04 - Chapters 11-13 - POV/Narration",
               "url": "/presentations/a-door-into-time/presentation-04/"
             },
             {
               "id": "presentation-05",
-              "name": "Presentation 5",
+              "name": "Week 5 - Chapters 14-16 - Structure and Sequence Focus",
               "url": "/presentations/a-door-into-time/presentation-05/"
             },
             {
               "id": "presentation-06",
-              "name": "Presentation 6",
+              "name": "Week 06 - Craft/Setting Focus | A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-06/"
             },
             {
               "id": "presentation-07",
-              "name": "Presentation 7",
+              "name": "Week 07 - Writing Methods & Setting Focus | A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-07/"
             },
             {
               "id": "presentation-08",
-              "name": "Presentation 8",
+              "name": "Week 08 – A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-08/"
             },
             {
               "id": "presentation-09",
-              "name": "Presentation 9",
+              "name": "Week 9 - Chapters 26-28 - Writing Strong Arguments with Topic Sentences",
               "url": "/presentations/a-door-into-time/presentation-09/"
             },
             {
               "id": "presentation-10",
-              "name": "Presentation 10",
+              "name": "Week 10 - Chapters 29-31 - Structure",
               "url": "/presentations/a-door-into-time/presentation-10/"
             },
             {
               "id": "presentation-11",
-              "name": "Presentation 11",
+              "name": "Week 11 - A Door Into Time - Chapters 32-37 - Multiple Perspectives in Storytelling",
               "url": "/presentations/a-door-into-time/presentation-11/"
             },
             {
               "id": "presentation-12",
-              "name": "Presentation 12",
+              "name": "Week 12 - A Door Into Time - Chapters 38-41 - Strong Textual Evidence Throughout",
               "url": "/presentations/a-door-into-time/presentation-12/"
             },
             {
               "id": "presentation-13",
-              "name": "Presentation 13",
+              "name": "Week 13 - A Door Into Time - Chapters 42-45 - Character Motivation and Internal Conflict",
               "url": "/presentations/a-door-into-time/presentation-13/"
             },
             {
               "id": "presentation-14",
-              "name": "Presentation 14",
+              "name": "F I N A L S   P R E P",
               "url": "/presentations/a-door-into-time/presentation-14/"
             },
             {
               "id": "presentation-15",
-              "name": "Presentation 15",
+              "name": "Finals Prep #1",
               "url": "/presentations/a-door-into-time/presentation-15/"
             },
             {
               "id": "presentation-16",
-              "name": "Presentation 16",
+              "name": "Finals Prep #2",
               "url": "/presentations/a-door-into-time/presentation-16/"
             }
           ]
@@ -95,13 +95,7 @@
         {
           "id": "warrior-of-kragdon-ah",
           "name": "Warrior of Kragdon-Ah",
-          "presentations": [
-            {
-              "id": "presentation-01",
-              "name": "Presentation 1",
-              "url": "/presentations/warrior-of-kragdon-ah/presentation-01/"
-            }
-          ]
+          "presentations": []
         }
       ]
     },
@@ -115,27 +109,27 @@
           "presentations": [
             {
               "id": "presentation-01",
-              "name": "Presentation 1",
+              "name": "Life Skills: Nutrition & Grocery Shopping - 4 Day Program",
               "url": "/life-skills/presentations/presentation-01/"
             },
             {
               "id": "presentation-02",
-              "name": "Presentation 2",
+              "name": "Complete Job Skills Presentation - 2 Week Program",
               "url": "/life-skills/presentations/presentation-02/"
             },
             {
               "id": "presentation-03",
-              "name": "Presentation 3",
+              "name": "Life Skills Presentation: Employment & Independent Living for Students",
               "url": "/life-skills/presentations/presentation-03/"
             },
             {
               "id": "presentation-04",
-              "name": "Presentation 4",
+              "name": "Counting Money",
               "url": "/life-skills/presentations/presentation-04/"
             },
             {
               "id": "presentation-05",
-              "name": "Presentation 5",
+              "name": "Understanding Your Paycheck",
               "url": "/life-skills/presentations/presentation-05/"
             }
           ]


### PR DESCRIPTION
## What
- Remove stale Life Skills listing for Presentation 32 from index/state data so it no longer appears in the Lessons menu.

## Why
- Presentation 32 was removed, but the UI still advertises it.

## Test
- Open Deploy Preview
- Open Lessons → Life Skills
- Confirm Presentation 32 no longer appears

## Notes
- Does NOT change slot count; Admin can still manage slot 32 if desired.