### PR TITLE
Admin: fix units-upsert jsonResponse undefined

### DIFF
--- a/netlify/functions/admin-units-upsert.js
+++ b/netlify/functions/admin-units-upsert.js
@@ -390,3 +390,7 @@ exports.handler = async (event) => {
     return json(500, { ok: false, error: String(e?.message || e) });
   }
 };
+
+function jsonResponse(_event, statusCode, obj, _headers = {}, _requestId = '') {
+  return json(statusCode, obj);
+}


### PR DESCRIPTION
Fixes production error where admin-units-upsert referenced jsonResponse but no helper existed. Adds a small shim so refusal paths return proper JSON instead of crashing.