### PR TITLE
RC-SEC-01A: guard Teacher Center at edge

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -175,6 +175,19 @@
   path = "/student/*"
   function = "student-entry-redirect"
 
+# Teacher Center access guard
+# Requires a valid RC teacher session before ordinary /teacher/* pages are served.
+# Login remains public; admin remains governed by admin-auth-guard below.
+[[edge_functions]]
+  path = "/teacher/*"
+  excludedPath = [
+    "/teacher/login",
+    "/teacher/login/*",
+    "/teacher/admin",
+    "/teacher/admin/*"
+  ]
+  function = "teacher-auth-guard"
+
 # Admin access guard - enforce server-side authentication for admin areas (PR 308, updated PR 335)
 # PR 335: Admin SSO via Teacher Center - requires Teacher Center session
 # Protects /admin and /admin/* from unauthenticated access

--- a/netlify/edge-functions/teacher-auth-guard.js
+++ b/netlify/edge-functions/teacher-auth-guard.js
@@ -1,0 +1,100 @@
+/**
+ * Netlify Edge Function: Teacher Center access guard
+ *
+ * Protects ordinary /teacher/* pages before static Teacher Center code is served.
+ *
+ * Explicit exclusions:
+ * - /teacher/login and /teacher/login/* remain public
+ * - /teacher/admin and /teacher/admin/* remain under admin-auth-guard
+ *
+ * Security rule:
+ * - If a valid RC teacher session cannot be proven, fail closed and redirect
+ *   directly to /teacher/login/ with the original path preserved in next=.
+ */
+
+function isTeacherLoginPath(pathname) {
+  return (
+    pathname === "/teacher/login" ||
+    pathname.startsWith("/teacher/login/")
+  );
+}
+
+function isTeacherAdminPath(pathname) {
+  return (
+    pathname === "/teacher/admin" ||
+    pathname.startsWith("/teacher/admin/")
+  );
+}
+
+function isProtectedTeacherPath(pathname) {
+  const isTeacherPath =
+    pathname === "/teacher" ||
+    pathname.startsWith("/teacher/");
+
+  return (
+    isTeacherPath &&
+    !isTeacherLoginPath(pathname) &&
+    !isTeacherAdminPath(pathname)
+  );
+}
+
+function hasTcCookie(cookieHeader) {
+  return /(^|;\s*)tc=/.test(cookieHeader || "");
+}
+
+function redirectToTeacherLogin(url) {
+  const next = `${url.pathname}${url.search}`;
+  const location =
+    `/teacher/login/?next=${encodeURIComponent(next)}`;
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: location,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export default async (request, context) => {
+  const url = new URL(request.url);
+
+  if (!isProtectedTeacherPath(url.pathname)) {
+    return context.next();
+  }
+
+  const cookie = request.headers.get("cookie") || "";
+
+  // No teacher cookie means there is no session to validate.
+  if (!hasTcCookie(cookie)) {
+    return redirectToTeacherLogin(url);
+  }
+
+  try {
+    const verifyUrl = new URL(
+      "/.netlify/functions/teacher-session",
+      url.origin
+    );
+
+    const verifyRes = await fetch(verifyUrl.toString(), {
+      method: "GET",
+      headers: { cookie },
+    });
+
+    // Fail closed for 401, 500, or any other non-success response.
+    if (verifyRes.status !== 200) {
+      return redirectToTeacherLogin(url);
+    }
+
+    const response = await context.next();
+    response.headers.set(
+      "X-Teacher-Session",
+      "teacher-session-valid"
+    );
+
+    return response;
+  } catch (_err) {
+    // Authentication infrastructure failure must not expose Teacher Center.
+    return redirectToTeacherLogin(url);
+  }
+};

--- a/tests/teacher-auth-guard.spec.js
+++ b/tests/teacher-auth-guard.spec.js
@@ -1,0 +1,155 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import guard from "../netlify/edge-functions/teacher-auth-guard.js";
+
+test.describe.configure({ mode: "serial" });
+
+function ctx(nextResponse) {
+  return {
+    next: async () =>
+      nextResponse ?? new Response("ok", { status: 200 }),
+  };
+}
+
+test("teacher login remains public", async () => {
+  const res = await guard(
+    new Request("https://example.com/teacher/login/"),
+    ctx(new Response("login", { status: 200 }))
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("login");
+});
+
+test("teacher admin remains delegated to admin guard", async () => {
+  const res = await guard(
+    new Request("https://example.com/teacher/admin/"),
+    ctx(new Response("admin", { status: 200 }))
+  );
+
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("admin");
+});
+
+test("missing tc cookie redirects before Teacher Center is served", async () => {
+  const res = await guard(
+    new Request("https://example.com/teacher/students/"),
+    ctx()
+  );
+
+  expect(res.status).toBe(302);
+  expect(res.headers.get("location")).toBe(
+    "/teacher/login/?next=%2Fteacher%2Fstudents%2F"
+  );
+});
+
+test("redirect preserves query string in next parameter", async () => {
+  const res = await guard(
+    new Request(
+      "https://example.com/teacher/students/?student=SYNTHETIC&tab=skills"
+    ),
+    ctx()
+  );
+
+  expect(res.status).toBe(302);
+
+  const location = res.headers.get("location") || "";
+  expect(location).toContain("/teacher/login/?next=");
+  expect(decodeURIComponent(location.split("next=")[1])).toBe(
+    "/teacher/students/?student=SYNTHETIC&tab=skills"
+  );
+});
+
+test("valid teacher session is verified same-origin and allowed", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async (url, options = {}) => {
+      expect(String(url)).toBe(
+        "https://example.com/.netlify/functions/teacher-session"
+      );
+      expect(options.method).toBe("GET");
+      expect(options.headers?.cookie || "").toContain("tc=valid-session");
+
+      return new Response(
+        JSON.stringify({ ok: true, role: "teacher" }),
+        { status: 200 }
+      );
+    };
+
+    const res = await guard(
+      new Request("https://example.com/teacher/", {
+        headers: { cookie: "tc=valid-session; other=x" },
+      }),
+      ctx(new Response("teacher center", { status: 200 }))
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-teacher-session")).toBe(
+      "teacher-session-valid"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+for (const status of [401, 500, 503]) {
+  test(`teacher-session ${status} fails closed`, async () => {
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = async () =>
+        new Response("not authorized", { status });
+
+      const res = await guard(
+        new Request("https://example.com/teacher/review/", {
+          headers: { cookie: "tc=bad-session" },
+        }),
+        ctx()
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(
+        "/teacher/login/?next=%2Fteacher%2Freview%2F"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+}
+
+test("teacher-session network failure fails closed", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = async () => {
+      throw new Error("synthetic verification failure");
+    };
+
+    const res = await guard(
+      new Request("https://example.com/teacher/gradebook/", {
+        headers: { cookie: "tc=unknown-session" },
+      }),
+      ctx()
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "/teacher/login/?next=%2Fteacher%2Fgradebook%2F"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("netlify routing protects teacher pages but excludes login and admin", () => {
+  const toml = readFileSync(
+    new URL("../netlify.toml", import.meta.url),
+    "utf8"
+  );
+
+  expect(toml).toContain('function = "teacher-auth-guard"');
+  expect(toml).toContain('path = "/teacher/*"');
+  expect(toml).toContain('"/teacher/login/*"');
+  expect(toml).toContain('"/teacher/admin/*"');
+});


### PR DESCRIPTION
## RC-SEC-01A — Teacher Center Front-Door Guard

### Goal
Require a valid RC teacher session before ordinary `/teacher/*` pages are served.

### Scope
- add fail-closed Teacher Center edge authentication guard
- protect ordinary `/teacher/*`
- keep `/teacher/login/*` public
- leave `/teacher/admin/*` under the existing admin guard
- preserve requested Teacher Center path through the `next` parameter

### Security behavior
- missing `tc` cookie → redirect to Teacher Center login
- invalid session → redirect
- teacher-session 401/500/503 → redirect
- teacher-session network failure → redirect
- valid teacher/admin RC session → Teacher Center allowed

### Tests
- new focused guard suite: 10/10 passed
- existing Teacher Center auth suites: 9/9 passed

### Explicitly out of scope
- no Supabase changes
- no RLS changes
- no database/schema/migration changes
- no password/RPC privilege changes
- no Hub cleanup
- no production data changes

### Known pre-existing issue
The existing admin-auth-guard test baseline has two failures because its test expects `/admin-login/` while the implementation still redirects through `/hub/`. RC-SEC-01A does not modify that legacy admin behavior.

### Rollback
Revert this code change and redeploy. No database rollback is required.
