### PR TITLE
Admin: make units upsert safer (admin-only, branch-first)

### DIFF
--- a/netlify/functions/admin-units-upsert.js
+++ b/netlify/functions/admin-units-upsert.js
@@ -237,14 +237,12 @@ async function verifySession(event) {
 
   if (!r.ok) return { ok: false, response: json(401, { ok: false, error: 'Session expired or invalid' }) };
 
-    // HARD GATE: must be admin (raw_role from teacher-session)
-    const rawRole = (r && (r.raw_role ?? r.rawRole ?? r.role)) || null;
-    if (rawRole !== 'admin') {
-      return jsonResponse(event, 403, { ok: false, error: 'Admin required' }, {}, requestId);
-    }
 
   const text = await r.text().catch(() => '');
   const j = safeJsonParse(text);
+  // HARD GATE: must be admin (raw_role from teacher-session)
+  const rawRole = (j && (j.raw_role ?? j.rawRole ?? j.role)) || null;
+  if (rawRole !== 'admin') return { ok: false, response: json(403, { ok: false, error: 'Admin required' }) };
   if (j && j.ok === false) return { ok: false, response: json(401, { ok: false, error: 'Session expired or invalid' }) };
 
   return { ok: true };


### PR DESCRIPTION
Hardens admin-units-upsert so only admin users can run it (raw_role must be admin). Defaults to committing on a branch (admin/units-<id>) instead of main, and refuses branch=main unless confirmMain:true is provided. Also auto-creates the target branch if missing.