### PR TITLE
Auto-generate Lessons index from disk + new category scaffolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "check:inline-scripts": "node scripts/check-inline-scripts.cjs",
     "check:nav-script": "node scripts/check-asset-paths.cjs",
     "check:schema-sync": "node scripts/schema-sync-check.mjs",
-    "postbuild": "node scripts/check-env-leaks.js && node scripts/check-inline-scripts.cjs && node scripts/check-asset-paths.cjs"
+    "postbuild": "node scripts/check-env-leaks.js && node scripts/check-inline-scripts.cjs && node scripts/check-asset-paths.cjs",
+    "generate:lessons-index": "node scripts/generate-lessons-index.mjs",
+    "prebuild": "node scripts/generate-lessons-index.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",

--- a/scripts/generate-lessons-index.mjs
+++ b/scripts/generate-lessons-index.mjs
@@ -1,0 +1,197 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const SITE_DIR = path.join(process.cwd(), 'site');
+const OUT_PATH = path.join(SITE_DIR, 'assets', 'content', 'lessons-index.json');
+
+const LANG_DIR = path.join(SITE_DIR, 'presentations');
+const LIFE_DIR = path.join(SITE_DIR, 'life-skills', 'presentations');
+
+function decodeEntities(s) {
+  return String(s || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)));
+}
+
+async function exists(p) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+async function readText(p) {
+  return await fs.readFile(p, 'utf8');
+}
+
+async function readHtmlTitle(indexHtmlPath) {
+  try {
+    const html = await readText(indexHtmlPath);
+    const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (!m) return null;
+    const t = decodeEntities(m[1].trim());
+    return t || null;
+  } catch {
+    return null;
+  }
+}
+
+function isPresentationDirName(name) {
+  return /^presentation-\d+$/i.test(name);
+}
+
+function presNum(name) {
+  const m = String(name).match(/presentation-(\d+)/i);
+  return m ? Number(m[1]) : Number.POSITIVE_INFINITY;
+}
+
+function niceFromId(id) {
+  const s = String(id || '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return s.replace(/\b\w/g, c => c.toUpperCase());
+}
+
+async function safeReadJson(p) {
+  try {
+    const raw = await fs.readFile(p, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function buildExistingMaps(existing) {
+  const unitNameById = new Map();
+  const presNameByUrl = new Map();
+
+  const sections = existing?.sections;
+  if (!Array.isArray(sections)) return { unitNameById, presNameByUrl };
+
+  for (const sec of sections) {
+    const units = sec?.units;
+    if (!Array.isArray(units)) continue;
+    for (const u of units) {
+      if (u?.id && u?.name) unitNameById.set(String(u.id), String(u.name));
+      const pres = u?.presentations;
+      if (!Array.isArray(pres)) continue;
+      for (const p of pres) {
+        if (p?.url && p?.name) presNameByUrl.set(String(p.url), String(p.name));
+      }
+    }
+  }
+  return { unitNameById, presNameByUrl };
+}
+
+async function listDirs(dir) {
+  try {
+    const items = await fs.readdir(dir, { withFileTypes: true });
+    return items.filter(d => d.isDirectory()).map(d => d.name);
+  } catch {
+    return [];
+  }
+}
+
+async function scanUnit(unitId, unitAbsDir, urlPrefix, maps) {
+  const dirs = (await listDirs(unitAbsDir)).filter(isPresentationDirName);
+  dirs.sort((a, b) => presNum(a) - presNum(b));
+
+  const presentations = [];
+  for (const d of dirs) {
+    const indexHtml = path.join(unitAbsDir, d, 'index.html');
+    if (!(await exists(indexHtml))) continue;
+
+    const url = `${urlPrefix}/${unitId}/${d}/`.replace(/\/{2,}/g, '/');
+    const id = d.toLowerCase();
+
+    let name = maps.presNameByUrl.get(url) || null;
+    // Prefer <title> when the old name is generic or missing
+    const old = (name || '').trim();
+    const generic = /^presentation\s+\d+$/i.test(old) || old.toLowerCase() === 'open' || old === '';
+    if (generic) {
+      const title = await readHtmlTitle(indexHtml);
+      if (title) name = title;
+    }
+    if (!name) name = niceFromId(d);
+
+    presentations.push({ id, name, url });
+  }
+
+  const unitName = maps.unitNameById.get(unitId) || niceFromId(unitId);
+  return { id: unitId, name: unitName, presentations };
+}
+
+async function scanLanguageArts(maps) {
+  const unitIds = await listDirs(LANG_DIR);
+  unitIds.sort((a, b) => a.localeCompare(b));
+
+  const units = [];
+  for (const unitId of unitIds) {
+    const abs = path.join(LANG_DIR, unitId);
+    const u = await scanUnit(unitId, abs, '/presentations', maps);
+    if (u.presentations.length > 0) units.push(u); // hide empty categories
+  }
+  return { name: 'LANGUAGE ARTS', units };
+}
+
+async function scanLifeSkills(maps) {
+  // Life Skills is a single unit, presentations live directly under /life-skills/presentations/presentation-XX/
+  const dirs = (await listDirs(LIFE_DIR)).filter(isPresentationDirName);
+  dirs.sort((a, b) => presNum(a) - presNum(b));
+
+  const presentations = [];
+  for (const d of dirs) {
+    const indexHtml = path.join(LIFE_DIR, d, 'index.html');
+    if (!(await exists(indexHtml))) continue;
+
+    const url = `/life-skills/presentations/${d.toLowerCase()}/`;
+    const id = d.toLowerCase();
+
+    let name = maps.presNameByUrl.get(url) || null;
+    const old = (name || '').trim();
+    const generic = /^presentation\s+\d+$/i.test(old) || old.toLowerCase() === 'open' || old === '';
+    if (generic) {
+      const title = await readHtmlTitle(indexHtml);
+      if (title) name = title;
+    }
+    if (!name) name = niceFromId(d);
+
+    presentations.push({ id, name, url });
+  }
+
+  const unit = {
+    id: 'life-skills',
+    name: maps.unitNameById.get('life-skills') || 'Life Skills',
+    presentations
+  };
+
+  const units = unit.presentations.length > 0 ? [unit] : [];
+  return { name: 'LIFE SKILLS', units };
+}
+
+async function main() {
+  const existing = await safeReadJson(OUT_PATH);
+  const maps = buildExistingMaps(existing);
+
+  const sections = [];
+  if (await exists(LANG_DIR)) sections.push(await scanLanguageArts(maps));
+  if (await exists(LIFE_DIR)) sections.push(await scanLifeSkills(maps));
+
+  const out = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    sections
+  };
+
+  await fs.mkdir(path.dirname(OUT_PATH), { recursive: true });
+  await fs.writeFile(OUT_PATH, JSON.stringify(out, null, 2) + '\n', 'utf8');
+
+  console.log(`✅ Generated: ${path.relative(process.cwd(), OUT_PATH)}`);
+}
+
+main().catch((e) => {
+  console.error('❌ generate-lessons-index failed:', e && e.stack ? e.stack : e);
+  process.exit(1);
+});

--- a/scripts/new-lesson-unit.mjs
+++ b/scripts/new-lesson-unit.mjs
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const title = args.find(a => !a.startsWith('-'));
+const section = (() => {
+  const i = args.indexOf('--section');
+  return i >= 0 ? (args[i + 1] || 'language-arts') : 'language-arts';
+})();
+const withPresentation = args.includes('--with-presentation');
+
+if (!title) {
+  console.error('Usage: node scripts/new-lesson-unit.mjs "Book Title" --section language-arts [--with-presentation]');
+  process.exit(1);
+}
+
+function slugify(s) {
+  return String(s)
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+const SITE_DIR = path.join(process.cwd(), 'site');
+const unitId = slugify(title);
+const base =
+  section === 'life-skills'
+    ? path.join(SITE_DIR, 'life-skills')
+    : path.join(SITE_DIR, 'presentations', unitId);
+
+async function ensureDir(p) {
+  await fs.mkdir(p, { recursive: true });
+}
+
+async function main() {
+  if (section === 'life-skills') {
+    console.error('❌ Life Skills is already a single unit. Use presentations slots there (presentation-01, etc.).');
+    process.exit(1);
+  }
+
+  await ensureDir(base);
+
+  if (withPresentation) {
+    const presDir = path.join(base, 'presentation-01');
+    await ensureDir(presDir);
+
+    const indexPath = path.join(presDir, 'index.html');
+    const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${title} — Presentation 1</title>
+</head>
+<body style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#0b1220;color:#e8eefc;padding:2rem;">
+  <h1>${title}</h1>
+  <p>This is a placeholder Presentation 1. Replace with your real deck/page when ready.</p>
+  <p><a href="/" style="color:#7dd3fc;">Home</a></p>
+</body>
+</html>
+`;
+    await fs.writeFile(indexPath, html, 'utf8');
+    console.log(`✅ Created unit + placeholder: site/presentations/${unitId}/presentation-01/index.html`);
+  } else {
+    console.log(`✅ Created unit folder: site/presentations/${unitId}/`);
+    console.log('   (It will NOT appear in Lessons until at least one presentation-* folder exists.)');
+    console.log('   Add one with: node scripts/new-lesson-unit.mjs "<Title>" --with-presentation');
+  }
+}
+
+main().catch((e) => {
+  console.error('❌ new-lesson-unit failed:', e && e.stack ? e.stack : e);
+  process.exit(1);
+});

--- a/site/assets/content/lessons-index.json
+++ b/site/assets/content/lessons-index.json
@@ -1,10 +1,9 @@
 {
-  "version": "1.0.0",
-  "updated": "2025-12-23T15:47:00Z",
+  "version": 1,
+  "generatedAt": "2025-12-28T14:22:02.058Z",
   "sections": [
     {
-      "id": "language-arts",
-      "name": "Language Arts",
+      "name": "LANGUAGE ARTS",
       "units": [
         {
           "id": "a-door-into-time",
@@ -12,136 +11,114 @@
           "presentations": [
             {
               "id": "presentation-03",
-              "name": "Presentation 3",
+              "name": "Week 03 - Chapters 8-10 - Setting Focus",
               "url": "/presentations/a-door-into-time/presentation-03/"
             },
             {
               "id": "presentation-04",
-              "name": "Presentation 4",
+              "name": "Week 04 - Chapters 11-13 - POV/Narration",
               "url": "/presentations/a-door-into-time/presentation-04/"
             },
             {
               "id": "presentation-05",
-              "name": "Presentation 5",
+              "name": "Week 5 - Chapters 14-16 - Structure and Sequence Focus",
               "url": "/presentations/a-door-into-time/presentation-05/"
             },
             {
               "id": "presentation-06",
-              "name": "Presentation 6",
+              "name": "Week 06 - Craft/Setting Focus | A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-06/"
             },
             {
               "id": "presentation-07",
-              "name": "Presentation 7",
+              "name": "Week 07 - Writing Methods & Setting Focus | A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-07/"
             },
             {
               "id": "presentation-08",
-              "name": "Presentation 8",
+              "name": "Week 08 – A Door Into Time",
               "url": "/presentations/a-door-into-time/presentation-08/"
             },
             {
               "id": "presentation-09",
-              "name": "Presentation 9",
+              "name": "Week 9 - Chapters 26-28 - Writing Strong Arguments with Topic Sentences",
               "url": "/presentations/a-door-into-time/presentation-09/"
             },
             {
               "id": "presentation-10",
-              "name": "Presentation 10",
+              "name": "Week 10 - Chapters 29-31 - Structure",
               "url": "/presentations/a-door-into-time/presentation-10/"
             },
             {
               "id": "presentation-11",
-              "name": "Presentation 11",
+              "name": "Week 11 - A Door Into Time - Chapters 32-37 - Multiple Perspectives in Storytelling",
               "url": "/presentations/a-door-into-time/presentation-11/"
             },
             {
               "id": "presentation-12",
-              "name": "Presentation 12",
+              "name": "Week 12 - A Door Into Time - Chapters 38-41 - Strong Textual Evidence Throughout",
               "url": "/presentations/a-door-into-time/presentation-12/"
             },
             {
               "id": "presentation-13",
-              "name": "Presentation 13",
+              "name": "Week 13 - A Door Into Time - Chapters 42-45 - Character Motivation and Internal Conflict",
               "url": "/presentations/a-door-into-time/presentation-13/"
             },
             {
               "id": "presentation-14",
-              "name": "Presentation 14",
+              "name": "F I N A L S   P R E P",
               "url": "/presentations/a-door-into-time/presentation-14/"
             },
             {
               "id": "presentation-15",
-              "name": "Presentation 15",
+              "name": "Finals Prep #1",
               "url": "/presentations/a-door-into-time/presentation-15/"
             },
             {
               "id": "presentation-16",
-              "name": "Presentation 16",
+              "name": "Finals Prep #2",
               "url": "/presentations/a-door-into-time/presentation-16/"
-            }
-          ]
-        },
-        {
-          "id": "lost-in-kragdon-ah",
-          "name": "Lost in Kragdon-Ah",
-          "presentations": []
-        },
-        {
-          "id": "return-from-kragdon-ah",
-          "name": "Return from Kragdon-Ah",
-          "presentations": []
-        },
-        {
-          "id": "warrior-of-kragdon-ah",
-          "name": "Warrior of Kragdon-Ah",
-          "presentations": [
-            {
-              "id": "presentation-01",
-              "name": "Presentation 1",
-              "url": "/presentations/warrior-of-kragdon-ah/presentation-01/"
             }
           ]
         }
       ]
     },
     {
-      "id": "life-skills",
-      "name": "Life Skills",
+      "name": "LIFE SKILLS",
       "units": [
         {
-          "id": "life-skills-main",
+          "id": "life-skills",
           "name": "Life Skills",
           "presentations": [
             {
               "id": "presentation-01",
-              "name": "Presentation 1",
+              "name": "Life Skills: Nutrition & Grocery Shopping - 4 Day Program",
               "url": "/life-skills/presentations/presentation-01/"
             },
             {
               "id": "presentation-02",
-              "name": "Presentation 2",
+              "name": "Complete Job Skills Presentation - 2 Week Program",
               "url": "/life-skills/presentations/presentation-02/"
             },
             {
               "id": "presentation-03",
-              "name": "Presentation 3",
+              "name": "Life Skills Presentation: Employment & Independent Living for Students",
               "url": "/life-skills/presentations/presentation-03/"
             },
             {
               "id": "presentation-04",
-              "name": "Presentation 4",
+              "name": "Counting Money",
               "url": "/life-skills/presentations/presentation-04/"
             },
             {
               "id": "presentation-05",
-              "name": "Presentation 5",
+              "name": "Understanding Your Paycheck",
               "url": "/life-skills/presentations/presentation-05/"
             },
             {
-              "id": "presentation-32",
-              "name": "Presentation 32",
-              "url": "/life-skills/presentations/presentation-32/"
+              "id": "presentation-06",
+              "name": "Counting Money",
+              "url": "/life-skills/presentations/presentation-06/"
             }
           ]
         }


### PR DESCRIPTION
## What
- Add a build-time generator for `site/assets/content/lessons-index.json` that scans the actual presentation folders on disk.
- Add a small CLI scaffolder to create a new Language Arts “category” (unit/book) folder.

## Why
- Prevent stale sidebar entries (ghost presentations/categories) without manual JSON edits.
- Make new books/categories easy to add without hunting through manifests.

## How it works
- Generator scans:
  - `site/presentations/*/presentation-*/index.html`  → Language Arts units
  - `site/life-skills/presentations/presentation-*/index.html` → Life Skills unit
- It uses `<title>` for presentation names when available and hides empty units by default.

## Test
- `node scripts/generate-lessons-index.mjs`
- Open Deploy Preview → Lessons
  - Only real presentations show
  - Titles are meaningful (from `<title>`) where possible
  - Empty units don’t appear

## New category (book) workflow
- Create category folder only:
  - `node scripts/new-lesson-unit.mjs "New Book Title"`
- Or create category + placeholder Presentation 1:
  - `node scripts/new-lesson-unit.mjs "New Book Title" --with-presentation`
- Regenerate index:
  - `node scripts/generate-lessons-index.mjs`
