### PR TITLE
Scaffold shells for core sections (Teacher + site pages)

### DIFF
--- a/site/lessons/index.html
+++ b/site/lessons/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Lessons</title>
+</head>
+<body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; line-height: 1.4">
+  <div style="max-width: 980px; margin: 0 auto">
+    <div style="display:flex; gap:12px; align-items:center; margin-bottom:16px">
+      <a href="/hub/" style="text-decoration:none; padding:10px 14px; border:1px solid #ccc; border-radius:10px">← Hub</a>
+      <div style="opacity:.8">Lessons</div>
+    </div>
+    <h1 style="margin: 0 0 10px">Lessons</h1>
+    <p>Shell ready. This will later host lesson tools/content.</p>
+  </div>
+</body>
+</html>

--- a/site/student2/index.html
+++ b/site/student2/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Student Portal (New)</title>
+</head>
+<body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; line-height: 1.4">
+  <div style="max-width: 980px; margin: 0 auto">
+    <div style="display:flex; gap:12px; align-items:center; margin-bottom:16px">
+      <a href="/hub/" style="text-decoration:none; padding:10px 14px; border:1px solid #ccc; border-radius:10px">← Hub</a>
+      <div style="opacity:.8">Student Portal (New)</div>
+    </div>
+    <h1 style="margin: 0 0 10px">Student Portal (New)</h1>
+    <p>Shell ready. Next PR will render native TXT assignments here.</p>
+  </div>
+</body>
+</html>

--- a/site/substitute/index.html
+++ b/site/substitute/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Substitute</title>
+</head>
+<body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; line-height: 1.4">
+  <div style="max-width: 980px; margin: 0 auto">
+    <div style="display:flex; gap:12px; align-items:center; margin-bottom:16px">
+      <a href="/hub/" style="text-decoration:none; padding:10px 14px; border:1px solid #ccc; border-radius:10px">← Hub</a>
+      <div style="opacity:.8">Substitute</div>
+    </div>
+    <h1 style="margin: 0 0 10px">Substitute</h1>
+    <p>Shell ready. This will later host substitute-ready plans.</p>
+  </div>
+</body>
+</html>

--- a/site/toolkits/index.html
+++ b/site/toolkits/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Toolkits</title>
+</head>
+<body style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; line-height: 1.4">
+  <div style="max-width: 980px; margin: 0 auto">
+    <div style="display:flex; gap:12px; align-items:center; margin-bottom:16px">
+      <a href="/hub/" style="text-decoration:none; padding:10px 14px; border:1px solid #ccc; border-radius:10px">← Hub</a>
+      <div style="opacity:.8">Toolkits</div>
+    </div>
+    <h1 style="margin: 0 0 10px">Toolkits</h1>
+    <p>Shell ready. This will later host your toolkits hub.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Adds missing shell pages so nav routes don’t 404.

Acceptance Criteria:
- /teacher/ and sidebar routes (Library/Review/Gradebook/Students/Classes/Data/Settings) load (gated as usual)
- /lessons/ /toolkits/ /substitute/ load
- /student2/ loads (new student portal shell)

Next PR: add Work→native TXT + tag parsing + Student Portal (New) renderer.