### PR TITLE
Teacher Center: Reporting scaffold (local drafts snapshot)

### DIFF
--- a/site/teacher/reporting/index.html
+++ b/site/teacher/reporting/index.html
@@ -5,6 +5,33 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Teacher Center — Reporting</title>
   <link rel="stylesheet" href="/web/teacher-shell.css" />
+  <style>
+    .tc-stack { display: grid; gap: 14px; }
+    .tc-kpis { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+    @media (max-width: 1100px){ .tc-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    @media (max-width: 640px){ .tc-kpis { grid-template-columns: 1fr; } }
+
+    .tc-card {
+      border-radius: 14px;
+      padding: 14px;
+      border: 1px solid rgba(255,255,255,.10);
+      background: rgba(0,0,0,.18);
+      backdrop-filter: blur(10px);
+    }
+    .tc-kpi-label { font-size: 12px; opacity: .80; }
+    .tc-kpi-value { font-size: 28px; font-weight: 900; line-height: 1.1; margin-top: 6px; }
+    .tc-row { display:flex; gap:10px; align-items:center; flex-wrap: wrap; }
+    .tc-subtle { opacity: .78; }
+    .tc-table { width: 100%; border-collapse: collapse; }
+    .tc-table th, .tc-table td { padding: 10px 10px; border-top: 1px solid rgba(255,255,255,.10); vertical-align: top; }
+    .tc-table thead th { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; opacity: .85; border-top: none; }
+    .tc-pill { display:inline-flex; align-items:center; gap:6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; border: 1px solid rgba(255,255,255,.14); background: rgba(255,255,255,.06); }
+    .tc-btnrow { display:flex; gap:10px; align-items:center; justify-content: space-between; flex-wrap: wrap; }
+    .tc-actions { display:flex; gap:10px; align-items:center; flex-wrap: wrap; }
+    .tc-small { font-size: 12px; opacity: .85; }
+    .tc-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .tc-note { font-size: 12px; opacity: .80; }
+  </style>
 </head>
 <body>
   <div class="tc-app">
@@ -32,49 +59,88 @@
       </aside>
 
       <main class="tc-main">
-        <h1>Work</h1>
-        <p><div style="max-width: 980px;">
-        <p style="margin-top:0;">
-          Reporting MVP: pick a report type + date range, then generate. (Controls are placeholders for now.)
-        </p>
+        <div class="tc-stack">
+          <div class="tc-row">
+            <h1 style="margin: 0">Reporting</h1>
+            <span class="tc-pill" id="pillMode">Local (browser)</span>
+            <span class="tc-pill tc-mono" id="pillSource">drafts: —</span>
+          </div>
 
-        <div style="display:flex; gap:12px; flex-wrap:wrap; align-items:flex-end; margin:16px 0;">
-          <label style="display:flex; flex-direction:column; gap:6px; min-width:240px;">
-            <span>Report type</span>
-            <select>
-              <option>Student Report (placeholder)</option>
-              <option>Class Report (placeholder)</option>
-              <option>IEP Goal Report (placeholder)</option>
-            </select>
-          </label>
+          <div class="tc-card">
+            <div class="tc-btnrow">
+              <div>
+                <div style="font-weight: 800">Snapshot</div>
+                <div class="tc-note">Scaffold: summarizes browser-local Work drafts for now. Next step is wiring real submissions + gradebook.</div>
+              </div>
+              <div class="tc-actions">
+                <a class="tc-btn" href="/teacher/work/" aria-label="Go to Work">🗂️ Work</a>
+                <button class="tc-btn" id="btnRefresh" type="button">↻ Refresh</button>
+                <button class="tc-btn" id="btnExport" type="button">⬇︎ Export JSON</button>
+              </div>
+            </div>
+          </div>
 
-          <label style="display:flex; flex-direction:column; gap:6px;">
-            <span>Start date</span>
-            <input type="date" />
-          </label>
+          <div class="tc-kpis" aria-label="Reporting KPIs">
+            <div class="tc-card">
+              <div class="tc-kpi-label">Drafts</div>
+              <div class="tc-kpi-value" id="kpiDrafts">—</div>
+              <div class="tc-small tc-subtle">Work drafts found in localStorage</div>
+            </div>
+            <div class="tc-card">
+              <div class="tc-kpi-label">With Mapping</div>
+              <div class="tc-kpi-value" id="kpiWithMapping">—</div>
+              <div class="tc-small tc-subtle">Mapping artifact attached</div>
+            </div>
+            <div class="tc-card">
+              <div class="tc-kpi-label">Assignment Type</div>
+              <div class="tc-kpi-value" id="kpiTypeMix">—</div>
+              <div class="tc-small tc-subtle">Link vs file</div>
+            </div>
+            <div class="tc-card">
+              <div class="tc-kpi-label">Most Recent</div>
+              <div class="tc-kpi-value" id="kpiRecent">—</div>
+              <div class="tc-small tc-subtle">Latest draft timestamp</div>
+            </div>
+          </div>
 
-          <label style="display:flex; flex-direction:column; gap:6px;">
-            <span>End date</span>
-            <input type="date" />
-          </label>
+          <div class="tc-card">
+            <div class="tc-btnrow" style="margin-bottom: 10px;">
+              <div style="font-weight: 800">Latest Drafts</div>
+              <div class="tc-small tc-subtle">Showing up to 20</div>
+            </div>
+            <div style="overflow:auto">
+              <table class="tc-table" aria-label="Drafts table">
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Assignment</th>
+                    <th>Mapping</th>
+                    <th>Created</th>
+                    <th class="tc-mono">ID</th>
+                  </tr>
+                </thead>
+                <tbody id="draftsBody">
+                  <tr><td colspan="5" class="tc-subtle">Loading…</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
 
-          <button type="button">Generate</button>
+          <div class="tc-card">
+            <div style="font-weight: 800; margin-bottom: 6px;">Next wiring (not in this PR)</div>
+            <ul style="margin: 0; padding-left: 18px;" class="tc-subtle">
+              <li>Publish drafts into Library</li>
+              <li>Student Portal sees released assignments</li>
+              <li>Submissions + resubmits</li>
+              <li>Teacher Review + Gradebook + IEP progress</li>
+            </ul>
+          </div>
         </div>
-
-        <div style="border:1px solid rgba(255,255,255,0.12); border-radius:12px; padding:12px; min-height:140px;">
-          <div style="opacity:0.85; margin-bottom:8px;">Output</div>
-          <pre style="margin:0; white-space:pre-wrap;">(Report output will appear here.)</pre>
-        </div>
-
-        <div style="display:flex; gap:10px; flex-wrap:wrap; margin-top:12px;">
-          <button type="button" disabled>Export CSV</button>
-          <button type="button" disabled>Print</button>
-        </div>
-      </div></p>
       </main>
     </div>
   </div>
 
   <script defer src="/web/teacher-shell.js"></script>
+  <script defer src="/web/tc-reporting.js"></script>
 </body>
 </html>

--- a/site/web/tc-reporting.js
+++ b/site/web/tc-reporting.js
@@ -1,0 +1,190 @@
+(function () {
+  const KEY_CANDIDATES = ["rc_tc_work_drafts","rc_tc_drafts","tc_work_drafts","teacher_center_work_drafts"];
+
+  function $(id){ return document.getElementById(id); }
+
+  function safeParseJSON(s){
+    try { return JSON.parse(s); } catch (_) { return null; }
+  }
+
+  function isDraftArray(x){
+    if (!Array.isArray(x)) return false;
+    if (x.length === 0) return true;
+    const d = x[0];
+    return d && typeof d === "object" && ("id" in d || "title" in d) && ("mapping" in d || "assignment" in d);
+  }
+
+  function detectDraftsFromLocalStorage(){
+    for (const k of KEY_CANDIDATES){
+      const raw = localStorage.getItem(k);
+      if (!raw) continue;
+      const v = safeParseJSON(raw);
+      if (isDraftArray(v)) return { key: k, drafts: v };
+    }
+
+    const hits = [];
+    for (let i = 0; i < localStorage.length; i++){
+      const k = localStorage.key(i);
+      if (!k) continue;
+      const raw = localStorage.getItem(k);
+      if (!raw || raw.length < 2) continue;
+      if (raw[0] !== "[" && raw[0] !== "{") continue;
+
+      const v = safeParseJSON(raw);
+      if (isDraftArray(v)) hits.push({ key: k, drafts: v });
+    }
+
+    hits.sort((a,b) => (b.drafts?.length || 0) - (a.drafts?.length || 0));
+    return hits[0] || { key: null, drafts: [] };
+  }
+
+  function fmtDate(ts){
+    if (!ts) return "—";
+    const d = new Date(ts);
+    if (Number.isNaN(d.getTime())) return "—";
+    return d.toLocaleString();
+  }
+
+  function inferCreatedAt(d){
+    return d.createdAt || d.created_at || d.ts || d.timestamp || null;
+  }
+
+  function inferAssignmentType(d){
+    const a = d.assignment || d.assignmentFile || d.assignmentLink || null;
+    if (!a) return "unknown";
+    if (typeof a === "string"){
+      if (/^https?:\/\//i.test(a)) return "link";
+      return "file";
+    }
+    if (typeof a === "object"){
+      if (a.url || a.link) return "link";
+      if (a.name || a.fileName || a.file) return "file";
+      if (a.type) return String(a.type);
+    }
+    return "unknown";
+  }
+
+  function hasMapping(d){
+    const m = d.mapping || d.mappingFile || null;
+    if (!m) return false;
+    if (typeof m === "string") return m.trim().length > 0;
+    if (typeof m === "object") return !!(m.name || m.fileName || m.file || m.url || m.link);
+    return true;
+  }
+
+  function summarize(drafts){
+    const total = drafts.length;
+    const withMapping = drafts.filter(hasMapping).length;
+
+    let link = 0, file = 0, unknown = 0;
+    let newest = null;
+
+    for (const d of drafts){
+      const t = inferAssignmentType(d);
+      if (t === "link") link++;
+      else if (t === "file") file++;
+      else unknown++;
+
+      const ts = inferCreatedAt(d);
+      if (ts){
+        const dt = new Date(ts).getTime();
+        if (!Number.isNaN(dt)){
+          if (newest === null || dt > newest) newest = dt;
+        }
+      }
+    }
+
+    return {
+      total,
+      withMapping,
+      typeMix: total === 0 ? "—" : `${link} link / ${file} file`,
+      newest: newest ? fmtDate(newest) : "—",
+      link, file, unknown
+    };
+  }
+
+  function escapeHtml(s){
+    return String(s)
+      .replaceAll("&","&amp;")
+      .replaceAll("<","&lt;")
+      .replaceAll(">","&gt;")
+      .replaceAll('"',"&quot;")
+      .replaceAll("'","&#039;");
+  }
+
+  function renderTable(drafts){
+    const body = $("draftsBody");
+    if (!body) return;
+
+    const rows = (drafts || [])
+      .slice()
+      .sort((a,b) => new Date(inferCreatedAt(b) || 0).getTime() - new Date(inferCreatedAt(a) || 0).getTime())
+      .slice(0, 20);
+
+    if (rows.length === 0){
+      body.innerHTML = '<tr><td colspan="5" class="tc-subtle">No drafts found yet. Create one in <a href="/teacher/work/">Work</a>.</td></tr>';
+      return;
+    }
+
+    body.innerHTML = rows.map((d) => {
+      const title = (d.title || "Untitled").toString();
+      const id = (d.id || "—").toString();
+      const created = fmtDate(inferCreatedAt(d));
+      const atype = inferAssignmentType(d);
+      const mapping = hasMapping(d) ? "yes" : "no";
+      return `
+        <tr>
+          <td>${escapeHtml(title)}</td>
+          <td>${escapeHtml(atype)}</td>
+          <td>${escapeHtml(mapping)}</td>
+          <td>${escapeHtml(created)}</td>
+          <td class="tc-mono">${escapeHtml(id)}</td>
+        </tr>
+      `;
+    }).join("");
+  }
+
+  function download(filename, text){
+    const blob = new Blob([text], { type: "application/json;charset=utf-8" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => { URL.revokeObjectURL(a.href); a.remove(); }, 0);
+  }
+
+  function refresh(){
+    const found = detectDraftsFromLocalStorage();
+    const key = found.key || "none";
+    const drafts = Array.isArray(found.drafts) ? found.drafts : [];
+    const s = summarize(drafts);
+
+    const pillSource = $("pillSource");
+    if (pillSource) pillSource.textContent = `drafts: ${drafts.length} (key: ${key})`;
+
+    if ($("kpiDrafts")) $("kpiDrafts").textContent = String(s.total);
+    if ($("kpiWithMapping")) $("kpiWithMapping").textContent = String(s.withMapping);
+    if ($("kpiTypeMix")) $("kpiTypeMix").textContent = s.typeMix;
+    if ($("kpiRecent")) $("kpiRecent").textContent = s.newest;
+
+    renderTable(drafts);
+
+    const btnExport = $("btnExport");
+    if (btnExport){
+      btnExport.onclick = () => {
+        const payload = { generatedAt: new Date().toISOString(), sourceKey: key, summary: s, drafts };
+        download(`tc-reporting_${new Date().toISOString().slice(0,10)}.json`, JSON.stringify(payload, null, 2));
+      };
+    }
+  }
+
+  function init(){
+    const btnRefresh = $("btnRefresh");
+    if (btnRefresh) btnRefresh.addEventListener("click", refresh);
+    refresh();
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+  else init();
+})();


### PR DESCRIPTION
Adds /teacher/reporting/ scaffold with a simple dashboard that summarizes browser-local Work drafts (localStorage) and exports a JSON snapshot.

Acceptance Criteria:
- /teacher/reporting/ loads under the new Teacher Center shell
- Shows KPI cards + a latest-drafts table (up to 20)
- Export downloads a JSON report snapshot
- No console errors on /teacher/reporting/
- /teacher/* gating remains intact

Notes:
- Client-side only. Next step is wiring real submissions + gradebook/progress.