### PR TITLE
Hub: honor ?next= after teacher login/resume

### DIFF
--- a/site/hub/index.html
+++ b/site/hub/index.html
@@ -3140,8 +3140,8 @@
           const u = new URL(window.location.href);
           const raw = (u.searchParams.get("next") || "").trim();
           if(!raw) return "";
-          if(!raw.startswith("/")) return "";           // same-origin only
-          if(raw.startswith("//")) return "";          // no protocol-relative
+          if(!raw.startsWith("/")) return "";           // same-origin only
+          if(raw.startsWith("//")) return "";          // no protocol-relative
           return raw;
         }catch(_){
           return "";


### PR DESCRIPTION
When /teacher/* redirects to /hub/?next=..., Hub now forwards to that next path after successful teacher login or session resume (safe, same-origin only).