### PR TITLE
Teacher Center Work: student-view preview (no JSON)

### DIFF
--- a/site/web/tc-work.js
+++ b/site/web/tc-work.js
@@ -251,28 +251,6 @@ ${shown}
       .split("\n")
       .slice(0, 80)
       .join("\n");
-
-    const payload = {
-      id: d.id,
-      title: d.title,
-      className: d.className,
-      releaseAt: d.releaseAt,
-      dueAt: d.dueAt,
-      createdAt: d.createdAt,
-      notes: d.notes || "",
-      assignment: {
-        kind: d.assignment ? d.assignment.kind : null,
-        name: d.assignment ? d.assignment.name : null,
-        link: d.assignment ? d.assignment.link : null,
-        snippet: assignmentSnippet || "(no stored assignment text — link or file too large?)",
-      },
-      mapping: {
-        name: d.mapping ? d.mapping.name : null,
-        kind: d.mapping ? d.mapping.kind : null,
-        snippet: mappingSnippet || "(no mapping text stored?)",
-      },
-    };
-
     body.innerHTML = renderStudentPreviewHtml(d);
     overlay.hidden = false;
   }


### PR DESCRIPTION
Replaces raw JSON Preview with Student View rendering. TXT previews strip [MLS]/[DESE]/[IG]/[IEP] tags by default. Mapping overlay toggle will be follow-up PR.