### PR TITLE
RC-2026-27-05 fix Life Skills landing resolution

### DIFF
--- a/site/assets/js/unit-grid.js
+++ b/site/assets/js/unit-grid.js
@@ -24,11 +24,16 @@
 
   function inferUnitId(units, pathname){
     const clean = pathname.replace(/index\.html$/,'').replace(/\/+$/,'/') || '/';
-    for (const u of units){
+    const activeUnits = units.filter(function(unit){
+      return unit &&
+        (unit.status || 'active') === 'active';
+    });
+
+    for (const u of activeUnits){
       const pp = String(u.pagePath||'').replace(/\/+$/,'/') || '/';
       if (pp && clean === pp) return u.id;
     }
-    for (const u of units){
+    for (const u of activeUnits){
       const pp = String(u.pagePath||'').replace(/\/+$/,'/');
       if (pp && clean.startsWith(pp)) return u.id;
     }

--- a/tests/curriculum-collection-generic-route.test.cjs
+++ b/tests/curriculum-collection-generic-route.test.cjs
@@ -36,6 +36,13 @@ assert.ok(
 );
 
 assert.ok(
+  unitGrid.includes('const activeUnits = units.filter') &&
+    unitGrid.includes('for (const u of activeUnits)') &&
+    unitGrid.includes("(unit.status || 'active') === 'active'"),
+  'path-based unit resolution must skip archived records before matching duplicate page paths'
+);
+
+assert.ok(
   unitGrid.includes('const inferredUnit = units.find') &&
     unitGrid.includes("return inferredUnit ? inferredUnit.id : '';"),
   'legacy collection grids must not actively resolve archived collections'

--- a/tests/curriculum-presentation-import-bulk.spec.js
+++ b/tests/curriculum-presentation-import-bulk.spec.js
@@ -62,3 +62,23 @@ test('retains continuous Life Skills animation and interaction', async ({ page }
     spin: getComputedStyle(document.querySelector('.slide.active .ring')).animationName
   }))).toEqual({ bob: 'bob', spin: 'spin' });
 });
+
+test('renders all 37 presentations on the Life Skills landing page', async ({ page }) => {
+  await page.goto('/life-skills/');
+
+  const cards = page.locator('#grid .card');
+
+  await expect(cards).toHaveCount(37);
+
+  await expect(cards.first()).toContainText(
+    'Week 1: Course Orientation & Baseline - Worker Profile and Functional Baselines'
+  );
+
+  await expect(cards.last()).toContainText(
+    'Week 37: Integrated Employment and Money Simulation - Show the Skills That Matter'
+  );
+
+  await expect(
+    page.locator('#grid .card.disabled')
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- fixes the empty Life Skills landing page
- skips archived registry records before resolving shared page paths
- resolves `/life-skills/` to the active `life-sc-2026-27` collection
- renders all 37 weekly Life Skills presentation cards
- adds durable data and browser regression coverage

## Root cause

The archived legacy `life` record and active `life-sc-2026-27` record both use `/life-skills/`.

The shared grid loader selected the first matching path, then rejected it because it was archived, without continuing to the active record.

## Scope

Exactly three files:

- `site/assets/js/unit-grid.js`
- `tests/curriculum-collection-generic-route.test.cjs`
- `tests/curriculum-presentation-import-bulk.spec.js`

No presentation HTML, titles, animations, registry data, student data, database schema, auth/RLS, or production records changed.

## Validation

- `git diff --check` passed
- targeted ESLint: 0 errors, 1 pre-existing unused-helper warning
- 4 data contracts passed
- 9 Playwright browser tests passed
- Life Skills landing acceptance verifies:
  - 37 cards
  - correct Week 1 title
  - correct Week 37 title
  - zero disabled cards
