### PR TITLE
Teacher Center: add Admin link in sidebar

### DIFF
--- a/site/teacher/classes/index.html
+++ b/site/teacher/classes/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/data/index.html
+++ b/site/teacher/data/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/gradebook/index.html
+++ b/site/teacher/gradebook/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/index.html
+++ b/site/teacher/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/library/index.html
+++ b/site/teacher/library/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/review/index.html
+++ b/site/teacher/review/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/settings/index.html
+++ b/site/teacher/settings/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/students/index.html
+++ b/site/teacher/students/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>

--- a/site/teacher/work/index.html
+++ b/site/teacher/work/index.html
@@ -25,6 +25,7 @@
           <a data-href="/teacher/students/" href="/teacher/students/"><span class="tc-icon">🧑‍🎓</span><span class="tc-label">Students</span></a>
           <a data-href="/teacher/classes/" href="/teacher/classes/"><span class="tc-icon">🏫</span><span class="tc-label">Classes</span></a>
           <a data-href="/teacher/data/" href="/teacher/data/"><span class="tc-icon">🧾</span><span class="tc-label">Data</span></a>
+          <a data-href="/admin/" href="/admin/"><span class="tc-icon">🛡️</span><span class="tc-label">Admin</span></a>
           <a data-href="/teacher/settings/" href="/teacher/settings/"><span class="tc-icon">⚙️</span><span class="tc-label">Settings</span></a>
         </nav>
       </aside>


### PR DESCRIPTION
Adds an Admin nav item to the /teacher/ sidebar (placed under Data) across all Teacher Center route shells. Access control remains enforced by the /admin edge guard.