### PR TITLE
Fix local Supabase config parsing

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -341,9 +341,6 @@ deno_version = 2
 enabled = true
 verify_jwt = false
 
-[functions.daily-digest.schedule]
-cron = "0 6 * * 1-5"
-
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
## Summary

Removes an invalid nested schedule stanza from `supabase/config.toml`:

- `[functions.daily-digest.schedule]`
- `cron = "0 6 * * 1-5"`

The valid `daily-digest` function configuration remains unchanged.

## Why

The installed Supabase CLI does not accept the nested schedule configuration and local Supabase commands fail while parsing the project configuration.

## Validation

- change is limited to `supabase/config.toml`
- exactly three lines are removed
- TOML parsing succeeds
- Supabase CLI proceeds past configuration parsing successfully
- subsequent `supabase status` failure was caused only by the absence of a repo-local Docker container, not by configuration parsing

## Safety

- no Supabase schema change
- no RLS change
- no auth change
- no database migration
- no production data change
- no deployment initiated manually
