### PR TITLE
Stabilize lessons-index generatedAt to avoid no-op diffs

### DIFF
--- a/scripts/generate-lessons-index.mjs
+++ b/scripts/generate-lessons-index.mjs
@@ -1,5 +1,27 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { execSync } from "node:child_process";
+
+function stableGeneratedAt() {
+  // Stable timestamp so running the generator doesn't create a fake git diff.
+  // We use the latest commit time affecting presentation directories.
+  try {
+    const out = execSync(
+      "git log -1 --format=%cI -- site/presentations site/life-skills/presentations",
+      { stdio: ["ignore", "pipe", "ignore"] }
+    ).toString().trim();
+    if (out) return out;
+  } catch (_) {}
+
+  // Fallback: keep existing generatedAt if present, otherwise current time.
+  try {
+    const existing = JSON.parse(fs.readFileSync("site/assets/content/lessons-index.json", "utf8"));
+    if (existing && existing.generatedAt) return existing.generatedAt;
+  } catch (_) {}
+
+  return new Date().toISOString();
+}
+
 
 const SITE_DIR = path.join(process.cwd(), 'site');
 const OUT_PATH = path.join(SITE_DIR, 'assets', 'content', 'lessons-index.json');
@@ -181,7 +203,7 @@ async function main() {
 
   const out = {
     version: 1,
-    generatedAt: new Date().toISOString(),
+    generatedAt: stableGeneratedAt(),
     sections
   };
 

--- a/site/assets/content/lessons-index.json
+++ b/site/assets/content/lessons-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2025-12-28T14:22:02.058Z",
+  "generatedAt": "2025-12-27T20:38:44-06:00",
   "sections": [
     {
       "name": "LANGUAGE ARTS",


### PR DESCRIPTION
## What
- Change lessons-index.json `generatedAt` to use latest git commit time affecting presentation directories.
- Prevents dirty working trees when generator is run with no content changes.

## Why
- Previously `generatedAt` changed every run, causing constant no-op diffs.

## Test
- Run: node scripts/generate-lessons-index.mjs
- Confirm: git diff is empty when no presentation files changed.