### PR TITLE
RC-2026-27-08 enable immediate presentation keyboard navigation

### DIFF
--- a/site/assets/js/open-in-viewer.js
+++ b/site/assets/js/open-in-viewer.js
@@ -135,7 +135,7 @@
         '<div class="pv-clock" id="pvInlineClock"></div>' +
       '</div>' +
       '<div class="pv-frame">' +
-        '<iframe class="pv-iframe" id="pvInlineIframe" ' +
+        '<iframe class="pv-iframe" id="pvInlineIframe" tabindex="0" ' +
           'sandbox="allow-scripts allow-same-origin allow-forms" ' +
           'allow="fullscreen" allowfullscreen ' +
           'title="Presentation content"></iframe>' +
@@ -215,6 +215,22 @@
     var iframe = el.querySelector('#pvInlineIframe');
     var titleEl = el.querySelector('#pvInlineTitle');
 
+    function focusPresentationFrame() {
+      window.requestAnimationFrame(function () {
+        try {
+          iframe.focus({ preventScroll: true });
+        } catch {
+          iframe.focus();
+        }
+      });
+    }
+
+    iframe.addEventListener(
+      'load',
+      focusPresentationFrame,
+      { once: true }
+    );
+
     // Normalise directory URLs
     var src = srcPath.endsWith('/') ? srcPath + 'index.html' : srcPath;
     iframe.src = src;
@@ -227,6 +243,7 @@
     el.classList.remove('presentation-mode');
     el.classList.add('open');
     document.body.style.overflow = 'hidden';
+    focusPresentationFrame();
 
     // Start clock — use class clock if available, otherwise fall back to simple time
     if (!_classClockCtrl && window.RCClassClock) {

--- a/tests/curriculum-presentation-import-bulk.spec.js
+++ b/tests/curriculum-presentation-import-bulk.spec.js
@@ -98,6 +98,23 @@ test('loads Life Skills through the real inline viewer and preserves Language Ar
       .evaluate(stage => stage.style.transform)
   )).toMatch(/scale\(/);
 
+  // keyboard works immediately for Life Skills without clicking inside
+  await expect.poll(() => (
+    page.evaluate(() => document.activeElement?.id || '')
+  )).toBe('pvInlineIframe');
+
+  await page.keyboard.press('ArrowRight');
+
+  await expect(
+    lifeSkillsFrame.locator('#count')
+  ).toHaveText('2 / 23');
+
+  await page.keyboard.press('ArrowLeft');
+
+  await expect(
+    lifeSkillsFrame.locator('#count')
+  ).toHaveText('1 / 23');
+
   await page.goto(
     '/language-arts/collection/?collection=1984-2026-27'
   );
@@ -122,6 +139,23 @@ test('loads Life Skills through the real inline viewer and preserves Language Ar
       .locator('#stage')
       .evaluate(stage => stage.style.transform)
   )).toMatch(/scale\(/);
+
+  // keyboard works immediately for Language Arts without clicking inside
+  await expect.poll(() => (
+    page.evaluate(() => document.activeElement?.id || '')
+  )).toBe('pvInlineIframe');
+
+  await page.keyboard.press('ArrowRight');
+
+  await expect(
+    languageArtsFrame.locator('#count')
+  ).toHaveText('2 / 33');
+
+  await page.keyboard.press('ArrowLeft');
+
+  await expect(
+    languageArtsFrame.locator('#count')
+  ).toHaveText('1 / 33');
 
   expect(inlineScriptCspErrors).toEqual([]);
 });


### PR DESCRIPTION
## Goal

Make presentation keyboard navigation work immediately after launch, without requiring the user to click inside the presentation first.

## Confirmed defect

When the inline viewer opened:

- keyboard focus remained on the selected landing-page card
- Arrow Right and Arrow Left did not reach the presentation iframe
- clicking Prev or Next moved focus into the iframe
- keyboard navigation then began working normally

## Changes

- made the shared presentation iframe explicitly focusable
- focused the iframe when the viewer opens
- focused it again after the presentation finishes loading
- added regression coverage for immediate keyboard navigation in:
  - Life Skills
  - Language Arts

## Local verification

- JavaScript syntax check passed
- targeted ESLint passed
- CSP and presentation contracts: 2 passed
- Playwright browser acceptance: 5 passed
- Life Skills advances from `1 / 23` to `2 / 23` with Arrow Right immediately after launch
- Arrow Left returns it to `1 / 23`
- Language Arts advances from `1 / 33` to `2 / 33` immediately after launch
- Arrow Left returns it to `1 / 33`

## Guardrails

- no presentation HTML files changed
- no keyboard logic duplicated in the parent page
- no route, CSP, sidebar, or navigation redesign
- no database, authentication, schema, RLS, secrets, or student data changes
