### PR TITLE
RC-SEC-01E-T1: secure DESE rollup read boundary

### DIFF
--- a/netlify/functions/teacher-dese-rollups.js
+++ b/netlify/functions/teacher-dese-rollups.js
@@ -1,0 +1,465 @@
+'use strict';
+
+// Teacher-only DESE standards rollup endpoint.
+//
+// GET /.netlify/functions/teacher-dese-rollups
+//   Returns rollups for active students enrolled in classes owned by the
+//   authenticated teacher.
+//
+// GET /.netlify/functions/teacher-dese-rollups?student_code=S001
+//   Returns rollups only when that student is actively enrolled in one of
+//   the authenticated teacher's classes.
+//
+// School year is resolved server-side using getOperationalSchoolYear().
+// The browser is not permitted to choose the school year.
+
+const {
+  generateRequestId,
+  jsonResponse,
+  handleCorsPreFlight,
+} = require('./_lib/http');
+
+const {
+  requireTeacher,
+} = require('./_lib/auth');
+
+const {
+  rest,
+  rpc,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = require('./_lib/supa');
+
+const {
+  getOperationalSchoolYear,
+} = require('./_lib/school-year');
+
+const {
+  SESSION_SECRET,
+} = process.env;
+
+const MAX_RPC_CONCURRENCY = 6;
+
+function isUuid(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    .test(String(value || ''));
+}
+
+function normalizeStudentCode(value) {
+  const code = String(value || '').trim();
+
+  if (!code) return '';
+
+  if (!/^[A-Za-z0-9_-]{1,40}$/.test(code)) {
+    return null;
+  }
+
+  return code;
+}
+
+async function readJson(response, label) {
+  if (!response || response.ok !== true) {
+    const status =
+      response && Number.isInteger(response.status)
+        ? response.status
+        : 0;
+
+    let detail = '';
+
+    if (response && typeof response.text === 'function') {
+      detail = await response
+        .text()
+        .catch(() => '');
+    }
+
+    throw new Error(
+      `${label} failed: ${status}` +
+      (detail ? ` ${detail.slice(0, 160)}` : '')
+    );
+  }
+
+  const body = await response.json();
+
+  return Array.isArray(body)
+    ? body
+    : [];
+}
+
+async function fetchOwnedStudents(teacherId) {
+  const classesResponse =
+    await rest(
+      '/rest/v1/classes' +
+      '?select=id' +
+      `&teacher_id=eq.${encodeURIComponent(teacherId)}`
+    );
+
+  const classes =
+    await readJson(
+      classesResponse,
+      'Teacher classes query'
+    );
+
+  const classIds =
+    [
+      ...new Set(
+        classes
+          .map((row) => row && row.id)
+          .filter(isUuid)
+      ),
+    ];
+
+  if (classIds.length === 0) {
+    return [];
+  }
+
+  const enrollmentResponse =
+    await rest(
+      '/rest/v1/class_enrollments' +
+      '?select=student_id,active,students!inner(id,code,active)' +
+      '&active=eq.true' +
+      `&class_id=in.(${classIds.map(encodeURIComponent).join(',')})`
+    );
+
+  const enrollments =
+    await readJson(
+      enrollmentResponse,
+      'Teacher enrollments query'
+    );
+
+  const studentsById =
+    new Map();
+
+  for (const enrollment of enrollments) {
+    if (!enrollment || enrollment.active === false) {
+      continue;
+    }
+
+    const nested =
+      Array.isArray(enrollment.students)
+        ? enrollment.students[0]
+        : enrollment.students;
+
+    if (
+      !nested ||
+      !isUuid(nested.id) ||
+      !nested.code ||
+      nested.active === false
+    ) {
+      continue;
+    }
+
+    if (!studentsById.has(nested.id)) {
+      studentsById.set(
+        nested.id,
+        {
+          id: nested.id,
+          code: String(nested.code),
+        }
+      );
+    }
+  }
+
+  return [...studentsById.values()];
+}
+
+async function fetchStudentRollups(
+  student,
+  schoolYear
+) {
+  const response =
+    await rpc(
+      'student_dese_rollups',
+      {
+        p_student_id: student.id,
+        p_school_year: schoolYear,
+      }
+    );
+
+  const rows =
+    await readJson(
+      response,
+      'Student DESE rollup query'
+    );
+
+  return rows.map((row) => ({
+    student_id: student.id,
+    student_code: student.code,
+    dese_code: row.dese_code,
+    percent_correct: row.percent_correct,
+    total_earned: row.total_earned,
+    total_possible: row.total_possible,
+    item_count: row.item_count,
+  }));
+}
+
+async function mapWithConcurrency(
+  items,
+  limit,
+  worker
+) {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results =
+    new Array(items.length);
+
+  let cursor = 0;
+
+  async function runWorker() {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+
+      if (index >= items.length) {
+        return;
+      }
+
+      results[index] =
+        await worker(
+          items[index],
+          index
+        );
+    }
+  }
+
+  const workerCount =
+    Math.min(
+      limit,
+      items.length
+    );
+
+  await Promise.all(
+    Array.from(
+      { length: workerCount },
+      () => runWorker()
+    )
+  );
+
+  return results;
+}
+
+exports.handler = async (event) => {
+  const requestId =
+    generateRequestId();
+
+  if (event.httpMethod === 'OPTIONS') {
+    return handleCorsPreFlight(
+      event,
+      ['GET', 'OPTIONS'],
+      ['Content-Type']
+    );
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return jsonResponse(
+      event,
+      405,
+      {
+        ok: false,
+        error: 'Method Not Allowed',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  if (!SESSION_SECRET) {
+    return jsonResponse(
+      event,
+      500,
+      {
+        ok: false,
+        error: 'Server not configured',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  const teacherAuth =
+    requireTeacher(
+      event,
+      SESSION_SECRET
+    );
+
+  if (!teacherAuth.ok) {
+    return jsonResponse(
+      event,
+      401,
+      {
+        ok: false,
+        error: 'Unauthorized',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  if (
+    !SUPABASE_URL ||
+    !SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return jsonResponse(
+      event,
+      503,
+      {
+        ok: false,
+        error: 'Service unavailable',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  const teacherId =
+    teacherAuth.user &&
+    teacherAuth.user.teacherId;
+
+  if (!isUuid(teacherId)) {
+    console.warn(
+      `[teacher-dese-rollups] [${requestId}] ` +
+      'Verified teacher session has no usable teacherId'
+    );
+
+    return jsonResponse(
+      event,
+      403,
+      {
+        ok: false,
+        error: 'Teacher identity unavailable',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  const params =
+    event.queryStringParameters || {};
+
+  const studentCode =
+    normalizeStudentCode(
+      params.student_code
+    );
+
+  if (studentCode === null) {
+    return jsonResponse(
+      event,
+      400,
+      {
+        ok: false,
+        error: 'Invalid student_code',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  try {
+    const schoolYear =
+      getOperationalSchoolYear();
+
+    const ownedStudents =
+      await fetchOwnedStudents(
+        teacherId
+      );
+
+    if (studentCode) {
+      const student =
+        ownedStudents.find(
+          (candidate) =>
+            candidate.code === studentCode
+        );
+
+      if (!student) {
+        return jsonResponse(
+          event,
+          404,
+          {
+            ok: false,
+            error: 'Student not available',
+          },
+          {
+            'Cache-Control': 'no-store',
+          },
+          requestId
+        );
+      }
+
+      const rows =
+        await fetchStudentRollups(
+          student,
+          schoolYear
+        );
+
+      return jsonResponse(
+        event,
+        200,
+        {
+          ok: true,
+          school_year: schoolYear,
+          rows,
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    const groupedRows =
+      await mapWithConcurrency(
+        ownedStudents,
+        MAX_RPC_CONCURRENCY,
+        (student) =>
+          fetchStudentRollups(
+            student,
+            schoolYear
+          )
+      );
+
+    return jsonResponse(
+      event,
+      200,
+      {
+        ok: true,
+        school_year: schoolYear,
+        rows: groupedRows.flat(),
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  } catch (error) {
+    console.error(
+      `[teacher-dese-rollups] [${requestId}] Error:`,
+      error
+    );
+
+    return jsonResponse(
+      event,
+      500,
+      {
+        ok: false,
+        error: 'Unable to load DESE rollups',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+};

--- a/site/teacher/students/index.html
+++ b/site/teacher/students/index.html
@@ -3604,7 +3604,7 @@
     <script defer src="/web/teacher-shell.js?v=20260331"></script>
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script type="module" src="/web/staleness-utils.js?v=20260408"></script>
-    <script type="module" src="/web/tc-students.js?v=2026072502"></script>
+    <script type="module" src="/web/tc-students.js?v=2026072801"></script>
     <script type="module" src="/web/tc-observation.js?v=20260424"></script>
     <script defer src="/assets/js/class-clock.js" type="module"></script>
     <script>

--- a/site/web/home-dashboard.js
+++ b/site/web/home-dashboard.js
@@ -331,7 +331,7 @@ window.addEventListener('resize', function() {
 // ── Standards Focus Card ──────────────────────────────────────────────────────
 // Fetches DESE rollup data and renders a compact "Standards Focus" card on the
 // home dashboard when there are critical or needs-support standards.
-// Only fires when the user has a Supabase (teacher) session.
+// Loads only through the authenticated Teacher Center server boundary.
 
 function hdGetTier(pct) {
   if (pct >= 80) return 'excellent';
@@ -340,26 +340,23 @@ function hdGetTier(pct) {
   return 'critical';
 }
 
-function hdCurrentSchoolYear() {
-  var now = new Date();
-  return (now.getMonth() + 1) >= 8 ? now.getFullYear() : now.getFullYear() - 1;
-}
-
 function renderStandardsFocusCard() {
   var cardEl = document.getElementById('focus-standards');
   if (!cardEl) return;
 
-  import('/web/supabase-client.js').then(function(mod) {
-    return mod.getSupabase();
-  }).then(function(supabase) {
-    if (!supabase) return; // Not a teacher session — leave card hidden
+  Promise.resolve().then(function() {
+    return fetch('/.netlify/functions/teacher-dese-rollups', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { 'Accept': 'application/json' },
+    });
+  }).then(function(response) {
+    if (!response.ok) return;
 
-    return supabase.rpc('all_students_dese_rollups', {
-      p_school_year: hdCurrentSchoolYear(),
-    }).then(function(result) {
-      if (result.error || !Array.isArray(result.data) || result.data.length === 0) return;
+    return response.json().then(function(result) {
+      if (!result || !result.ok || !Array.isArray(result.rows) || result.rows.length === 0) return;
 
-      var rows = result.data;
+      var rows = result.rows;
 
       // Aggregate per-standard: average percent_correct across all students
       var stdAccum = {};

--- a/site/web/tc-ai-builder.js
+++ b/site/web/tc-ai-builder.js
@@ -1394,29 +1394,47 @@
     return 'critical';
   }
 
-  function aibSpCurrentSchoolYear() {
-    const now = new Date();
-    return (now.getMonth() + 1) >= 8 ? now.getFullYear() : now.getFullYear() - 1;
-  }
-
   /** Session-level cache: null = not fetched yet */
   let aibRollupCache = null;
 
   async function aibFetchRollups() {
     if (aibRollupCache !== null) return aibRollupCache;
+
     try {
-      const { getSupabase } = await import('/web/supabase-client.js');
-      const supabase = await getSupabase();
-      if (!supabase) { aibRollupCache = []; return aibRollupCache; }
-      const { data, error } = await supabase.rpc('all_students_dese_rollups', {
-        p_school_year: aibSpCurrentSchoolYear(),
-      });
-      aibRollupCache = error || !Array.isArray(data) ? [] : data;
-      if (error) console.warn('[tc-ai-builder] all_students_dese_rollups error:', error.message);
+      const response = await fetch(
+        '/.netlify/functions/teacher-dese-rollups',
+        {
+          method: 'GET',
+          credentials: 'same-origin',
+          headers: { 'Accept': 'application/json' },
+        }
+      );
+
+      if (!response.ok) {
+        console.warn(
+          '[tc-ai-builder] teacher-dese-rollups HTTP error:',
+          response.status
+        );
+        aibRollupCache = [];
+        return aibRollupCache;
+      }
+
+      const payload = await response.json();
+
+      aibRollupCache =
+        payload &&
+        payload.ok &&
+        Array.isArray(payload.rows)
+          ? payload.rows
+          : [];
     } catch (err) {
-      console.warn('[tc-ai-builder] all_students_dese_rollups failed:', err);
+      console.warn(
+        '[tc-ai-builder] teacher-dese-rollups failed:',
+        err
+      );
       aibRollupCache = [];
     }
+
     return aibRollupCache;
   }
 

--- a/site/web/tc-overview.js
+++ b/site/web/tc-overview.js
@@ -1662,42 +1662,47 @@
   let spRollupCache = null;
 
   /**
-   * Derive the current school year (August 1 is the boundary).
-   */
-  function spCurrentSchoolYear() {
-    const now = new Date();
-    return (now.getMonth() + 1) >= 8 ? now.getFullYear() : now.getFullYear() - 1;
-  }
-
-  /**
-   * Fetch all-student DESE rollups via Supabase RPC.
-   * Falls back gracefully when the RPC isn't deployed yet.
+   * Fetch all-student DESE rollups through the signed Teacher Center boundary.
+   * School-year selection and teacher/student scoping are server-owned.
    */
   async function spFetchRollups() {
     if (spRollupCache !== null) return spRollupCache;
 
-    const { getSupabase } = await import('/web/supabase-client.js');
-    const supabase = await getSupabase();
-    if (!supabase) {
+    try {
+      const response = await fetch(
+        '/.netlify/functions/teacher-dese-rollups',
+        {
+          method: 'GET',
+          credentials: 'same-origin',
+          headers: { 'Accept': 'application/json' },
+        }
+      );
+
+      if (!response.ok) {
+        console.warn(
+          '[tc-overview] teacher-dese-rollups HTTP error:',
+          response.status
+        );
+        spRollupCache = [];
+        return spRollupCache;
+      }
+
+      const payload = await response.json();
+
+      spRollupCache =
+        payload &&
+        payload.ok &&
+        Array.isArray(payload.rows)
+          ? payload.rows
+          : [];
+    } catch (err) {
+      console.warn(
+        '[tc-overview] teacher-dese-rollups failed:',
+        err
+      );
       spRollupCache = [];
-      return spRollupCache;
     }
 
-    const schoolYear = spCurrentSchoolYear();
-    try {
-      const { data, error } = await supabase.rpc('all_students_dese_rollups', {
-        p_school_year: schoolYear,
-      });
-      if (error) {
-        console.warn('[tc-overview] all_students_dese_rollups RPC error:', error.message);
-        spRollupCache = [];
-      } else {
-        spRollupCache = Array.isArray(data) ? data : [];
-      }
-    } catch (err) {
-      console.warn('[tc-overview] all_students_dese_rollups failed:', err);
-      spRollupCache = [];
-    }
     return spRollupCache;
   }
 

--- a/site/web/tc-students.js
+++ b/site/web/tc-students.js
@@ -10251,120 +10251,57 @@
   }
 
   /**
-   * Fetch DESE standard rollups for a student from the `student_dese_rollups` RPC.
-   * Results are cached in `deseRollupCache` to avoid redundant round-trips when the
-   * teacher switches tabs and back within the same data-load cycle.
+   * Fetch DESE standard rollups for a student through the signed
+   * Teacher Center server boundary.
    *
-   * Returns an array of raw rollup rows:
-   *   { dese_code, percent_correct, total_earned, total_possible, item_count }
+   * Teacher ownership and school-year selection are enforced server-side.
    */
   async function fetchDeseRollups(student) {
-    if (!student?.id) return [];
+    if (!student?.code) return [];
 
     const cached = deseRollupCache.get(student.code);
     if (cached) return cached;
 
-    const now = new Date();
-    const m = now.getMonth() + 1; // 1-based month
-    const schoolYear = m >= 7 ? now.getFullYear() : now.getFullYear() - 1;
-
     try {
-      const supabase = await getSupabase();
-      if (!supabase) return [];
+      const url =
+        '/.netlify/functions/teacher-dese-rollups' +
+        '?student_code=' +
+        encodeURIComponent(student.code);
 
-      const { data, error } = await supabase.rpc('student_dese_rollups', {
-        p_student_id: student.id,
-        p_school_year: schoolYear,
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json' },
       });
 
-      let rows;
-      if (!error && Array.isArray(data)) {
-        rows = data;
-      } else {
-        if (error) {
-          console.warn('[tc-students] fetchDeseRollups: RPC error:', error.message, '— trying client-side fallback');
-        }
-        rows = await fetchDeseRollupsFallback(supabase, student.id, schoolYear);
+      if (!response.ok) {
+        console.warn(
+          '[tc-students] fetchDeseRollups: HTTP',
+          response.status
+        );
+        deseRollupCache.set(student.code, []);
+        return [];
       }
+
+      const payload = await response.json();
+
+      const rows =
+        payload &&
+        payload.ok &&
+        Array.isArray(payload.rows)
+          ? payload.rows
+          : [];
 
       deseRollupCache.set(student.code, rows);
+
       return rows;
     } catch (err) {
-      console.warn('[tc-students] fetchDeseRollups: failed:', err);
+      console.warn(
+        '[tc-students] fetchDeseRollups failed:',
+        err
+      );
       return [];
     }
-  }
-
-  /**
-   * Client-side fallback for DESE rollups when the RPC function is not deployed.
-   * Queries assignment_instances → submissions → submission_answers → assignment_items
-   * and aggregates earned/max points by dese_code.
-   *
-   * Reads dese_codes directly from assignment_items (always populated by the
-   * parser) rather than from assignment_item_mappings, which was previously
-   * only populated for items that also had IEP goal_codes.  This ensures that
-   * DESE-only students (no IEP goals) see their skills data.
-   */
-  async function fetchDeseRollupsFallback(supabase, studentId, schoolYear) {
-    const { data, error } = await supabase
-      .from('assignment_instances')
-      .select(`
-        settings,
-        submissions (
-          submission_answers (
-            earned_points,
-            max_points,
-            assignment_items!assignment_item_id (
-              dese_codes
-            )
-          )
-        )
-      `)
-      // !assignment_item_id disambiguates the FK from submission_answers → assignment_items
-      .eq('student_id', studentId)
-      .eq('school_year', schoolYear)
-      .limit(500);
-
-    if (error) throw error;
-    if ((data || []).length >= 500) {
-      console.warn('[tc-students] fetchDeseRollupsFallback: hit 500-row limit — DESE rollups may be incomplete. Deploy the student_dese_rollups RPC for accurate data.');
-    }
-
-    const rollupMap = new Map(); // dese_code → { earnedSum, maxSum, count }
-    for (const instance of data || []) {
-      if (instance?.settings?.non_instructional === true) continue;
-
-      for (const sub of instance.submissions || []) {
-        for (const sa of sub.submission_answers || []) {
-          const earned = typeof sa.earned_points === 'number' ? sa.earned_points : 0;
-          const max = typeof sa.max_points === 'number' ? sa.max_points : 0;
-          if (max <= 0) continue;
-
-          const item = sa.assignment_items;
-          if (!item || !Array.isArray(item.dese_codes)) continue;
-
-          for (const code of item.dese_codes) {
-            if (!code) continue;
-            const existing = rollupMap.get(code) || { earnedSum: 0, maxSum: 0, count: 0 };
-            existing.earnedSum += earned;
-            existing.maxSum += max;
-            existing.count += 1;
-            rollupMap.set(code, existing);
-          }
-        }
-      }
-    }
-
-    return Array.from(rollupMap.entries())
-      .filter(([, s]) => s.maxSum > 0)
-      .map(([dese_code, s]) => ({
-        dese_code,
-        percent_correct: Math.round(s.earnedSum / s.maxSum * 1000) / 10,
-        total_earned: s.earnedSum,
-        total_possible: s.maxSum,
-        item_count: s.count,
-      }))
-      .sort((a, b) => b.percent_correct - a.percent_correct);
   }
 
   /**

--- a/tests/non-instructional-dese-evidence.test.cjs
+++ b/tests/non-instructional-dese-evidence.test.cjs
@@ -63,26 +63,26 @@ assert.ok(
   'DESE evidence-card reader must exclude explicit non-instructional instances'
 );
 
-const fallback = section(
-  students,
-  '  async function fetchDeseRollupsFallback(supabase, studentId, schoolYear) {',
-  '  function initSkillsTabButton(contentDiv, student, signal) {'
+assert.ok(
+  !students.includes('fetchDeseRollupsFallback'),
+  'obsolete browser DESE rollup fallback must remain removed'
 );
 
 assert.ok(
-  fallback.includes('settings,'),
-  'DESE fallback query must fetch assignment-instance settings'
+  !students.includes("supabase.rpc('student_dese_rollups'"),
+  'Teacher Center must not call student_dese_rollups directly from the browser'
 );
 
 assert.ok(
-  fallback.includes(
-    'if (instance?.settings?.non_instructional === true) continue;'
+  students.includes(
+    '/.netlify/functions/teacher-dese-rollups'
   ),
-  'DESE fallback rollup must exclude explicit non-instructional instances'
+  'Teacher Center DESE rollups must use the authenticated server boundary'
 );
 
-console.log('✓ student_dese_rollups excludes explicit non-instructional instances');
-console.log('✓ all_students_dese_rollups excludes explicit non-instructional instances');
+console.log('✓ student_dese_rollups migration excludes explicit non-instructional instances');
+console.log('✓ historical all_students_dese_rollups migration excludes explicit non-instructional instances');
 console.log('✓ Teacher Center DESE evidence cards exclude marked instances');
-console.log('✓ Teacher Center DESE fallback rollups exclude marked instances');
+console.log('✓ obsolete browser DESE rollup fallback remains removed');
+console.log('✓ Teacher Center DESE rollups use the authenticated server boundary');
 console.log('\nNON-INSTRUCTIONAL DESE EVIDENCE: PASS');

--- a/tests/teacher-dese-rollup-browser-boundary.test.cjs
+++ b/tests/teacher-dese-rollup-browser-boundary.test.cjs
@@ -1,0 +1,148 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.resolve(
+      __dirname,
+      '..',
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+const files = {
+  home:
+    read('site/web/home-dashboard.js'),
+
+  overview:
+    read('site/web/tc-overview.js'),
+
+  aiBuilder:
+    read('site/web/tc-ai-builder.js'),
+
+  students:
+    read('site/web/tc-students.js'),
+};
+
+const endpoint =
+  '/.netlify/functions/teacher-dese-rollups';
+
+for (const [name, source] of Object.entries(files)) {
+  assert.ok(
+    source.includes(endpoint),
+    `${name} must use authenticated teacher DESE endpoint`
+  );
+}
+
+for (
+  const [name, source]
+  of Object.entries({
+    home: files.home,
+    overview: files.overview,
+    aiBuilder: files.aiBuilder,
+  })
+) {
+  assert.ok(
+    !source.includes('all_students_dese_rollups'),
+    `${name} must not call all_students_dese_rollups`
+  );
+}
+
+assert.ok(
+  !files.students.includes(
+    "supabase.rpc('student_dese_rollups'"
+  ),
+  'tc-students must not invoke student_dese_rollups directly'
+);
+
+assert.ok(
+  !files.students.includes(
+    'fetchDeseRollupsFallback'
+  ),
+  'raw browser rollup fallback must be removed'
+);
+
+assert.ok(
+  !files.home.includes(
+    'hdCurrentSchoolYear'
+  ),
+  'Home Dashboard duplicate school-year helper must be removed'
+);
+
+assert.ok(
+  !files.overview.includes(
+    'spCurrentSchoolYear'
+  ),
+  'Overview duplicate school-year helper must be removed'
+);
+
+assert.ok(
+  !files.aiBuilder.includes(
+    'aibSpCurrentSchoolYear'
+  ),
+  'AI Builder duplicate school-year helper must be removed'
+);
+
+const evidenceStart =
+  files.students.indexOf(
+    'async function fetchAllEvidenceForStudent'
+  );
+
+const evidenceEnd =
+  files.students.indexOf(
+    'async function fetchDeseEvidenceItems',
+    evidenceStart
+  );
+
+assert.ok(
+  evidenceStart >= 0 &&
+  evidenceEnd > evidenceStart,
+  'detailed evidence functions must remain present'
+);
+
+const evidenceBlock =
+  files.students.slice(
+    evidenceStart,
+    evidenceEnd
+  );
+
+assert.ok(
+  evidenceBlock.includes(
+    ".from('assignment_instances')"
+  ),
+  'T1 must not alter detailed DESE evidence transport'
+);
+
+console.log(
+  '✓ all four DESE rollup consumers use signed teacher endpoint'
+);
+
+console.log(
+  '✓ no browser all_students_dese_rollups calls remain'
+);
+
+console.log(
+  '✓ no browser student_dese_rollups call remains'
+);
+
+console.log(
+  '✓ raw client rollup fallback removed'
+);
+
+console.log(
+  '✓ duplicate browser school-year calculations removed'
+);
+
+console.log(
+  '✓ detailed evidence path intentionally unchanged for T2'
+);
+
+console.log();
+console.log(
+  'RC-SEC-01E-T1 browser-boundary tests PASS'
+);

--- a/tests/teacher-dese-rollups.test.cjs
+++ b/tests/teacher-dese-rollups.test.cjs
@@ -1,0 +1,582 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const endpointPath =
+  path.resolve(
+    __dirname,
+    '../netlify/functions/teacher-dese-rollups.js'
+  );
+
+const authPath =
+  require.resolve(
+    '../netlify/functions/_lib/auth'
+  );
+
+const supaPath =
+  require.resolve(
+    '../netlify/functions/_lib/supa'
+  );
+
+const httpPath =
+  require.resolve(
+    '../netlify/functions/_lib/http'
+  );
+
+const schoolYearPath =
+  require.resolve(
+    '../netlify/functions/_lib/school-year'
+  );
+
+const teacherId =
+  '11111111-1111-4111-8111-111111111111';
+
+const classId =
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const student1Id =
+  '22222222-2222-4222-8222-222222222222';
+
+const student2Id =
+  '33333333-3333-4333-8333-333333333333';
+
+let authResult;
+let restCalls;
+let rpcCalls;
+let restHandler;
+let rpcHandler;
+let yearCallCount;
+
+function response(
+  status,
+  body
+) {
+  return {
+    ok:
+      status >= 200 &&
+      status < 300,
+
+    status,
+
+    async json() {
+      return body;
+    },
+
+    async text() {
+      return JSON.stringify(body);
+    },
+  };
+}
+
+function installMocks() {
+  authResult = {
+    ok: true,
+    user: {
+      role: 'teacher',
+      username: 'teacher_test',
+      teacherId,
+    },
+  };
+
+  restCalls = [];
+  rpcCalls = [];
+  yearCallCount = 0;
+
+  restHandler =
+    async (url) => {
+      if (
+        url.startsWith(
+          '/rest/v1/classes?'
+        )
+      ) {
+        return response(
+          200,
+          [
+            {
+              id: classId,
+            },
+          ]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/class_enrollments?'
+        )
+      ) {
+        return response(
+          200,
+          [
+            {
+              student_id: student1Id,
+              active: true,
+              students: {
+                id: student1Id,
+                code: 'S001',
+                active: true,
+              },
+            },
+            {
+              student_id: student2Id,
+              active: true,
+              students: {
+                id: student2Id,
+                code: 'S002',
+                active: true,
+              },
+            },
+          ]
+        );
+      }
+
+      throw new Error(
+        `Unexpected REST URL: ${url}`
+      );
+    };
+
+  rpcHandler =
+    async (
+      name,
+      args
+    ) => {
+      assert.strictEqual(
+        name,
+        'student_dese_rollups'
+      );
+
+      return response(
+        200,
+        [
+          {
+            dese_code:
+              args.p_student_id === student1Id
+                ? '9-10.RL.1.A'
+                : '9-10.RL.2.A',
+            percent_correct:
+              args.p_student_id === student1Id
+                ? 75
+                : 50,
+            total_earned: 3,
+            total_possible: 4,
+            item_count: 2,
+          },
+        ]
+      );
+    };
+
+  require.cache[authPath] = {
+    id: authPath,
+    filename: authPath,
+    loaded: true,
+    exports: {
+      requireTeacher:
+        () => authResult,
+    },
+  };
+
+  require.cache[supaPath] = {
+    id: supaPath,
+    filename: supaPath,
+    loaded: true,
+    exports: {
+      SUPABASE_URL:
+        'https://example.invalid',
+
+      SUPABASE_SERVICE_ROLE_KEY:
+        'test-service-role',
+
+      rest:
+        async (url, options) => {
+          restCalls.push({
+            url,
+            options,
+          });
+
+          return restHandler(
+            url,
+            options
+          );
+        },
+
+      rpc:
+        async (name, args) => {
+          rpcCalls.push({
+            name,
+            args,
+          });
+
+          return rpcHandler(
+            name,
+            args
+          );
+        },
+    },
+  };
+
+  require.cache[httpPath] = {
+    id: httpPath,
+    filename: httpPath,
+    loaded: true,
+    exports: {
+      generateRequestId:
+        () => 'req-test',
+
+      jsonResponse:
+        (
+          _event,
+          statusCode,
+          body,
+          headers = {}
+        ) => ({
+          statusCode,
+          headers,
+          body:
+            JSON.stringify(body),
+        }),
+
+      handleCorsPreFlight:
+        () => ({
+          statusCode: 204,
+          body: '',
+        }),
+    },
+  };
+
+  require.cache[schoolYearPath] = {
+    id: schoolYearPath,
+    filename: schoolYearPath,
+    loaded: true,
+    exports: {
+      getOperationalSchoolYear:
+        () => {
+          yearCallCount += 1;
+          return 2026;
+        },
+    },
+  };
+
+  delete require.cache[endpointPath];
+}
+
+function event(
+  queryStringParameters = {}
+) {
+  return {
+    httpMethod: 'GET',
+    headers: {
+      cookie: 'tc=fake-signed-cookie',
+    },
+    queryStringParameters,
+  };
+}
+
+function bodyOf(result) {
+  return JSON.parse(
+    result.body
+  );
+}
+
+async function test(
+  name,
+  fn
+) {
+  try {
+    await fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    throw error;
+  }
+}
+
+async function run() {
+  const originalSessionSecret =
+    process.env.SESSION_SECRET;
+
+  process.env.SESSION_SECRET =
+    'unit-test-secret';
+
+  try {
+    installMocks();
+
+    const {
+      handler,
+    } = require(endpointPath);
+
+    await test(
+      'blocks unauthorized request before Supabase access',
+      async () => {
+        authResult = {
+          ok: false,
+        };
+
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event()
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          401
+        );
+
+        assert.strictEqual(
+          restCalls.length,
+          0
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          0
+        );
+      }
+    );
+
+    await test(
+      'rejects verified session without teacherId before Supabase access',
+      async () => {
+        authResult = {
+          ok: true,
+          user: {
+            role: 'teacher',
+            username: 'teacher_test',
+          },
+        };
+
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event()
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          403
+        );
+
+        assert.strictEqual(
+          restCalls.length,
+          0
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          0
+        );
+      }
+    );
+
+    await test(
+      'all-student mode uses owned active enrollments and operational year',
+      async () => {
+        authResult = {
+          ok: true,
+          user: {
+            role: 'teacher',
+            username: 'teacher_test',
+            teacherId,
+          },
+        };
+
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+        yearCallCount = 0;
+
+        const result =
+          await handler(
+            event({
+              school_year: '2025',
+            })
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          200
+        );
+
+        const payload =
+          bodyOf(result);
+
+        assert.strictEqual(
+          payload.ok,
+          true
+        );
+
+        assert.strictEqual(
+          payload.school_year,
+          2026,
+          'browser-supplied school_year must not override server year'
+        );
+
+        assert.strictEqual(
+          yearCallCount,
+          1
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          2
+        );
+
+        for (
+          const call
+          of rpcCalls
+        ) {
+          assert.strictEqual(
+            call.name,
+            'student_dese_rollups'
+          );
+
+          assert.strictEqual(
+            call.args.p_school_year,
+            2026
+          );
+        }
+
+        assert.deepStrictEqual(
+          payload.rows.map(
+            (row) =>
+              row.student_code
+          ).sort(),
+          [
+            'S001',
+            'S002',
+          ]
+        );
+
+        assert.ok(
+          restCalls[0].url.includes(
+            `teacher_id=eq.${teacherId}`
+          ),
+          'class query must scope by signed teacherId'
+        );
+      }
+    );
+
+    await test(
+      'per-student mode returns only a student in teacher-owned enrollment set',
+      async () => {
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event({
+              student_code: 'S001',
+            })
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          200
+        );
+
+        const payload =
+          bodyOf(result);
+
+        assert.strictEqual(
+          payload.rows.length,
+          1
+        );
+
+        assert.strictEqual(
+          payload.rows[0].student_code,
+          'S001'
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          1
+        );
+
+        assert.strictEqual(
+          rpcCalls[0].args.p_student_id,
+          student1Id
+        );
+      }
+    );
+
+    await test(
+      'student outside teacher-owned enrollment set is denied without rollup RPC',
+      async () => {
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event({
+              student_code: 'S999',
+            })
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          404
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          0
+        );
+      }
+    );
+
+    await test(
+      'invalid student code is rejected before database access',
+      async () => {
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event({
+              student_code:
+                '../../students',
+            })
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          400
+        );
+
+        assert.strictEqual(
+          restCalls.length,
+          0
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          0
+        );
+      }
+    );
+
+    console.log();
+    console.log(
+      'RC-SEC-01E-T1 endpoint tests PASS'
+    );
+  } finally {
+    if (
+      originalSessionSecret === undefined
+    ) {
+      delete process.env.SESSION_SECRET;
+    } else {
+      process.env.SESSION_SECRET =
+        originalSessionSecret;
+    }
+  }
+}
+
+run().catch(
+  (error) => {
+    console.error(error);
+    process.exitCode = 1;
+  }
+);


### PR DESCRIPTION
## RC-SEC-01E-T1

Moves Teacher Center DESE rollup reads behind the signed teacher-session server boundary.

### Security boundary

- requires verified Teacher Center session
- uses signed `teacherId` as the authoritative teacher identity
- scopes students through teacher-owned classes and active class enrollments
- resolves school year server-side with `getOperationalSchoolYear()`
- removes browser calls to `all_students_dese_rollups`
- removes browser calls to `student_dese_rollups`
- removes the raw client-side DESE rollup fallback
- does not recreate the missing `all_students_dese_rollups` RPC

### Scope

- Home Dashboard Standards Focus
- Teacher Overview Standards Pulse
- AI Builder Standards callout
- Student Skills DESE rollups
- authenticated `teacher-dese-rollups` Netlify function
- focused security and regression tests

Detailed per-student DESE evidence transport remains unchanged for the later T2 slice.

### QA

- authorization-before-database tests passed
- teacher/student ownership tests passed
- operational school-year tests passed
- browser-boundary regression tests passed
- non-instructional DESE regression passed
- full repository test suite passed
- direct browser DESE rollup RPC sweep clean

### Not included

- no database schema change
- no RLS change
- no grant/revoke
- no RPC creation/deletion
- no deployment
