### PR TITLE
Admin: fix units-upsert body var (production bug)

### DIFF
--- a/netlify/functions/admin-units-upsert.js
+++ b/netlify/functions/admin-units-upsert.js
@@ -268,6 +268,9 @@ function validatePayload(p) {
 }
 
 exports.handler = async (event) => {
+  // Parse request body once (used for branch + confirmMain)
+  const body = safeJsonParse(event.body || '{}') || {};
+
   try {
     if (event.httpMethod !== 'POST') return json(405, { ok: false, error: 'Method not allowed' });
 


### PR DESCRIPTION
Fixes runtime error in admin-units-upsert where  was referenced but not defined. Defines  once from event.body for branch + confirmMain logic.