### PR TITLE
Fix active-year ungraded count isolation

### DIFF
--- a/netlify/functions/_lib/school-year.js
+++ b/netlify/functions/_lib/school-year.js
@@ -25,6 +25,36 @@ function getCurrentSchoolYear(now = new Date()) {
 }
 
 /**
+ * Returns the active operational school year used for current teacher work.
+ *
+ * Unlike getCurrentSchoolYear(), July is treated as preparation for the
+ * upcoming school year:
+ *
+ *   Jan-Jun -> previous calendar year
+ *   Jul-Dec -> current calendar year
+ *
+ * Example:
+ *   June 30, 2026 -> 2025
+ *   July 1, 2026  -> 2026
+ *   July 25, 2026 -> 2026
+ *   August 1, 2026 -> 2026
+ *
+ * This does not change how historical dates are classified.
+ */
+function getOperationalSchoolYear(now = new Date()) {
+  const date = now instanceof Date ? now : new Date(now);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid date supplied to getOperationalSchoolYear');
+  }
+
+  const month = date.getMonth() + 1;
+  return month >= 7
+    ? date.getFullYear()
+    : date.getFullYear() - 1;
+}
+
+/**
  * Allows an assignment draft to explicitly target a school year.
  *
  * Supported:
@@ -59,5 +89,6 @@ function resolveSchoolYear(draft, now = new Date()) {
 
 module.exports = {
   getCurrentSchoolYear,
+  getOperationalSchoolYear,
   resolveSchoolYear,
 };

--- a/netlify/functions/teacher-ungraded-count.js
+++ b/netlify/functions/teacher-ungraded-count.js
@@ -10,6 +10,7 @@ const {
 
 const { requireTeacher } = require('./_lib/auth');
 const { getSupabaseConfig } = require('./_lib/supa');
+const { getOperationalSchoolYear } = require('./_lib/school-year');
 
 const { url: SUPABASE_URL, key: SUPABASE_SERVICE_ROLE_KEY } = getSupabaseConfig();
 const { SESSION_SECRET } = process.env;
@@ -39,8 +40,11 @@ exports.handler = async (event) => {
   }
 
   try {
-    // Count assignment_instances with status 'Submitted' (not yet graded)
-    const url = `${SUPABASE_URL}/rest/v1/assignment_instances?select=id&status=eq.Submitted`;
+    // Count only current operational-year instances awaiting grading.
+    // Historical and legacy NULL-year records remain preserved but do not
+    // inflate the active Teacher Center count.
+    const operationalYear = getOperationalSchoolYear();
+    const url = `${SUPABASE_URL}/rest/v1/assignment_instances?select=id&status=eq.Submitted&school_year=eq.${operationalYear}`;
     const resp = await fetch(url, {
       method: 'GET',
       headers: {

--- a/tests/school-year.test.cjs
+++ b/tests/school-year.test.cjs
@@ -4,6 +4,7 @@ const assert = require('assert');
 
 const {
   getCurrentSchoolYear,
+  getOperationalSchoolYear,
   resolveSchoolYear,
 } = require('../netlify/functions/_lib/school-year');
 
@@ -20,6 +21,30 @@ assert.strictEqual(
   2026
 );
 console.log('✓ existing August behavior remains 2026');
+
+assert.strictEqual(
+  getOperationalSchoolYear(new Date('2026-06-30T12:00:00')),
+  2025
+);
+console.log('✓ operational year remains 2025 through June 30');
+
+assert.strictEqual(
+  getOperationalSchoolYear(new Date('2026-07-01T12:00:00')),
+  2026
+);
+console.log('✓ operational year rolls to 2026 on July 1');
+
+assert.strictEqual(
+  getOperationalSchoolYear(new Date('2026-07-25T12:00:00')),
+  2026
+);
+console.log('✓ July 25 teacher operations target 2026');
+
+assert.strictEqual(
+  getCurrentSchoolYear(new Date('2026-07-25T12:00:00')),
+  2025
+);
+console.log('✓ July historical/calendar classification still remains 2025');
 
 assert.strictEqual(
   resolveSchoolYear(

--- a/tests/teacher-ungraded-count-school-year.test.cjs
+++ b/tests/teacher-ungraded-count-school-year.test.cjs
@@ -1,0 +1,131 @@
+'use strict';
+
+const assert = require('assert');
+
+const RealDate = global.Date;
+const realFetch = global.fetch;
+
+const endpointPath =
+  require.resolve('../netlify/functions/teacher-ungraded-count');
+const authPath =
+  require.resolve('../netlify/functions/_lib/auth');
+
+const savedEnv = {
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  SESSION_SECRET: process.env.SESSION_SECRET,
+};
+
+async function run() {
+  console.log('Running teacher ungraded school-year isolation test...\n');
+
+  process.env.SUPABASE_URL = 'https://synthetic.invalid';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'synthetic-test-key';
+  process.env.SESSION_SECRET = 'synthetic-session-secret';
+
+  // Freeze "today" in the July transition period.
+  global.Date = class FixedDate extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) {
+        super('2026-07-25T12:00:00-05:00');
+      } else {
+        super(...args);
+      }
+    }
+
+    static now() {
+      return new RealDate('2026-07-25T12:00:00-05:00').getTime();
+    }
+  };
+
+  const auth = require(authPath);
+  const originalRequireTeacher = auth.requireTeacher;
+
+  auth.requireTeacher = () => ({
+    ok: true,
+    user: { username: 'teacher_test' },
+  });
+
+  let capturedUrl = null;
+  let fetchCalls = 0;
+
+  global.fetch = async (url) => {
+    fetchCalls += 1;
+    capturedUrl = String(url);
+
+    return {
+      ok: true,
+      headers: {
+        get(name) {
+          return String(name).toLowerCase() === 'content-range'
+            ? '0-0/1'
+            : null;
+        },
+      },
+      async json() {
+        return [{ id: 'synthetic-instance' }];
+      },
+    };
+  };
+
+  try {
+    delete require.cache[endpointPath];
+    const { handler } = require(endpointPath);
+
+    const response = await handler({
+      httpMethod: 'GET',
+      headers: {},
+      body: null,
+    });
+
+    assert.strictEqual(response.statusCode, 200);
+    assert.strictEqual(fetchCalls, 1);
+
+    const body = JSON.parse(response.body);
+    assert.strictEqual(body.ok, true);
+    assert.strictEqual(body.count, 1);
+
+    assert.ok(
+      capturedUrl.includes('status=eq.Submitted'),
+      'query must count only Submitted instances'
+    );
+
+    assert.ok(
+      capturedUrl.includes('school_year=eq.2026'),
+      `July operational query must target 2026: ${capturedUrl}`
+    );
+
+    assert.ok(
+      !capturedUrl.includes('school_year=eq.2025'),
+      'ending 2025-26 year must not be counted as active in July'
+    );
+
+    assert.ok(
+      !capturedUrl.includes('school_year.is.null'),
+      'legacy NULL-year records must not enter active ungraded count'
+    );
+
+    console.log('✓ July 2026 operational ungraded query targets school_year=2026');
+    console.log('✓ 2025-26 records are excluded from the active count');
+    console.log('✓ NULL-year legacy records are excluded from the active count');
+    console.log('\n✓ Focused ungraded school-year isolation test passed!');
+  } finally {
+    auth.requireTeacher = originalRequireTeacher;
+    global.Date = RealDate;
+    global.fetch = realFetch;
+    delete require.cache[endpointPath];
+
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## RC-2026-27-13A — Active-year ungraded isolation

### Goal

Prevent historical and legacy assignment instances from inflating the active Teacher Center ungraded count.

### Operational-year rule

Historical/calendar school-year classification remains unchanged:

- July 2026 remains part of 2025–26 for historical date interpretation.

A separate operational school-year helper now treats July as preparation for the upcoming year:

- June 30, 2026 → operational year 2025
- July 1, 2026 → operational year 2026
- July 25, 2026 → operational year 2026

### Runtime behavior

`teacher-ungraded-count` now counts only:

- `status = Submitted`
- `school_year = active operational year`

It does not admit `school_year IS NULL`.

### Local certification

Guarded synthetic Supabase contained:

- one Submitted instance with `school_year = 2025`
- one Submitted instance with `school_year = 2026`
- one Submitted instance with `school_year = NULL`

On July 25, 2026:

- endpoint returned HTTP 200
- active ungraded count = 1
- 2025 record remained preserved but excluded
- 2026 record remained preserved and counted
- NULL legacy record remained preserved but excluded

Before and after database fingerprint:

`1|1|1`

No records were deleted or modified by the count request.

### Focused regressions

Passed:

- school-year helper tests
- Student Portal visible-school-years tests
- submission school-year inheritance tests
- focused teacher ungraded school-year isolation test

### Scope

Four files:

- `netlify/functions/_lib/school-year.js`
- `netlify/functions/teacher-ungraded-count.js`
- `tests/school-year.test.cjs`
- `tests/teacher-ungraded-count-school-year.test.cjs`

### Safety boundary

This PR does not:

- reclassify historical records
- modify production data
- change Supabase schema/RLS/auth
- change Student Portal visibility
- retire or delete 2025–26 records
- run Close Year

This is the first retire-by-isolation slice: historical data remains preserved while active teacher operations stop counting it.
