### PR TITLE
RC-2026-27-07 restore Life Skills presentation execution

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -228,6 +228,12 @@
   [headers.values]
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
 
+# Route-specific CSP for /life-skills/presentations-2026-27/* - allows inline scripts for current Life Skills presentation pages
+[[headers]]
+  for = "/life-skills/presentations-2026-27/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
+
 # Route-specific CSP for /language-arts/presentations/* - allows inline scripts for presentation pages
 [[headers]]
   for = "/language-arts/presentations/*"

--- a/tests/curriculum-presentation-csp.test.cjs
+++ b/tests/curriculum-presentation-csp.test.cjs
@@ -1,0 +1,44 @@
+/* global require */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('netlify.toml', 'utf8');
+
+const headerBlocks = Array.from(
+  source.matchAll(
+    /\[\[headers\]\]\s*for\s*=\s*"([^"]+)"\s*\[headers\.values\]\s*Content-Security-Policy\s*=\s*"([^"]*)"/g
+  ),
+  match => ({
+    route: match[1],
+    policy: match[2]
+  })
+);
+
+function requireInlineScriptPolicy(route) {
+  const block = headerBlocks.find(
+    candidate => candidate.route === route
+  );
+
+  assert.ok(
+    block,
+    `${route} must have a route-specific CSP header block`
+  );
+
+  assert.match(
+    block.policy,
+    /script-src\s+[^;]*'unsafe-inline'/,
+    `${route} must permit the existing inline presentation scripts`
+  );
+}
+
+requireInlineScriptPolicy(
+  '/life-skills/presentations-2026-27/*'
+);
+
+requireInlineScriptPolicy(
+  '/life-skills/presentations/*'
+);
+
+console.log(
+  'PASS: Current and legacy Life Skills presentation routes permit their existing inline scripts.'
+);

--- a/tests/curriculum-presentation-import-bulk.spec.js
+++ b/tests/curriculum-presentation-import-bulk.spec.js
@@ -63,6 +63,69 @@ test('retains continuous Life Skills animation and interaction', async ({ page }
   }))).toEqual({ bob: 'bob', spin: 'spin' });
 });
 
+test('loads Life Skills through the real inline viewer and preserves Language Arts', async ({ page }) => {
+  const inlineScriptCspErrors = [];
+
+  page.on('console', message => {
+    if (
+      message.type() === 'error' &&
+      /Refused to execute inline script/i.test(message.text())
+    ) {
+      inlineScriptCspErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/life-skills/');
+
+  const lifeSkillsCards = page.locator('#grid .card');
+  await expect(lifeSkillsCards).toHaveCount(37);
+
+  await lifeSkillsCards.first().click();
+
+  const lifeSkillsFrame = page.frameLocator('#pvInlineIframe');
+
+  await expect(
+    lifeSkillsFrame.locator('.slide.active')
+  ).toHaveCount(1);
+
+  await expect(
+    lifeSkillsFrame.locator('#count')
+  ).toHaveText('1 / 23');
+
+  await expect.poll(async () => (
+    lifeSkillsFrame
+      .locator('#stage')
+      .evaluate(stage => stage.style.transform)
+  )).toMatch(/scale\(/);
+
+  await page.goto(
+    '/language-arts/collection/?collection=1984-2026-27'
+  );
+
+  const languageArtsCards = page.locator('#grid .card');
+  await expect(languageArtsCards).toHaveCount(14);
+
+  await languageArtsCards.nth(1).click();
+
+  const languageArtsFrame = page.frameLocator('#pvInlineIframe');
+
+  await expect(
+    languageArtsFrame.locator('.slide.active')
+  ).toHaveCount(1);
+
+  await expect(
+    languageArtsFrame.locator('#count')
+  ).toHaveText('1 / 33');
+
+  await expect.poll(async () => (
+    languageArtsFrame
+      .locator('#stage')
+      .evaluate(stage => stage.style.transform)
+  )).toMatch(/scale\(/);
+
+  expect(inlineScriptCspErrors).toEqual([]);
+});
+
 test('renders all 37 presentations on the Life Skills landing page', async ({ page }) => {
   await page.goto('/life-skills/');
 


### PR DESCRIPTION
## Goal

Restore execution of the 2026–27 Life Skills presentations.

## Confirmed defect

The global Content Security Policy blocked the presentations' existing inline JavaScript because the route-specific exception covered:

- `/life-skills/presentations/*`

but not the current route:

- `/life-skills/presentations-2026-27/*`

Without the script:

- no slide received `.active`
- the slide counter remained empty
- presentation scaling and navigation initialization never ran

## Changes

- added a route-specific CSP header for `/life-skills/presentations-2026-27/*`
- preserved the legacy Life Skills presentation CSP route
- added a configuration contract test for both routes
- added inline-viewer regression coverage for Life Skills
- retained Language Arts inline-viewer verification

## Local verification

- targeted ESLint passed
- CSP and presentation contracts: 2 passed
- Playwright browser acceptance: 5 passed

## Deploy-preview verification required

The Netlify deploy preview must prove:

- the current Life Skills route receives a CSP allowing its inline script
- Life Skills opens through the real inline viewer
- one slide becomes active
- the counter displays `1 / 23`
- the stage receives a scale transform
- no inline-script CSP violation occurs
- Language Arts still loads normally

## Guardrails

- no presentation HTML changed
- no global CSP relaxation
- no legacy route removed
- no database, auth, schema, RLS, secrets, student data, or deployment settings changed outside the scoped `netlify.toml` route header
