### PR TITLE
RC-2026-27-09 add contextual classroom navigation

### DIFF
--- a/site/web/public-shell.js
+++ b/site/web/public-shell.js
@@ -30,6 +30,109 @@
     });
   }
 
+  function normalizePath(pathname){
+    const normalized = (pathname || '/')
+      .replace(/index\.html$/i, '')
+      .replace(/\/+$/, '');
+
+    return normalized || '/';
+  }
+
+  function getContextualParent(){
+    const path = normalizePath(location.pathname);
+
+    if (
+      path === '/language-arts' ||
+      path === '/life-skills' ||
+      path === '/toolkits'
+    ) {
+      return { label: 'Home', href: '/' };
+    }
+
+    if (
+      path === '/language-arts/toolkit' ||
+      path === '/math-toolkit'
+    ) {
+      return { label: 'Toolkits', href: '/toolkits/' };
+    }
+
+    if (path.startsWith('/language-arts/')) {
+      return {
+        label: 'Language Arts',
+        href: '/language-arts/'
+      };
+    }
+
+    if (path.startsWith('/life-skills/')) {
+      return {
+        label: 'Life Skills',
+        href: '/life-skills/'
+      };
+    }
+
+    if (path === '/math-toolkit/algebra') {
+      return {
+        label: 'Math Toolkit',
+        href: '/math-toolkit/'
+      };
+    }
+
+    if (path.startsWith('/math-toolkit/algebra/')) {
+      return {
+        label: 'Algebra',
+        href: '/math-toolkit/algebra/'
+      };
+    }
+
+    if (path.startsWith('/math-toolkit/')) {
+      return {
+        label: 'Math Toolkit',
+        href: '/math-toolkit/'
+      };
+    }
+
+    return null;
+  }
+
+  function insertContextualBackNavigation(){
+    const parent = getContextualParent();
+    if (!parent) return;
+
+    if (document.querySelector('.tc-context-nav')) return;
+
+    const main = document.querySelector('.tc-main');
+    if (!main) return;
+
+    const container =
+      main.querySelector('.content-wrapper, .wrap') || main;
+
+    const nav = document.createElement('nav');
+    nav.className = 'tc-context-nav';
+    nav.setAttribute('aria-label', 'Contextual navigation');
+
+    let link = document.querySelector('.back-link');
+
+    if (link) {
+      link.remove();
+      link.classList.remove('back-link');
+    } else {
+      link = document.createElement('a');
+    }
+
+    link.classList.add('tc-context-back');
+    link.href = parent.href;
+    link.setAttribute(
+      'aria-label',
+      'Back to ' + parent.label
+    );
+    link.innerHTML =
+      '<span aria-hidden="true">←</span>' +
+      '<span>Back to ' + parent.label + '</span>';
+
+    nav.appendChild(link);
+    container.insertBefore(nav, container.firstChild);
+  }
+
   function init(){
     // Public pages - no authentication required
 
@@ -78,6 +181,7 @@
       }
     });
 
+    insertContextualBackNavigation();
     wireNavActive();
   }
 

--- a/site/web/teacher-shell.css
+++ b/site/web/teacher-shell.css
@@ -281,3 +281,40 @@ iframe[src*="app.netlify.com"]{
     pointer-events: auto;
   }
 }
+
+/* Contextual parent navigation */
+.tc-context-nav {
+  display: flex;
+  align-items: center;
+  margin: 0 0 1rem;
+}
+
+.tc-context-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.58rem 0.88rem;
+  border: 1px solid var(--tc-border);
+  border-radius: 10px;
+  background: rgba(255,255,255,.06);
+  color: var(--tc-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 750;
+  line-height: 1;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.tc-context-back:hover {
+  background: rgba(255,255,255,.11);
+  border-color: rgba(255,255,255,.22);
+  transform: translateX(-2px);
+}
+
+.tc-context-back:focus-visible {
+  outline: 2px solid var(--tc-nav-active-accent);
+  outline-offset: 3px;
+}

--- a/tests/contextual-subpage-navigation.spec.js
+++ b/tests/contextual-subpage-navigation.spec.js
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+const routes = [
+  {
+    route: '/language-arts/',
+    label: 'Home',
+    parent: '/'
+  },
+  {
+    route: '/life-skills/',
+    label: 'Home',
+    parent: '/'
+  },
+  {
+    route: '/toolkits/',
+    label: 'Home',
+    parent: '/'
+  },
+  {
+    route: '/language-arts/collection/?collection=1984-2026-27',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/a-door-into-time/',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/lost-in-kragdon-ah/',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/return-from-kragdon-ah/',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/warrior-of-kragdon-ah/',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/assignment-hub/',
+    label: 'Language Arts',
+    parent: '/language-arts/'
+  },
+  {
+    route: '/language-arts/toolkit/',
+    label: 'Toolkits',
+    parent: '/toolkits/'
+  },
+  {
+    route: '/math-toolkit/',
+    label: 'Toolkits',
+    parent: '/toolkits/'
+  },
+  {
+    route: '/math-toolkit/algebra/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/geometry/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/number-sense/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/data-statistics/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/money-math/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/general/',
+    label: 'Math Toolkit',
+    parent: '/math-toolkit/'
+  },
+  {
+    route: '/math-toolkit/algebra/pre-algebra/',
+    label: 'Algebra',
+    parent: '/math-toolkit/algebra/'
+  },
+  {
+    route: '/math-toolkit/algebra/algebra-1/',
+    label: 'Algebra',
+    parent: '/math-toolkit/algebra/'
+  },
+  {
+    route: '/math-toolkit/algebra/algebra-2/',
+    label: 'Algebra',
+    parent: '/math-toolkit/algebra/'
+  },
+  {
+    route: '/math-toolkit/algebra/algebra-3/',
+    label: 'Algebra',
+    parent: '/math-toolkit/algebra/'
+  },
+  {
+    route: '/math-toolkit/algebra/college-algebra/',
+    label: 'Algebra',
+    parent: '/math-toolkit/algebra/'
+  }
+];
+
+test(
+  'provides one contextual parent button on classroom-material pages',
+  async ({ page }) => {
+    for (const item of routes) {
+      await page.goto(item.route);
+
+      const nav = page.locator('nav.tc-context-nav');
+      const link = nav.locator('a.tc-context-back');
+
+      await expect(
+        nav,
+        `${item.route} should have one contextual nav`
+      ).toHaveCount(1);
+
+      await expect(link).toBeVisible();
+
+      await expect(link).toHaveAccessibleName(
+        `Back to ${item.label}`
+      );
+
+      await expect(link).toHaveAttribute(
+        'href',
+        item.parent
+      );
+
+      expect(
+        await nav.evaluate(element => (
+          element.parentElement?.firstElementChild === element
+        ))
+      ).toBe(true);
+
+      await link.click();
+      await page.waitForLoadState('domcontentloaded');
+
+      expect(new URL(page.url()).pathname).toBe(
+        item.parent
+      );
+    }
+  }
+);


### PR DESCRIPTION
## Goal

Provide clear contextual parent-navigation buttons across classroom-material landing pages and subpages.

## Changes

- added route-aware contextual navigation through the shared public shell
- added shared button styling through the existing teacher shell stylesheet
- normalized the existing manual toolkit back links into the shared component
- added browser regression coverage for the classroom-material hierarchy

## Navigation hierarchy

- Language Arts → Home
- Life Skills → Home
- Toolkits → Home
- Language Arts books, collections, and Assignment Hub → Language Arts
- Language Arts Toolkit → Toolkits
- Math Toolkit → Toolkits
- Math categories → Math Toolkit
- individual Algebra levels → Algebra

## Local verification

- diff check passed
- JavaScript syntax checks passed
- targeted ESLint passed
- curriculum navigation contracts: 2 passed
- contextual navigation and existing curriculum browser acceptance: 10 passed
- each tested page renders exactly one contextual navigation button
- each button has the correct accessible name and parent route
- each button successfully navigates to its expected parent

## Guardrails

- no presentation HTML changed
- no individual classroom page rewrites
- no sidebar redesign
- no route changes
- no database, authentication, schema, RLS, secrets, student data, or deployment-setting changes
