### PR TITLE
Admin: fix units-upsert getRepoInfo undefined

### DIFF
--- a/netlify/functions/admin-units-upsert.js
+++ b/netlify/functions/admin-units-upsert.js
@@ -134,6 +134,12 @@ function parseRepo() {
   return { owner, repo };
 }
 
+
+async function getRepoInfo() {
+  const { owner, repo } = parseRepo();
+  return await ghGET(`/repos/${owner}/${repo}`);
+}
+
 async function getRepoDefaultBranch() {
   const { owner, repo } = parseRepo();
   const info = await ghGET(`/repos/${owner}/${repo}`);


### PR DESCRIPTION
Production bugfix: admin-units-upsert uses getRepoInfo() in branch safety logic but helper was missing. Adds getRepoInfo() wrapper around the GitHub /repos API.