### PR TITLE
RC-2026-27-01 curriculum collection registry v2

### DIFF
--- a/netlify/functions/admin-units-upsert.js
+++ b/netlify/functions/admin-units-upsert.js
@@ -27,6 +27,10 @@ function normalizeUnits(data) {
     const nu = {
       id: String(u.id),
       title: String(u.title || ''),
+      kind: String(u.kind || 'collection'),
+      description: String(u.description || ''),
+      status: String(u.status || 'active'),
+      sortOrder: Number.isFinite(Number(u.sortOrder)) ? Number(u.sortOrder) : 0,
       section: String(u.section || ''),
       baseOut: String(u.baseOut || ''),
       slots: Number(u.slots || 0),
@@ -306,20 +310,69 @@ async function verifySession(event) {
 function validatePayload(p) {
   const title = String(p?.title || '').trim();
   const id = String(p?.id || '').trim();
+  const kind = String(p?.kind || 'collection').trim();
+  const description = String(p?.description || '').trim();
+  const status = String(p?.status || 'active').trim();
+  const sortOrder = Number(p?.sortOrder || 0);
   const section = String(p?.section || '').trim();
   const slots = Number(p?.slots || 0);
   const baseOut = String(p?.baseOut || '').trim();
   const pagePath = String(p?.pagePath || '').trim();
 
   if (!title) return 'Title is required';
-  if (!/^[a-z0-9][a-z0-9_-]{1,31}$/.test(id)) return 'Invalid id (2–32 chars: a–z, 0–9, - or _)';
+  if (!/^[a-z0-9][a-z0-9_-]{1,31}$/.test(id)) {
+    return 'Invalid id (2–32 chars: a–z, 0–9, - or _)';
+  }
+  if (!['book', 'unit', 'theme', 'text-set', 'collection', 'toolkit'].includes(kind)) {
+    return 'Invalid collection type';
+  }
+  if (description.length > 500) return 'Description must be 500 characters or fewer';
+  if (!['active', 'archived'].includes(status)) return 'Invalid collection status';
+  if (!Number.isFinite(sortOrder) || sortOrder < -100000 || sortOrder > 100000) {
+    return 'Invalid display order';
+  }
   if (!['language-arts', 'life-skills'].includes(section)) return 'Invalid section';
   if (!Number.isFinite(slots) || slots < 1 || slots > 64) return 'Slots must be 1–64';
-  if (!baseOut || baseOut.startsWith('/') || baseOut.includes('..')) return 'baseOut must be a relative path (no leading "/" or "..")';
-  if (!pagePath.startsWith('/') || !pagePath.endsWith('/')) return 'pagePath must start and end with "/"';
+  if (!baseOut || baseOut.startsWith('/') || baseOut.includes('..')) {
+    return 'baseOut must be a relative path (no leading "/" or "..")';
+  }
+  if (!pagePath.startsWith('/') || !pagePath.endsWith('/')) {
+    return 'pagePath must start and end with "/"';
+  }
 
   return '';
 }
+
+
+function policyValue(value) {
+  return String(value || '').trim();
+}
+
+function validateUnitUpdatePolicy(existingUnit, unit) {
+  if (existingUnit) {
+    for (const field of ['section', 'baseOut', 'pagePath']) {
+      if (policyValue(existingUnit[field]) !== policyValue(unit[field])) {
+        return `Existing collection ${field} is locked to preserve live routes and materials.`;
+      }
+    }
+
+    return '';
+  }
+
+  if (unit.section === 'language-arts') {
+    if (unit.pagePath !== '/language-arts/collection/') {
+      return 'New Language Arts collections must use the shared collection route.';
+    }
+
+    if (unit.baseOut !== `presentations/${unit.id}`) {
+      return 'New Language Arts collections must use the managed presentation folder.';
+    }
+  }
+
+  return '';
+}
+
+exports.validateUnitUpdatePolicy = validateUnitUpdatePolicy;
 
 exports.handler = async (event) => {
   // Parse request body once (used for branch + confirmMain)
@@ -340,6 +393,10 @@ exports.handler = async (event) => {
     const unit = {
       id: String(payload.id).trim(),
       title: String(payload.title).trim(),
+      kind: String(payload.kind || 'collection').trim(),
+      description: String(payload.description || '').trim(),
+      status: String(payload.status || 'active').trim(),
+      sortOrder: Number.isFinite(Number(payload.sortOrder)) ? Number(payload.sortOrder) : 0,
       section: String(payload.section).trim(),
       slots: Number(payload.slots),
       baseOut: String(payload.baseOut).trim(),
@@ -364,6 +421,11 @@ exports.handler = async (event) => {
     // Upsert unit in units.json (preserve order; replace if exists)
     const existingUnits = Array.isArray(unitsDoc.units) ? unitsDoc.units.slice() : [];
     const idx = existingUnits.findIndex(u => u && String(u.id) === unit.id);
+    const existingUnit = idx >= 0 ? existingUnits[idx] : null;
+
+    const policyError = validateUnitUpdatePolicy(existingUnit, unit);
+    if (policyError) return json(400, { ok: false, error: policyError });
+
     const nextUnit = { ...unit };
 
     if (idx >= 0) existingUnits[idx] = { ...existingUnits[idx], ...nextUnit };
@@ -418,9 +480,15 @@ exports.handler = async (event) => {
       blobs.set('assets/data/site-state.json', Buffer.from(JSON.stringify(nextState, null, 2) + '\n', 'utf8'));
     }
 
-    // Create a safe unit landing page if missing (don’t overwrite custom pages)
+    // New Language Arts collections use the reusable generic collection page.
+    // Do not create a one-off static page for them. Existing explicit routes
+    // retain their current create-if-missing behavior.
+    const usesGenericCollectionRoute =
+      unit.section === 'language-arts' &&
+      unit.pagePath === '/language-arts/collection/';
+
     let createdIndex = false;
-    if (!paths.has(unitIndexPath)) {
+    if (!usesGenericCollectionRoute && !paths.has(unitIndexPath)) {
       const html = generateCategoryIndex(unit.id, nextState, units);
       blobs.set(unitIndexPath, Buffer.from(html, 'utf8'));
       createdIndex = true;
@@ -440,6 +508,7 @@ exports.handler = async (event) => {
       branch,
       pr, unit,
       createdIndex,
+      usesGenericCollectionRoute,
       unitIndexPath,
     });
   } catch (e) {

--- a/scripts/generate-lessons-index.mjs
+++ b/scripts/generate-lessons-index.mjs
@@ -295,7 +295,11 @@ async function scanLanguageArts(maps, unitsData, siteState) {
   const unitByFolderName = new Map();
   if (unitsData?.units) {
     for (const u of unitsData.units) {
-      if (u.section === 'language-arts' && u.id !== 'toolkit') {
+      if (
+        u.section === 'language-arts' &&
+        u.id !== 'toolkit' &&
+        (u.status || 'active') === 'active'
+      ) {
         // Extract folder name from baseOut (e.g., "presentations/lost-in-kragdon-ah" -> "lost-in-kragdon-ah")
         const folder = u.baseOut.split('/').pop();
         unitByFolderName.set(folder, u);
@@ -352,6 +356,17 @@ async function scanLanguageArts(maps, unitsData, siteState) {
       }
     }
   }
+
+  units.sort((a, b) => {
+    const aMeta = unitByFolderName.get(a.id) || {};
+    const bMeta = unitByFolderName.get(b.id) || {};
+    const aOrder = Number.isFinite(Number(aMeta.sortOrder)) ? Number(aMeta.sortOrder) : 0;
+    const bOrder = Number.isFinite(Number(bMeta.sortOrder)) ? Number(bMeta.sortOrder) : 0;
+
+    if (aOrder !== bOrder) return aOrder - bOrder;
+
+    return String(a.name || '').localeCompare(String(b.name || ''));
+  });
 
   return { name: 'LANGUAGE ARTS', units };
 }

--- a/site/assets/data/units.json
+++ b/site/assets/data/units.json
@@ -14,7 +14,11 @@
       "section": "language-arts",
       "baseOut": "presentations/a-door-into-time",
       "slots": 16,
-      "pagePath": "/language-arts/a-door-into-time/"
+      "pagePath": "/language-arts/a-door-into-time/",
+      "kind": "book",
+      "description": "",
+      "status": "active",
+      "sortOrder": 10
     },
     {
       "id": "lik",
@@ -22,7 +26,11 @@
       "section": "language-arts",
       "baseOut": "presentations/lost-in-kragdon-ah",
       "slots": 16,
-      "pagePath": "/language-arts/lost-in-kragdon-ah/"
+      "pagePath": "/language-arts/lost-in-kragdon-ah/",
+      "kind": "book",
+      "description": "",
+      "status": "active",
+      "sortOrder": 20
     },
     {
       "id": "rfk",
@@ -30,7 +38,11 @@
       "section": "language-arts",
       "baseOut": "presentations/return-from-kragdon-ah",
       "slots": 16,
-      "pagePath": "/language-arts/return-from-kragdon-ah/"
+      "pagePath": "/language-arts/return-from-kragdon-ah/",
+      "kind": "book",
+      "description": "",
+      "status": "active",
+      "sortOrder": 30
     },
     {
       "id": "wok",
@@ -38,7 +50,11 @@
       "section": "language-arts",
       "baseOut": "presentations/warrior-of-kragdon-ah",
       "slots": 16,
-      "pagePath": "/language-arts/warrior-of-kragdon-ah/"
+      "pagePath": "/language-arts/warrior-of-kragdon-ah/",
+      "kind": "book",
+      "description": "",
+      "status": "active",
+      "sortOrder": 40
     },
     {
       "id": "life",

--- a/site/assets/js/language-arts-collections.js
+++ b/site/assets/js/language-arts-collections.js
@@ -1,0 +1,97 @@
+'use strict';
+
+(function () {
+  function collectionHref(unit) {
+    const path = String((unit && unit.pagePath) || '/language-arts/').trim();
+
+    if (path === '/language-arts/collection/') {
+      return path + '?collection=' + encodeURIComponent(String(unit && unit.id || ''));
+    }
+
+    return path;
+  }
+
+  function activeLanguageArtsCollections(units) {
+    return (units || [])
+      .filter((unit) =>
+        unit &&
+        unit.section === 'language-arts' &&
+        unit.id !== 'toolkit' &&
+        (unit.status || 'active') === 'active'
+      )
+      .sort((a, b) => {
+        const aOrder = Number.isFinite(Number(a.sortOrder)) ? Number(a.sortOrder) : 0;
+        const bOrder = Number.isFinite(Number(b.sortOrder)) ? Number(b.sortOrder) : 0;
+
+        if (aOrder !== bOrder) return aOrder - bOrder;
+
+        return String(a.title || '').localeCompare(String(b.title || ''));
+      });
+  }
+
+  function bookIcon() {
+    return '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>';
+  }
+
+  function renderCollectionCards(grid, collections) {
+    grid.innerHTML = '';
+
+    collections.forEach((unit) => {
+      const card = document.createElement('a');
+      card.className = 'book-card';
+      card.href = collectionHref(unit);
+
+      const icon = document.createElement('div');
+      icon.className = 'book-icon';
+      icon.innerHTML = bookIcon();
+
+      const content = document.createElement('div');
+
+      const title = document.createElement('strong');
+      title.className = 'book-title';
+      title.textContent = unit.title || unit.id;
+      content.appendChild(title);
+
+      if (unit.description) {
+        const description = document.createElement('div');
+        description.style.cssText = 'margin-top:4px;font-size:.9rem;opacity:.72;';
+        description.textContent = unit.description;
+        content.appendChild(description);
+      }
+
+      card.appendChild(icon);
+      card.appendChild(content);
+      grid.appendChild(card);
+    });
+  }
+
+  async function init() {
+    const grid = document.querySelector('.book-grid');
+    if (!grid) return;
+
+    try {
+      const response = await fetch('/assets/data/units.json?t=' + Date.now(), {
+        cache: 'no-store'
+      });
+
+      if (!response.ok) return;
+
+      const data = await response.json();
+      const collections = activeLanguageArtsCollections(
+        Array.isArray(data.units) ? data.units : []
+      );
+
+      if (collections.length) {
+        renderCollectionCards(grid, collections);
+      }
+    } catch (_) {
+      // Preserve the static legacy cards as a no-network fallback.
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/site/assets/js/unit-grid.js
+++ b/site/assets/js/unit-grid.js
@@ -35,6 +35,61 @@
     return '';
   }
 
+  function requestedCollectionId(){
+    try {
+      const value = new URLSearchParams(window.location.search).get('collection');
+      return value ? String(value).trim() : '';
+    } catch {
+      return '';
+    }
+  }
+
+  function isGenericCollectionRoute(){
+    const clean = location.pathname
+      .replace(/index\.html$/, '')
+      .replace(/\/+$/, '/') || '/';
+
+    return clean === '/language-arts/collection/';
+  }
+
+  function resolveUnitId(units){
+    const requestedId = requestedCollectionId();
+
+    if (requestedId && isGenericCollectionRoute()) {
+      const requestedCollection = units.find(function(unit){
+        return unit &&
+          unit.id === requestedId &&
+          unit.section === 'language-arts' &&
+          unit.id !== 'toolkit' &&
+          (unit.status || 'active') === 'active';
+      });
+
+      return requestedCollection ? requestedCollection.id : '';
+    }
+
+    return inferUnitId(units, location.pathname);
+  }
+
+  function applyGenericCollectionLabels(unit){
+    if (!isGenericCollectionRoute() || !unit) return;
+
+    const title = unit.title || 'Curriculum Collection';
+    const titleEl = qs('[data-collection-title]');
+    const descriptionEl = qs('[data-collection-description]');
+    const app = qs('.tc-app');
+
+    if (titleEl) titleEl.textContent = title;
+
+    if (descriptionEl) {
+      descriptionEl.textContent =
+        unit.description || 'Explore presentations and activities';
+    }
+
+    if (app) app.setAttribute('data-page-title', title);
+
+    document.title = title + ' – Reinisch Classroom';
+  }
+
   // Config: Enable defensive slot checking (check if presentation exists even when link missing)
   const DEFENSIVE_SLOT_CHECK = true;
 
@@ -170,9 +225,11 @@
     const unitsData = await loadUnits();
     const units = Array.isArray(unitsData.units) ? unitsData.units : [];
 
-    const unitId = inferUnitId(units, location.pathname);
+    const unitId = resolveUnitId(units);
     const unit = units.find(u => u.id === unitId);
     if (!unit) return;
+
+    applyGenericCollectionLabels(unit);
 
     const state = await loadState();
     await buildGrid(grid, unit, state);

--- a/site/language-arts/collection/index.html
+++ b/site/language-arts/collection/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="emerald">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Curriculum Collection – Reinisch Classroom</title>
+  <meta name="description" content="Language Arts curriculum collection"/>
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+  <link rel="stylesheet" href="/assets/css/rc-theme.css"/>
+  <link rel="stylesheet" href="/assets/css/unit-grid.css"/>
+  <link rel="stylesheet" href="/web/teacher-shell.css"/>
+  <link rel="stylesheet" href="/assets/css/class-clock.css"/>
+  <link rel="stylesheet" href="/assets/css/class-mode.css"/>
+
+  <script src="/web/public-nav.js"></script>
+  <script src="/web/sidebar-init.js"></script>
+  <script defer src="/assets/js/class-clock.js" type="module"></script>
+  <script defer src="/web/class-mode.js"></script>
+  <script src="/assets/js/open-in-viewer.js"></script>
+  <script defer src="/assets/js/unit-grid.js"></script>
+</head>
+<body>
+  <div class="tc-app" data-page-title="Curriculum Collection">
+    <div class="tc-shell">
+      <main class="tc-main">
+        <div class="wrap">
+          <header>
+            <h1 data-collection-title>Curriculum Collection</h1>
+            <p class="unit-subtitle" data-collection-description>
+              Explore presentations and activities
+            </p>
+          </header>
+
+          <section class="grid" id="grid" aria-live="polite"></section>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script defer src="/web/public-shell.js"></script>
+</body>
+</html>

--- a/site/language-arts/index.html
+++ b/site/language-arts/index.html
@@ -195,5 +195,6 @@
 
     <script defer src="/web/public-shell.js"></script>
     <script defer src="/assets/js/open-in-viewer.js"></script>
+    <script defer src="/assets/js/language-arts-collections.js"></script>
   </body>
 </html>

--- a/site/teacher/admin/app.js
+++ b/site/teacher/admin/app.js
@@ -892,6 +892,8 @@ async function showPRResult(pr){
 
 
 (function () {
+  let knownUnits = [];
+
   function slugify(s) {
     return String(s || '')
       .toLowerCase()
@@ -903,128 +905,351 @@ async function showPRResult(pr){
       .replace(/^-|-$/g, '');
   }
 
-  function qs(id) { return document.getElementById(id); }
+  function qs(id) {
+    return document.getElementById(id);
+  }
+
+  function value(id, fallback = '') {
+    return String(qs(id)?.value || fallback).trim();
+  }
 
   function setStatus(msg) {
     const el = qs('unitMgrStatus');
     if (el) el.textContent = msg || '';
   }
 
+  function languageArtsCollections() {
+    return knownUnits
+      .filter((unit) =>
+        unit &&
+        unit.section === 'language-arts' &&
+        unit.id !== 'toolkit'
+      )
+      .sort((a, b) => {
+        const aOrder = Number.isFinite(Number(a.sortOrder)) ? Number(a.sortOrder) : 0;
+        const bOrder = Number.isFinite(Number(b.sortOrder)) ? Number(b.sortOrder) : 0;
+
+        if (aOrder !== bOrder) return aOrder - bOrder;
+
+        return String(a.title || '').localeCompare(String(b.title || ''));
+      });
+  }
+
+  function nextLanguageArtsSortOrder() {
+    const orders = languageArtsCollections()
+      .map((unit) => Number(unit.sortOrder))
+      .filter(Number.isFinite);
+
+    return orders.length ? Math.max(...orders) + 10 : 10;
+  }
+
+  function selectedExistingUnit() {
+    const id = value('unitMgrExisting');
+    return knownUnits.find((unit) => unit && unit.id === id) || null;
+  }
+
   function buildPayload() {
-    const title = (qs('unitMgrTitle')?.value || '').trim();
-    const id = (qs('unitMgrId')?.value || '').trim();
-    const section = (qs('unitMgrSection')?.value || 'language-arts').trim();
-    const slots = Number(qs('unitMgrSlots')?.value || 16);
+    const existing = selectedExistingUnit();
+    const title = value('unitMgrTitle');
+    const id = value('unitMgrId');
+    const section = value('unitMgrSection', 'language-arts');
+    const slots = Number(value('unitMgrSlots', '16'));
+    const kind = value('unitMgrKind', 'collection');
+    const description = value('unitMgrDescription');
+    const status = value('unitMgrStatusField', 'active');
+    const sortOrder = Number(value('unitMgrSortOrder', '0'));
 
-    const baseOut = (qs('unitMgrBaseOut')?.value || '').trim();
-    const pagePath = (qs('unitMgrPagePath')?.value || '').trim();
+    let baseOut = value('unitMgrBaseOut');
+    let pagePath = value('unitMgrPagePath');
 
-    return { id, title, section, slots, baseOut, pagePath };
+    if (section === 'language-arts' && !existing) {
+      if (!baseOut && id) baseOut = `presentations/${id}`;
+      if (!pagePath) pagePath = '/language-arts/collection/';
+    }
+
+    return {
+      id,
+      title,
+      kind,
+      description,
+      status,
+      sortOrder,
+      section,
+      slots,
+      baseOut,
+      pagePath,
+    };
   }
 
   function renderPreview(payload) {
     const pre = qs('unitMgrPreview');
     if (!pre) return;
+
     pre.textContent = JSON.stringify(payload, null, 2);
   }
 
-  function validateClient(p) {
-    if (!p.title) return 'Title is required';
-    if (!/^[a-z0-9][a-z0-9_-]{1,31}$/.test(p.id)) return 'Invalid Unit ID (use lowercase a–z, 0–9, - or _)';
-    if (!['language-arts', 'life-skills'].includes(p.section)) return 'Invalid section';
-    if (!Number.isFinite(p.slots) || p.slots < 1 || p.slots > 64) return 'Slots must be 1–64';
-    if (!p.baseOut || p.baseOut.startsWith('/') || p.baseOut.includes('..')) return 'baseOut must be a relative path (no leading "/" or "..")';
-    if (!p.pagePath.startsWith('/') || !p.pagePath.endsWith('/')) return 'pagePath must start and end with "/"';
+  function validateClient(payload) {
+    if (!payload.title) return 'Title is required';
+    if (!/^[a-z0-9][a-z0-9_-]{1,31}$/.test(payload.id)) {
+      return 'Invalid Collection ID (use lowercase a–z, 0–9, - or _)';
+    }
+    if (!['book', 'unit', 'theme', 'text-set', 'collection'].includes(payload.kind)) {
+      return 'Invalid collection type';
+    }
+    if (payload.description.length > 500) {
+      return 'Description must be 500 characters or fewer';
+    }
+    if (!['active', 'archived'].includes(payload.status)) {
+      return 'Invalid collection status';
+    }
+    if (!Number.isFinite(payload.sortOrder)) {
+      return 'Display order must be a number';
+    }
+    if (payload.section !== 'language-arts') {
+      return 'Curriculum Collection Manager is currently scoped to Language Arts.';
+    }
+    if (!Number.isFinite(payload.slots) || payload.slots < 1 || payload.slots > 64) {
+      return 'Slots must be 1–64';
+    }
+    if (!payload.baseOut || payload.baseOut.startsWith('/') || payload.baseOut.includes('..')) {
+      return 'Presentation folder must be a relative path without ".."';
+    }
+    if (!payload.pagePath.startsWith('/') || !payload.pagePath.endsWith('/')) {
+      return 'Collection route must start and end with "/"';
+    }
+
     return '';
   }
 
-  async function upsert() {
-    const btn = qs('btnUnitMgrUpsert');
-    const p = buildPayload();
-    renderPreview(p);
+  function populateCollectionSelect() {
+    const select = qs('unitMgrExisting');
+    if (!select) return;
 
-    const err = validateClient(p);
-    if (err) { await rcAlert('Error', err); return; }
+    const currentValue = select.value;
+    select.innerHTML = '';
+
+    const newOption = document.createElement('option');
+    newOption.value = '';
+    newOption.textContent = 'Create a new collection';
+    select.appendChild(newOption);
+
+    languageArtsCollections().forEach((unit) => {
+      const option = document.createElement('option');
+      option.value = unit.id;
+      option.textContent =
+        `${unit.title || unit.id} — ${unit.status || 'active'}`;
+      select.appendChild(option);
+    });
+
+    if ([...select.options].some((option) => option.value === currentValue)) {
+      select.value = currentValue;
+    }
+  }
+
+  function resetNewCollection() {
+    const select = qs('unitMgrExisting');
+    if (select) select.value = '';
+
+    if (qs('unitMgrTitle')) qs('unitMgrTitle').value = '';
+    if (qs('unitMgrId')) qs('unitMgrId').value = '';
+    if (qs('unitMgrKind')) qs('unitMgrKind').value = 'book';
+    if (qs('unitMgrDescription')) qs('unitMgrDescription').value = '';
+    if (qs('unitMgrStatusField')) qs('unitMgrStatusField').value = 'active';
+    if (qs('unitMgrSortOrder')) {
+      qs('unitMgrSortOrder').value = String(nextLanguageArtsSortOrder());
+    }
+    if (qs('unitMgrSection')) qs('unitMgrSection').value = 'language-arts';
+    if (qs('unitMgrSlots')) qs('unitMgrSlots').value = '16';
+    if (qs('unitMgrBaseOut')) qs('unitMgrBaseOut').value = '';
+    if (qs('unitMgrPagePath')) {
+      qs('unitMgrPagePath').value = '/language-arts/collection/';
+    }
+
+    setStatus('New Language Arts collection');
+    renderPreview(buildPayload());
+  }
+
+  function loadSelectedCollection() {
+    const unit = selectedExistingUnit();
+
+    if (!unit) {
+      resetNewCollection();
+      return;
+    }
+
+    if (qs('unitMgrTitle')) qs('unitMgrTitle').value = unit.title || '';
+    if (qs('unitMgrId')) qs('unitMgrId').value = unit.id || '';
+    if (qs('unitMgrKind')) qs('unitMgrKind').value = unit.kind || 'collection';
+    if (qs('unitMgrDescription')) qs('unitMgrDescription').value = unit.description || '';
+    if (qs('unitMgrStatusField')) qs('unitMgrStatusField').value = unit.status || 'active';
+    if (qs('unitMgrSortOrder')) {
+      qs('unitMgrSortOrder').value = String(
+        Number.isFinite(Number(unit.sortOrder)) ? Number(unit.sortOrder) : 0
+      );
+    }
+    if (qs('unitMgrSection')) qs('unitMgrSection').value = unit.section || 'language-arts';
+    if (qs('unitMgrSlots')) qs('unitMgrSlots').value = String(unit.slots || 16);
+    if (qs('unitMgrBaseOut')) qs('unitMgrBaseOut').value = unit.baseOut || '';
+    if (qs('unitMgrPagePath')) qs('unitMgrPagePath').value = unit.pagePath || '';
+
+    setStatus(`Editing "${unit.title || unit.id}"`);
+    renderPreview(buildPayload());
+  }
+
+  async function loadKnownCollections() {
+    try {
+      const response = await fetch('/assets/data/units.json?t=' + Date.now(), {
+        cache: 'no-store',
+      });
+
+      if (!response.ok) throw new Error(`units.json ${response.status}`);
+
+      const data = await response.json();
+      knownUnits = Array.isArray(data.units) ? data.units : [];
+      populateCollectionSelect();
+      resetNewCollection();
+    } catch (error) {
+      knownUnits = [];
+      console.warn('[Curriculum Collection Manager] Could not load units.json:', error);
+      setStatus('Registry unavailable; manual fields remain available.');
+      renderPreview(buildPayload());
+    }
+  }
+
+  async function upsert() {
+    const button = qs('btnUnitMgrUpsert');
+    const payload = buildPayload();
+    renderPreview(payload);
+
+    const err = validateClient(payload);
+    if (err) {
+      await rcAlert('Collection validation', err);
+      return;
+    }
 
     try {
-      if (btn) btn.disabled = true;
-      setStatus('Saving…');
+      if (button) button.disabled = true;
+      setStatus('Saving draft…');
 
-      const res = await fetch('/.netlify/functions/admin-units-upsert', {
+      const response = await fetch('/.netlify/functions/admin-units-upsert', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
         cache: 'no-store',
-        body: JSON.stringify(Object.assign({}, p, { createPr: true })),
+        body: JSON.stringify({ ...payload, createPr: true }),
       });
 
-      const bodyText = await res.text().catch((err) => {
-        console.warn('[Category Manager] Failed to read response body:', err);
-        return '';
-      });
-      let data = null;
-      try { data = JSON.parse(bodyText); } catch { data = { ok: false, error: bodyText }; }
-      if (!res.ok || !data.ok) {
-        console.error('[Category Manager] error:', { status: res.status, body: bodyText, parsed: data });
-        await rcAlert('Error', `Create/Update failed: ${data.error || bodyText || res.status}`);
-        setStatus('Error');
+      const bodyText = await response.text().catch(() => '');
+      let data;
+
+      try {
+        data = JSON.parse(bodyText);
+      } catch {
+        data = { ok: false, error: bodyText };
+      }
+
+      if (!response.ok || !data.ok) {
+        console.error('[Curriculum Collection Manager] Save failed:', {
+          status: response.status,
+          body: bodyText,
+          parsed: data,
+        });
+        await rcAlert(
+          'Collection save failed',
+          data.error || bodyText || String(response.status)
+        );
+        setStatus('Save failed');
         return;
       }
 
-      try { showPRResult((data && data.pr) ? data.pr : null); } catch (e) { /* ignore */ }
+      try {
+        showPRResult(data.pr || null);
+      } catch (_) {
+        // The save itself completed. A blocked pop-up should not make it look failed.
+      }
 
-      setStatus('Saved ✓');
-      await rcAlert('Upload Complete', `Saved! Commit: ${data.commit}\nIndex created: ${data.createdIndex ? 'YES' : 'NO'}`);
+      setStatus('Draft saved');
+      await rcAlert(
+        'Collection draft saved',
+        `Saved "${payload.title}". Commit: ${data.commit}\nDraft PR: ${data.pr?.url || 'not created'}`
+      );
 
-      location.reload();
-    } catch (e) {
-      console.error(e);
-      await rcAlert('Error', 'Create/Update failed: ' + (e?.message || String(e)));
-      setStatus('Error');
+      await loadKnownCollections();
+    } catch (error) {
+      console.error('[Curriculum Collection Manager] Save error:', error);
+      await rcAlert(
+        'Collection save failed',
+        error?.message || String(error)
+      );
+      setStatus('Save failed');
     } finally {
-      if (btn) btn.disabled = false;
+      if (button) button.disabled = false;
     }
   }
 
   async function autofill() {
-    const title = (qs('unitMgrTitle')?.value || '').trim();
-    if (!title) { await rcAlert('Validation', 'Enter a Title first'); return; }
+    const title = value('unitMgrTitle');
+    if (!title) {
+      await rcAlert('Collection setup', 'Enter a collection title first.');
+      return;
+    }
 
     const slug = slugify(title);
-    const section = (qs('unitMgrSection')?.value || 'language-arts').trim();
+    const section = value('unitMgrSection', 'language-arts');
 
-    if (qs('unitMgrId') && !qs('unitMgrId').value.trim()) qs('unitMgrId').value = slug.slice(0, 32);
-    if (qs('unitMgrBaseOut') && !qs('unitMgrBaseOut').value.trim()) {
-      qs('unitMgrBaseOut').value = section === 'life-skills'
-        ? 'life-skills/presentations'
-        : `presentations/${slug}`;
-    }
-    if (qs('unitMgrPagePath') && !qs('unitMgrPagePath').value.trim()) {
-      qs('unitMgrPagePath').value = section === 'life-skills'
-        ? '/life-skills/'
-        : `/language-arts/${slug}/`;
+    if (qs('unitMgrId') && !value('unitMgrId')) {
+      qs('unitMgrId').value = slug.slice(0, 32);
     }
 
-    const p = buildPayload();
-    renderPreview(p);
+    const id = value('unitMgrId');
+
+    if (qs('unitMgrBaseOut') && !value('unitMgrBaseOut')) {
+      qs('unitMgrBaseOut').value =
+        section === 'life-skills'
+          ? 'life-skills/presentations'
+          : `presentations/${id || slug}`;
+    }
+
+    if (qs('unitMgrPagePath') && !value('unitMgrPagePath')) {
+      qs('unitMgrPagePath').value =
+        section === 'life-skills'
+          ? '/life-skills/'
+          : '/language-arts/collection/';
+    }
+
+    if (qs('unitMgrSortOrder') && !value('unitMgrSortOrder')) {
+      qs('unitMgrSortOrder').value = String(nextLanguageArtsSortOrder());
+    }
+
+    renderPreview(buildPayload());
   }
 
   document.addEventListener('DOMContentLoaded', () => {
     const card = qs('unitManagerCard');
     if (!card) return;
 
-    const btnAuto = qs('btnUnitMgrAutofill');
-    const btnUp = qs('btnUnitMgrUpsert');
+    qs('btnUnitMgrAutofill')?.addEventListener('click', autofill);
+    qs('btnUnitMgrUpsert')?.addEventListener('click', upsert);
+    qs('btnUnitMgrNew')?.addEventListener('click', resetNewCollection);
+    qs('unitMgrExisting')?.addEventListener('change', loadSelectedCollection);
 
-    btnAuto?.addEventListener('click', autofill);
-    btnUp?.addEventListener('click', upsert);
-
-    ['unitMgrTitle','unitMgrId','unitMgrSection','unitMgrSlots','unitMgrBaseOut','unitMgrPagePath'].forEach((id) => {
+    [
+      'unitMgrTitle',
+      'unitMgrId',
+      'unitMgrKind',
+      'unitMgrDescription',
+      'unitMgrStatusField',
+      'unitMgrSortOrder',
+      'unitMgrSection',
+      'unitMgrSlots',
+      'unitMgrBaseOut',
+      'unitMgrPagePath',
+    ].forEach((id) => {
       qs(id)?.addEventListener('input', () => renderPreview(buildPayload()));
       qs(id)?.addEventListener('change', () => renderPreview(buildPayload()));
     });
 
-    renderPreview(buildPayload());
+    loadKnownCollections();
   });
 })();
 

--- a/site/teacher/admin/gate.js
+++ b/site/teacher/admin/gate.js
@@ -1,6 +1,14 @@
+/* eslint-env browser */
 // Server-side session gate - check Teacher Center session
 // PR 335: Admin SSO via Teacher Center
 (function(){
+  function revealAdminUtilityCards(){
+    ['unitScaffolderCard', 'unitManagerCard'].forEach(function(id){
+      const card = document.getElementById(id);
+      if (card) card.style.display='block';
+    });
+  }
+
   async function gate(){
     try{
       const r = await fetch('/.netlify/functions/teacher-session', { cache:'no-store', credentials:'same-origin' });
@@ -18,8 +26,13 @@
         return;
       }
 
-      document.getElementById('app').style.display='block';
-      document.getElementById('gate').style.display='none';
+      const app = document.getElementById('app');
+      const gateEl = document.getElementById('gate');
+
+      if (app) app.style.display='block';
+      if (gateEl) gateEl.style.display='none';
+
+      revealAdminUtilityCards();
     }catch{
       location.replace('/hub/?reason=gate_error&next=%2Fteacher%2Fadmin%2F');
     }

--- a/site/teacher/admin/index.html
+++ b/site/teacher/admin/index.html
@@ -351,32 +351,71 @@
 
         <div class="card" id="unitManagerCard" style="margin-top:12px; display:none">
           <div class="card-header">
-            <div>Category Manager</div>
+            <div>Curriculum Collection Manager</div>
           </div>
 
           <div class="hint" style="margin-bottom:10px">
-            Creates/updates a category by writing <code>units.json</code> + initializing <code>site-state.json</code>.
-            Also creates a safe default unit landing page if missing (won't overwrite custom pages).
+            Create, update, archive, and reorder curriculum collections through the existing guarded draft-PR path.
+            Existing book routes and presentation folders are preserved. New Language Arts collections use the shared collection page.
           </div>
 
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+            <div style="grid-column:1 / -1">
+              <label style="display:block;font-weight:700;margin-bottom:6px">Existing collection</label>
+              <div style="display:flex;gap:10px;align-items:center">
+                <select id="unitMgrExisting" class="input" style="flex:1">
+                  <option value="">Create a new collection</option>
+                </select>
+                <button class="admin-btn" id="btnUnitMgrNew" type="button">New collection</button>
+              </div>
+              <div class="hint">Choose an existing collection to edit it. Use Active/Archived instead of deleting instructional history.</div>
+            </div>
+
             <div>
               <label style="display:block;font-weight:700;margin-bottom:6px">Title</label>
               <input id="unitMgrTitle" class="input" placeholder="Fahrenheit 451" />
             </div>
 
             <div>
-              <label style="display:block;font-weight:700;margin-bottom:6px">Unit ID (lowercase)</label>
-              <input id="unitMgrId" class="input" placeholder="f451" />
-              <div class="hint">2–32 chars: a–z, 0–9, <code>-</code>, <code>_</code></div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Collection ID (lowercase)</label>
+              <input id="unitMgrId" class="input" placeholder="long-way-down" />
+              <div class="hint">2–32 chars: a–z, 0–9, <code>-</code>, <code>_</code>. Existing IDs are preserved.</div>
+            </div>
+
+            <div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Collection type</label>
+              <select id="unitMgrKind" class="input">
+                <option value="book">Book</option>
+                <option value="unit">Unit</option>
+                <option value="theme">Theme</option>
+                <option value="text-set">Text set</option>
+                <option value="collection">Other collection</option>
+              </select>
+            </div>
+
+            <div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Status</label>
+              <select id="unitMgrStatusField" class="input">
+                <option value="active">Active</option>
+                <option value="archived">Archived</option>
+              </select>
+            </div>
+
+            <div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Display order</label>
+              <input id="unitMgrSortOrder" class="input" type="number" step="10" value="10" />
+              <div class="hint">Lower numbers appear first.</div>
             </div>
 
             <div>
               <label style="display:block;font-weight:700;margin-bottom:6px">Section</label>
-              <select id="unitMgrSection" class="input">
-                <option value="language-arts">Language Arts</option>
-                <option value="life-skills">Life Skills</option>
-              </select>
+              <input
+                id="unitMgrSection"
+                class="input"
+                value="language-arts"
+                readonly
+              />
+              <div class="hint">This manager is currently scoped to the safe Language Arts collection workflow.</div>
             </div>
 
             <div>
@@ -385,15 +424,21 @@
             </div>
 
             <div style="grid-column:1 / -1">
-              <label style="display:block;font-weight:700;margin-bottom:6px">baseOut</label>
-              <input id="unitMgrBaseOut" class="input" placeholder="presentations/fahrenheit-451" />
-              <div class="hint">Where presentations live (relative path). No leading slash.</div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Managed presentation folder</label>
+              <input id="unitMgrBaseOut" class="input" placeholder="presentations/collection-id" readonly />
+              <div class="hint">Created automatically for new collections and protected for existing collections.</div>
             </div>
 
             <div style="grid-column:1 / -1">
-              <label style="display:block;font-weight:700;margin-bottom:6px">pagePath</label>
-              <input id="unitMgrPagePath" class="input" placeholder="/language-arts/fahrenheit-451/" />
-              <div class="hint">Must start and end with <code>/</code></div>
+              <label style="display:block;font-weight:700;margin-bottom:6px">Managed collection route</label>
+              <input id="unitMgrPagePath" class="input" placeholder="/language-arts/collection/" readonly />
+              <div class="hint">New Language Arts collections use the shared collection page. Existing routes stay protected.</div>
+            </div>
+
+            <div style="grid-column:1 / -1">
+              <label style="display:block;font-weight:700;margin-bottom:6px">Teacher-facing description</label>
+              <textarea id="unitMgrDescription" class="input" rows="3" maxlength="500" placeholder="Optional description for the Language Arts collection page."></textarea>
+              <div class="hint">This is shown to teachers on the Language Arts landing page. It does not issue material to students.</div>
             </div>
           </div>
 
@@ -404,7 +449,7 @@
             </button>
             <button class="admin-btn primary" id="btnUnitMgrUpsert">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>
-              Create / Update Category
+              Save Collection Draft
             </button>
             <div class="hint" id="unitMgrStatus" style="margin-left:auto"></div>
           </div>

--- a/site/teacher/admin/index.html
+++ b/site/teacher/admin/index.html
@@ -327,25 +327,25 @@
 
         <!-- New Category helper (Language Arts) -->
         <section class="panel" id="unitScaffolderCard" style="margin-top: 1rem; display:none">
-          <h2 style="margin: 0 0 .5rem 0;">New Category (Language Arts)</h2>
+          <h2 style="margin: 0 0 .5rem 0;">Legacy Local Scaffolder (Language Arts)</h2>
           <div class="hint" style="margin-bottom:.75rem;">
-            This does not modify the live site directly. It generates the exact commands to run locally to scaffold a new unit folder and regenerate the Lessons index.
+            Legacy helper: this only copies Terminal commands for manually scaffolding folders and regenerating the Lessons index. For 2026–27 collection setup, use the Curriculum Collection Manager below.
           </div>
 
-          <label for="newUnitTitle" style="display:block; font-weight:600; margin:.5rem 0 .25rem;">Unit title</label>
+          <label for="newUnitTitle" style="display:block; font-weight:600; margin:.5rem 0 .25rem;">Legacy scaffold title</label>
           <input id="newUnitTitle" type="text" placeholder="e.g., Long Way Down" style="width:100%; padding:.6rem .7rem; border-radius:.5rem; border:1px solid rgba(255,255,255,.2); background: rgba(255,255,255,.08); color: inherit;" />
 
           <div style="display:flex; flex-wrap:wrap; gap:.5rem; margin:.75rem 0;">
-            <button class="admin-btn primary" id="copyNewUnitCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy: scaffold category + Presentation 1</button>
-            <button class="admin-btn warn" id="copyNewUnitCmdNoPres"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy: scaffold category only</button>
-            <button class="admin-btn primary" id="copyGenerateIndexCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy: regenerate Lessons index</button>
-            <button class="admin-btn warn" id="copyFullWorkflowCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy: full workflow</button>
+            <button class="admin-btn primary" id="copyNewUnitCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy legacy scaffold + Presentation 1</button>
+            <button class="admin-btn warn" id="copyNewUnitCmdNoPres"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy legacy scaffold only</button>
+            <button class="admin-btn primary" id="copyGenerateIndexCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy regenerate Lessons index</button>
+            <button class="admin-btn warn" id="copyFullWorkflowCmd"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Copy legacy full workflow</button>
           </div>
 
           <pre id="unitCmdPreview" style="white-space:pre-wrap; padding:.75rem; border-radius:.5rem; border:1px solid rgba(255,255,255,.2); background: rgba(0,0,0,.25); margin:0;"></pre>
 
           <div class="hint" style="margin-top:.5rem;">
-            Paste into Terminal at repo root. Then commit + push (or open a PR) like normal.
+            Use only when you intentionally need the older local folder-scaffolding workflow. The registry workflow below is the preferred 2026–27 collection path.
           </div>
         </section>
 
@@ -355,8 +355,8 @@
           </div>
 
           <div class="hint" style="margin-bottom:10px">
-            Create, update, archive, and reorder curriculum collections through the existing guarded draft-PR path.
-            Existing book routes and presentation folders are preserved. New Language Arts collections use the shared collection page.
+            Recommended 2026–27 workflow: create, update, archive, and reorder Language Arts collections through the existing guarded draft-PR path.
+            Existing book routes and presentation folders are preserved. New Language Arts collections land on the shared collection page and use a managed presentation folder.
           </div>
 
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">

--- a/site/web/public-nav.js
+++ b/site/web/public-nav.js
@@ -34,15 +34,76 @@
   ];
 
   var LA_NAV = [
-    { href: '/',                                   label: 'Home',                  icon: I.home   },
-    { href: '/language-arts/',                     label: 'Language Arts',         icon: I.book   },
-    { href: '/language-arts/toolkit/',             label: 'Toolkit',               icon: I.wrench },
-    { href: '/language-arts/a-door-into-time/',    label: 'A Door Into Time',      icon: I.book   },
-    { href: '/language-arts/lost-in-kragdon-ah/',  label: 'Lost in Kragdon-ah',    icon: I.book   },
-    { href: '/language-arts/return-from-kragdon-ah/', label: 'Return from Kragdon-ah', icon: I.book },
-    { href: '/language-arts/warrior-of-kragdon-ah/',  label: 'Warrior of Kragdon-ah',  icon: I.book },
-    { href: '/toolkits/',                          label: 'All Toolkits',          icon: I.wrench },
+    { href: '/',                       label: 'Home',          icon: I.home   },
+    { href: '/language-arts/',         label: 'Language Arts', icon: I.book   },
+    { href: '/language-arts/toolkit/', label: 'Toolkit',       icon: I.wrench },
+    { href: '/toolkits/',              label: 'All Toolkits',  icon: I.wrench },
   ];
+
+  function activeLanguageArtsCollections(units){
+    return (units || [])
+      .filter(function(unit){
+        return unit &&
+          unit.section === 'language-arts' &&
+          unit.id !== 'toolkit' &&
+          (unit.status || 'active') === 'active';
+      })
+      .sort(function(a, b){
+        var aOrder = Number.isFinite(Number(a.sortOrder)) ? Number(a.sortOrder) : 0;
+        var bOrder = Number.isFinite(Number(b.sortOrder)) ? Number(b.sortOrder) : 0;
+        if (aOrder !== bOrder) return aOrder - bOrder;
+        return String(a.title || '').localeCompare(String(b.title || ''));
+      });
+  }
+
+  function collectionHref(unit){
+    var path = String(unit && unit.pagePath || '').trim();
+
+    if (path === '/language-arts/collection/') {
+      return path + '?collection=' + encodeURIComponent(String(unit && unit.id || ''));
+    }
+
+    return path || '/language-arts/';
+  }
+
+  async function appendLanguageArtsCollections(){
+    if (!location.pathname.startsWith('/language-arts/')) return;
+
+    var nav = document.querySelector('.tc-sidebar .tc-nav');
+    if (!nav || nav.querySelector('[data-collection-nav="true"]')) return;
+
+    try {
+      var response = await fetch('/assets/data/units.json?t=' + Date.now(), {
+        cache: 'no-store'
+      });
+      if (!response.ok) return;
+
+      var data = await response.json();
+      var collections = activeLanguageArtsCollections(
+        Array.isArray(data.units) ? data.units : []
+      );
+
+      var insertBefore = nav.querySelector('a[data-href="/toolkits/"]');
+
+      collections.forEach(function(unit){
+        var href = collectionHref(unit);
+        var html =
+          '<a href="' + esc(href) + '" data-href="' + esc(href) + '"' +
+          ' data-collection-nav="true">' +
+          '<span class="tc-icon">' + I.book + '</span>' +
+          '<span class="tc-label">' + esc(unit.title || unit.id) + '</span>' +
+          '</a>';
+
+        if (insertBefore) {
+          insertBefore.insertAdjacentHTML('beforebegin', html);
+        } else {
+          nav.insertAdjacentHTML('beforeend', html);
+        }
+      });
+    } catch (_) {
+      // Keep base navigation available if the registry cannot be loaded.
+    }
+  }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
   function esc(s){
@@ -119,6 +180,8 @@
     setTimeout(function() {
       document.dispatchEvent(new CustomEvent('rc-nav-ready'));
     }, 0);
+
+    appendLanguageArtsCollections();
   }
 
   if(document.readyState === 'loading'){

--- a/tests/admin-units-upsert-collection-policy.test.cjs
+++ b/tests/admin-units-upsert-collection-policy.test.cjs
@@ -1,0 +1,86 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+
+const {
+  validateUnitUpdatePolicy,
+} = require('../netlify/functions/admin-units-upsert.js');
+
+const legacy = {
+  id: 'adit',
+  section: 'language-arts',
+  baseOut: 'presentations/a-door-into-time',
+  pagePath: '/language-arts/a-door-into-time/',
+};
+
+const metadataOnlyEdit = {
+  ...legacy,
+  title: 'A Door Into Time — Revised Title',
+  kind: 'book',
+  description: 'Teacher-facing description only.',
+  status: 'archived',
+  sortOrder: 999,
+  slots: 16,
+};
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(legacy, metadataOnlyEdit),
+  '',
+  'Metadata-only edits must remain allowed for an existing collection'
+);
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(legacy, {
+    ...metadataOnlyEdit,
+    baseOut: 'presentations/something-else',
+  }),
+  'Existing collection baseOut is locked to preserve live routes and materials.'
+);
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(legacy, {
+    ...metadataOnlyEdit,
+    pagePath: '/language-arts/something-else/',
+  }),
+  'Existing collection pagePath is locked to preserve live routes and materials.'
+);
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(legacy, {
+    ...metadataOnlyEdit,
+    section: 'life-skills',
+  }),
+  'Existing collection section is locked to preserve live routes and materials.'
+);
+
+const newLanguageArtsCollection = {
+  id: 'long-way-down',
+  section: 'language-arts',
+  baseOut: 'presentations/long-way-down',
+  pagePath: '/language-arts/collection/',
+};
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(null, newLanguageArtsCollection),
+  '',
+  'A new Language Arts collection must accept the managed folder and shared route'
+);
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(null, {
+    ...newLanguageArtsCollection,
+    pagePath: '/language-arts/long-way-down/',
+  }),
+  'New Language Arts collections must use the shared collection route.'
+);
+
+assert.strictEqual(
+  validateUnitUpdatePolicy(null, {
+    ...newLanguageArtsCollection,
+    baseOut: 'presentations/not-the-id',
+  }),
+  'New Language Arts collections must use the managed presentation folder.'
+);
+
+console.log('PASS: admin-units-upsert collection route/material policy');

--- a/tests/admin-units-upsert-collection-validation.test.cjs
+++ b/tests/admin-units-upsert-collection-validation.test.cjs
@@ -1,0 +1,119 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const modulePath = path.resolve(
+  __dirname,
+  '..',
+  'netlify',
+  'functions',
+  'admin-units-upsert.js'
+);
+
+const originalFetch = global.fetch;
+
+function sessionOkResponse() {
+  return {
+    ok: true,
+    text: async () => JSON.stringify({
+      ok: true,
+      raw_role: 'admin',
+    }),
+  };
+}
+
+async function runValidationCase(payload) {
+  delete require.cache[modulePath];
+
+  global.fetch = async (url) => {
+    if (String(url).includes('/.netlify/functions/teacher-session')) {
+      return sessionOkResponse();
+    }
+
+    throw new Error(`Unexpected network call during validation test: ${url}`);
+  };
+
+  const { handler } = require(modulePath);
+
+  const response = await handler({
+    httpMethod: 'POST',
+    headers: {
+      host: 'example.test',
+      'x-forwarded-proto': 'https',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  return {
+    statusCode: response.statusCode,
+    body: JSON.parse(response.body),
+  };
+}
+
+(async () => {
+  const validBase = {
+    id: 'test-collection',
+    title: 'Test Collection',
+    kind: 'book',
+    description: '',
+    status: 'active',
+    sortOrder: 10,
+    section: 'language-arts',
+    slots: 16,
+    baseOut: 'presentations/test-collection',
+    pagePath: '/language-arts/collection/',
+  };
+
+  const invalidKind = await runValidationCase({
+    ...validBase,
+    kind: 'spaceship',
+  });
+
+  assert.strictEqual(invalidKind.statusCode, 400);
+  assert.strictEqual(invalidKind.body.ok, false);
+  assert.strictEqual(invalidKind.body.error, 'Invalid collection type');
+
+  const invalidStatus = await runValidationCase({
+    ...validBase,
+    status: 'deleted-forever',
+  });
+
+  assert.strictEqual(invalidStatus.statusCode, 400);
+  assert.strictEqual(invalidStatus.body.ok, false);
+  assert.strictEqual(invalidStatus.body.error, 'Invalid collection status');
+
+  const invalidOrder = await runValidationCase({
+    ...validBase,
+    sortOrder: 100001,
+  });
+
+  assert.strictEqual(invalidOrder.statusCode, 400);
+  assert.strictEqual(invalidOrder.body.ok, false);
+  assert.strictEqual(invalidOrder.body.error, 'Invalid display order');
+
+  const invalidDescription = await runValidationCase({
+    ...validBase,
+    description: 'x'.repeat(501),
+  });
+
+  assert.strictEqual(invalidDescription.statusCode, 400);
+  assert.strictEqual(invalidDescription.body.ok, false);
+  assert.strictEqual(
+    invalidDescription.body.error,
+    'Description must be 500 characters or fewer'
+  );
+
+  console.log(
+    'PASS: admin-units-upsert collection metadata validation through handler'
+  );
+})()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    global.fetch = originalFetch;
+    delete require.cache[modulePath];
+  });

--- a/tests/curriculum-collection-admin-copy.test.cjs
+++ b/tests/curriculum-collection-admin-copy.test.cjs
@@ -1,0 +1,44 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const adminIndex = fs.readFileSync('site/teacher/admin/index.html', 'utf8');
+
+assert(
+  adminIndex.includes('Legacy Local Scaffolder (Language Arts)'),
+  'Old command-copy scaffolder must be labeled as legacy/local.'
+);
+
+assert(
+  adminIndex.includes('For 2026–27 collection setup, use the Curriculum Collection Manager below.'),
+  'Legacy scaffolder must point users to the new 2026–27 registry workflow.'
+);
+
+assert(
+  adminIndex.includes('Recommended 2026–27 workflow: create, update, archive, and reorder Language Arts collections'),
+  'Curriculum Collection Manager must be presented as the preferred 2026–27 workflow.'
+);
+
+assert(
+  adminIndex.includes('New Language Arts collections land on the shared collection page and use a managed presentation folder.'),
+  'Curriculum Collection Manager copy must explain where new collections land.'
+);
+
+assert(
+  adminIndex.includes('Managed presentation folder'),
+  'Curriculum Collection Manager must keep the managed folder field visible.'
+);
+
+assert(
+  adminIndex.includes('Managed collection route'),
+  'Curriculum Collection Manager must keep the managed route field visible.'
+);
+
+assert(
+  adminIndex.includes('Save Collection Draft'),
+  'Curriculum Collection Manager must keep the guarded draft save action visible.'
+);
+
+console.log('PASS: admin collection wording clearly separates legacy scaffolder from 2026–27 registry workflow');

--- a/tests/curriculum-collection-generic-route.spec.js
+++ b/tests/curriculum-collection-generic-route.spec.js
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Curriculum Collection Registry v2 generic route', () => {
+  test('resolves an active legacy collection through the reusable route', async ({ page }) => {
+    await page.goto('/language-arts/collection/?collection=adit');
+
+    await expect(page.locator('[data-collection-title]')).toHaveText(
+      'A Door Into Time'
+    );
+
+    await expect(page).toHaveTitle('A Door Into Time – Reinisch Classroom');
+
+    await expect(
+      page.locator('[data-collection-nav="true"]')
+    ).toHaveCount(4);
+  });
+
+  test('keeps the existing legacy book route intact', async ({ page }) => {
+    await page.goto('/language-arts/a-door-into-time/');
+
+    await expect(page.locator('h1')).toHaveText('A Door Into Time');
+    await expect(page).toHaveTitle('A Door Into Time – Reinisch Classroom');
+  });
+});
+
+test('resolves a new registry-only collection without a dedicated route', async ({ page }) => {
+  await page.route('**/assets/data/units.json*', async (route) => {
+    const response = await route.fetch();
+    const data = await response.json();
+
+    data.units.push({
+      id: 'future-text-set',
+      title: 'Future Text Set',
+      kind: 'text-set',
+      description: 'A registry-only collection used for browser acceptance testing.',
+      status: 'active',
+      sortOrder: 50,
+      section: 'language-arts',
+      slots: 16,
+      baseOut: 'presentations/future-text-set',
+      pagePath: '/language-arts/collection/',
+    });
+
+    await route.fulfill({
+      response,
+      json: data,
+    });
+  });
+
+  await page.goto('/language-arts/collection/?collection=future-text-set');
+
+  await expect(page.locator('[data-collection-title]')).toHaveText(
+    'Future Text Set'
+  );
+
+  await expect(
+    page.locator('[data-collection-description]')
+  ).toHaveText(
+    'A registry-only collection used for browser acceptance testing.'
+  );
+
+  await expect(page).toHaveTitle('Future Text Set – Reinisch Classroom');
+
+  await expect(
+    page.locator('[data-collection-nav="true"]')
+  ).toHaveCount(5);
+
+  await expect(
+    page.locator('[data-collection-nav="true"]').filter({
+      hasText: 'Future Text Set',
+    })
+  ).toHaveCount(1);
+});
+
+
+test('orders active registry collections and hides archived collections', async ({ page }) => {
+  await page.route('**/assets/data/units.json*', async (route) => {
+    const response = await route.fetch();
+    const data = await response.json();
+
+    data.units.push(
+      {
+        id: 'prelude-unit',
+        title: 'Prelude Unit',
+        kind: 'unit',
+        description: 'Appears before the legacy books by display order.',
+        status: 'active',
+        sortOrder: 5,
+        section: 'language-arts',
+        slots: 16,
+        baseOut: 'presentations/prelude-unit',
+        pagePath: '/language-arts/collection/',
+      },
+      {
+        id: 'retired-text-set',
+        title: 'Retired Text Set',
+        kind: 'text-set',
+        description: 'Must remain out of active navigation.',
+        status: 'archived',
+        sortOrder: 1,
+        section: 'language-arts',
+        slots: 16,
+        baseOut: 'presentations/retired-text-set',
+        pagePath: '/language-arts/collection/',
+      }
+    );
+
+    await route.fulfill({
+      response,
+      json: data,
+    });
+  });
+
+  await page.goto('/language-arts/collection/?collection=adit');
+
+  const collectionLinks = page.locator('[data-collection-nav="true"]');
+
+  await expect(collectionLinks).toHaveCount(5);
+  await expect(collectionLinks.first()).toContainText('Prelude Unit');
+
+  await expect(
+    collectionLinks.filter({ hasText: 'Retired Text Set' })
+  ).toHaveCount(0);
+});

--- a/tests/curriculum-collection-generic-route.test.cjs
+++ b/tests/curriculum-collection-generic-route.test.cjs
@@ -1,0 +1,63 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const unitGrid = fs.readFileSync('site/assets/js/unit-grid.js', 'utf8');
+const nav = fs.readFileSync('site/web/public-nav.js', 'utf8');
+const landingRenderer = fs.readFileSync(
+  'site/assets/js/language-arts-collections.js',
+  'utf8'
+);
+const genericRoute = fs.readFileSync(
+  'site/language-arts/collection/index.html',
+  'utf8'
+);
+
+assert.ok(
+  unitGrid.includes('function requestedCollectionId()'),
+  'unit-grid must read the collection query parameter'
+);
+
+assert.ok(
+  unitGrid.includes('function resolveUnitId(units)'),
+  'unit-grid must resolve a collection ID for the generic route'
+);
+
+assert.ok(
+  unitGrid.includes("clean === '/language-arts/collection/'"),
+  'unit-grid must limit query-based collection resolution to the generic route'
+);
+
+assert.ok(
+  unitGrid.includes("(unit.status || 'active') === 'active'"),
+  'generic route resolution must hide archived collections'
+);
+
+assert.ok(
+  unitGrid.includes('applyGenericCollectionLabels(unit)'),
+  'generic route must receive its registry title and description'
+);
+
+assert.ok(
+  nav.includes("path === '/language-arts/collection/'") &&
+  nav.includes("'?collection='"),
+  'shared Language Arts navigation must include the collection query parameter'
+);
+
+assert.ok(
+  landingRenderer.includes("path === '/language-arts/collection/'") &&
+  landingRenderer.includes("'?collection='"),
+  'Language Arts landing cards must include the collection query parameter'
+);
+
+assert.ok(
+  genericRoute.includes('data-collection-title') &&
+  genericRoute.includes('data-collection-description') &&
+  genericRoute.includes('id="grid"') &&
+  genericRoute.includes('/assets/js/unit-grid.js'),
+  'generic collection page must contain dynamic labels and the shared grid'
+);
+
+console.log('PASS: Curriculum Collection Registry v2 generic collection route');

--- a/tests/curriculum-collection-manager-reveal.test.cjs
+++ b/tests/curriculum-collection-manager-reveal.test.cjs
@@ -1,0 +1,48 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const adminIndex = fs.readFileSync('site/teacher/admin/index.html', 'utf8');
+const adminGate = fs.readFileSync('site/teacher/admin/gate.js', 'utf8');
+
+assert(
+  adminIndex.includes('id="unitManagerCard"'),
+  'Teacher Admin page must include Curriculum Collection Manager card.'
+);
+
+assert(
+  /id="unitManagerCard"[^>]*display:none/.test(adminIndex),
+  'Curriculum Collection Manager starts hidden until the admin gate opens the app.'
+);
+
+assert(
+  adminGate.includes('function revealAdminUtilityCards'),
+  'Admin gate must define a helper that reveals optional admin utility cards.'
+);
+
+assert(
+  adminGate.includes("'unitManagerCard'") || adminGate.includes('"unitManagerCard"'),
+  'Admin gate reveal helper must include Curriculum Collection Manager.'
+);
+
+assert(
+  adminGate.includes("'unitScaffolderCard'") || adminGate.includes('"unitScaffolderCard"'),
+  'Admin gate reveal helper must preserve the existing unit scaffolder reveal behavior.'
+);
+
+const appRevealIndex = adminGate.indexOf("if (app) app.style.display='block';");
+const managerRevealIndex = adminGate.indexOf('revealAdminUtilityCards();');
+
+assert(
+  appRevealIndex !== -1,
+  'Admin gate must still reveal the main app container after admin verification.'
+);
+
+assert(
+  managerRevealIndex > appRevealIndex,
+  'Curriculum Collection Manager must be revealed after the admin gate opens the app.'
+);
+
+console.log('PASS: Curriculum Collection Manager reveals after admin gate');

--- a/tests/curriculum-collection-manager.test.cjs
+++ b/tests/curriculum-collection-manager.test.cjs
@@ -1,0 +1,102 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const markup = fs.readFileSync('site/teacher/admin/index.html', 'utf8');
+const manager = fs.readFileSync('site/teacher/admin/app.js', 'utf8');
+const backend = fs.readFileSync('netlify/functions/admin-units-upsert.js', 'utf8');
+const generator = fs.readFileSync('scripts/generate-lessons-index.mjs', 'utf8');
+
+for (const id of [
+  'unitMgrExisting',
+  'btnUnitMgrNew',
+  'unitMgrKind',
+  'unitMgrDescription',
+  'unitMgrStatusField',
+  'unitMgrSortOrder',
+]) {
+  assert.ok(markup.includes('id="' + id + '"'), 'Missing Admin manager control: ' + id);
+}
+
+assert.ok(
+  markup.includes('id="unitMgrSection"') &&
+  markup.includes('value="language-arts"') &&
+  markup.includes('This manager is currently scoped to the safe Language Arts collection workflow.'),
+  'Curriculum Collection Manager must be visibly scoped to Language Arts'
+);
+
+assert.ok(
+  !markup.includes('<option value="life-skills">Life Skills</option>'),
+  'Curriculum Collection Manager must not offer a new Life Skills collection path'
+);
+
+assert.ok(
+  manager.includes('Curriculum Collection Manager is currently scoped to Language Arts.'),
+  'Curriculum Collection Manager must reject a forged non-Language-Arts section value'
+);
+
+assert.ok(
+  manager.includes("pagePath = '/language-arts/collection/';"),
+  'New Language Arts collections must default to the reusable collection route'
+);
+
+assert.ok(
+  manager.includes("body: JSON.stringify({ ...payload, createPr: true })"),
+  'Collection manager must retain the guarded draft-PR save path'
+);
+
+assert.ok(
+  manager.includes('function loadKnownCollections()'),
+  'Collection manager must load existing collections for editing'
+);
+
+assert.ok(
+  manager.includes('function resetNewCollection()'),
+  'Collection manager must support creating a new collection'
+);
+
+for (const field of ['kind', 'description', 'status', 'sortOrder']) {
+  assert.ok(
+    backend.includes(field),
+    'Backend must preserve collection field: ' + field
+  );
+}
+
+assert.ok(
+  markup.includes('id="unitMgrBaseOut" class="input" placeholder="presentations/collection-id" readonly'),
+  'Managed presentation folder must be read-only in the Admin manager'
+);
+
+assert.ok(
+  markup.includes('id="unitMgrPagePath" class="input" placeholder="/language-arts/collection/" readonly'),
+  'Managed collection route must be read-only in the Admin manager'
+);
+
+assert.ok(
+  backend.includes('function validateUnitUpdatePolicy('),
+  'Backend must enforce route and material-path preservation'
+);
+
+assert.ok(
+  backend.includes('usesGenericCollectionRoute'),
+  'Backend must recognize the reusable generic collection route'
+);
+
+assert.ok(
+  backend.includes("unit.pagePath === '/language-arts/collection/'"),
+  'Backend must avoid generating one static page per new Language Arts collection'
+);
+
+assert.ok(
+  generator.includes("(u.status || 'active') === 'active'"),
+  'Generated lessons index must omit archived collections'
+);
+
+assert.ok(
+  generator.includes('units.sort((a, b) => {'),
+  'Generated lessons index must respect registry ordering'
+);
+
+console.log('PASS: Curriculum Collection Registry v2 manager and backend contract');

--- a/tests/curriculum-collection-navigation.test.cjs
+++ b/tests/curriculum-collection-navigation.test.cjs
@@ -1,0 +1,51 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const nav = fs.readFileSync('site/web/public-nav.js', 'utf8');
+const landing = fs.readFileSync('site/language-arts/index.html', 'utf8');
+const renderer = fs.readFileSync('site/assets/js/language-arts-collections.js', 'utf8');
+
+assert.ok(
+  landing.includes('/assets/js/language-arts-collections.js'),
+  'Language Arts landing page must load the registry-backed collection renderer'
+);
+
+assert.ok(
+  renderer.includes('/assets/data/units.json'),
+  'Language Arts landing renderer must load the collection registry'
+);
+
+assert.ok(
+  renderer.includes("unit.section === 'language-arts'"),
+  'Language Arts landing renderer must filter to Language Arts collections'
+);
+
+assert.ok(
+  renderer.includes("(unit.status || 'active') === 'active'"),
+  'Language Arts landing renderer must exclude archived collections'
+);
+
+assert.ok(
+  nav.includes('function appendLanguageArtsCollections'),
+  'Shared navigation must append active Language Arts collections dynamically'
+);
+
+const laNavStart = nav.indexOf('var LA_NAV = [');
+const laNavEnd = nav.indexOf('];', laNavStart);
+
+assert.ok(laNavStart >= 0 && laNavEnd > laNavStart, 'LA_NAV block must exist');
+
+const laNavBlock = nav.slice(laNavStart, laNavEnd);
+
+assert.ok(
+  !laNavBlock.includes('A Door Into Time') &&
+  !laNavBlock.includes('Lost in Kragdon') &&
+  !laNavBlock.includes('Return from Kragdon') &&
+  !laNavBlock.includes('Warrior of Kragdon'),
+  'LA_NAV must no longer hardcode the four legacy book titles'
+);
+
+console.log('PASS: Curriculum Collection Registry v2 navigation wiring');

--- a/tests/curriculum-collection-registry.test.cjs
+++ b/tests/curriculum-collection-registry.test.cjs
@@ -1,0 +1,60 @@
+/* eslint-env node */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+const registry = JSON.parse(
+  fs.readFileSync('site/assets/data/units.json', 'utf8')
+);
+
+assert.ok(Array.isArray(registry.units), 'units.json must expose a units array');
+
+const expectedBooks = {
+  adit: {
+    sortOrder: 10,
+    baseOut: 'presentations/a-door-into-time',
+    pagePath: '/language-arts/a-door-into-time/',
+  },
+  lik: {
+    sortOrder: 20,
+    baseOut: 'presentations/lost-in-kragdon-ah',
+    pagePath: '/language-arts/lost-in-kragdon-ah/',
+  },
+  rfk: {
+    sortOrder: 30,
+    baseOut: 'presentations/return-from-kragdon-ah',
+    pagePath: '/language-arts/return-from-kragdon-ah/',
+  },
+  wok: {
+    sortOrder: 40,
+    baseOut: 'presentations/warrior-of-kragdon-ah',
+    pagePath: '/language-arts/warrior-of-kragdon-ah/',
+  },
+};
+
+const sortOrders = [];
+
+for (const [id, expected] of Object.entries(expectedBooks)) {
+  const unit = registry.units.find((item) => item && item.id === id);
+
+  assert.ok(unit, 'Missing legacy collection: ' + id);
+  assert.strictEqual(unit.section, 'language-arts', id + ' must remain Language Arts');
+  assert.strictEqual(unit.kind, 'book', id + ' must be marked as a book');
+  assert.strictEqual(unit.description, '', id + ' must retain an empty optional description');
+  assert.strictEqual(unit.status, 'active', id + ' must remain active');
+  assert.strictEqual(unit.sortOrder, expected.sortOrder, id + ' has an unexpected display order');
+  assert.strictEqual(unit.slots, 16, id + ' must retain 16 presentation slots');
+  assert.strictEqual(unit.baseOut, expected.baseOut, id + ' baseOut changed unexpectedly');
+  assert.strictEqual(unit.pagePath, expected.pagePath, id + ' route changed unexpectedly');
+
+  sortOrders.push(unit.sortOrder);
+}
+
+assert.strictEqual(
+  new Set(sortOrders).size,
+  sortOrders.length,
+  'Legacy collection display orders must remain unique'
+);
+
+console.log('PASS: Curriculum Collection Registry v2 legacy-book contract');


### PR DESCRIPTION
## Summary

Adds Curriculum Collection Registry v2 for the 2026–27 Reinisch Classroom stabilization path.

This PR makes Language Arts curriculum collections lifecycle-aware and registry-driven while preserving the existing legacy book workflows.

## What changed

- Added collection metadata to `site/assets/data/units.json`:
  - `kind`
  - `description`
  - `status`
  - `sortOrder`
- Added registry-driven Language Arts landing cards.
- Added registry-driven public sidebar entries.
- Added shared generic collection route:
  - `/language-arts/collection/?collection=<id>`
- Preserved existing legacy book routes and folders.
- Added Admin Curriculum Collection Manager behind the existing guarded admin workflow.
- Locked existing collection `section`, `baseOut`, and `pagePath` at the backend.
- Scoped the new manager to the safe Language Arts collection workflow.
- Updated lesson-index generator behavior to honor active/archive status and registry sort order.

## Safety boundaries

This PR does **not** change:

- Supabase schema
- Supabase RLS
- Supabase auth
- Netlify settings
- student login
- student submissions
- assignment schema
- gradebook schema
- classroom reset/archive workflow
- real student data

The Admin manager still uses the existing guarded draft-PR path.

## Test proof

Focused checks passed locally:

- `node tests/curriculum-collection-registry.test.cjs`
- `node tests/curriculum-collection-navigation.test.cjs`
- `node tests/curriculum-collection-generic-route.test.cjs`
- `node tests/curriculum-collection-manager.test.cjs`
- `node tests/admin-units-upsert-collection-validation.test.cjs`
- `node tests/admin-units-upsert-collection-policy.test.cjs`
- `npm run check:nav-script`
- `npx playwright test tests/curriculum-collection-generic-route.spec.js`

Playwright result:

- 4 passed

## Known baseline issues, not introduced by this PR

- Full unit suite still has existing date-label helper failures.
- `check:inline-scripts` has existing legacy violations on clean `HEAD` and on this branch:
  - 2,417 violations in 132 files.
- `generate:lessons-index` has pre-existing output drift on clean `HEAD`.
  - Repo-defined Netlify build command does not run `generate:lessons-index`.

## Review focus

Please verify:

- Existing legacy Language Arts routes still load.
- `/language-arts/` shows registry-driven collection cards.
- `/language-arts/collection/?collection=<id>` resolves active registry collections.
- Archived collections are hidden from active navigation.
- Admin Collection Manager is scoped to Language Arts and preserves existing routes/folders.
