### PR TITLE
RC-SEC-01E-T2: secure detailed DESE evidence boundary

### DIFF
--- a/netlify/functions/teacher-dese-rollups.js
+++ b/netlify/functions/teacher-dese-rollups.js
@@ -57,6 +57,21 @@ function normalizeStudentCode(value) {
   return code;
 }
 
+function normalizeDetailMode(value) {
+  const mode =
+    String(value || '')
+      .trim()
+      .toLowerCase();
+
+  if (!mode) {
+    return '';
+  }
+
+  return mode === 'evidence'
+    ? mode
+    : null;
+}
+
 async function readJson(response, label) {
   if (!response || response.ok !== true) {
     const status =
@@ -190,6 +205,129 @@ async function fetchStudentRollups(
     total_possible: row.total_possible,
     item_count: row.item_count,
   }));
+}
+
+
+async function fetchStudentEvidence(
+  student,
+  schoolYear
+) {
+  const select =
+    'assignment_id,settings,' +
+    'assignments!assignment_id(title),' +
+    'submissions(' +
+      'submitted_at,' +
+      'submission_answers(' +
+        'earned_points,' +
+        'max_points,' +
+        'is_correct,' +
+        'teacher_note,' +
+        'assignment_items!assignment_item_id(' +
+          'item_ref,' +
+          'dese_codes,' +
+          'meta' +
+        ')' +
+      ')' +
+    ')';
+
+  const response =
+    await rest(
+      '/rest/v1/assignment_instances' +
+      `?select=${select}` +
+      `&student_id=eq.${encodeURIComponent(student.id)}` +
+      `&school_year=eq.${encodeURIComponent(schoolYear)}` +
+      '&limit=1000'
+    );
+
+  const instances =
+    await readJson(
+      response,
+      'Student DESE evidence query'
+    );
+
+  const rows = [];
+
+  const asArray =
+    (value) => {
+      if (!value) return [];
+      return Array.isArray(value)
+        ? value
+        : [value];
+    };
+
+  for (const instance of instances) {
+    if (
+      instance?.settings?.non_instructional === true
+    ) {
+      continue;
+    }
+
+    const assignment =
+      Array.isArray(instance?.assignments)
+        ? instance.assignments[0]
+        : instance?.assignments;
+
+    const assignmentTitle =
+      assignment?.title || '';
+
+    for (const submission of asArray(instance?.submissions)) {
+      for (
+        const answer of
+        asArray(submission?.submission_answers)
+      ) {
+        const item =
+          Array.isArray(answer?.assignment_items)
+            ? answer.assignment_items[0]
+            : answer?.assignment_items;
+
+        if (
+          !item ||
+          !Array.isArray(item.dese_codes) ||
+          item.dese_codes.length === 0
+        ) {
+          continue;
+        }
+
+        if (
+          typeof answer.max_points !== 'number' ||
+          answer.max_points <= 0
+        ) {
+          continue;
+        }
+
+        const questionText =
+          item.meta?.question ||
+          item.item_ref ||
+          null;
+
+        for (const code of item.dese_codes) {
+          if (!code) continue;
+
+          rows.push({
+            dese_code: String(code),
+            question_text: questionText,
+            assignment_title: assignmentTitle,
+            assignment_id: instance.assignment_id,
+            submitted_at:
+              submission?.submitted_at || null,
+            earned_points:
+              typeof answer.earned_points === 'number'
+                ? answer.earned_points
+                : null,
+            max_points: answer.max_points,
+            is_correct:
+              typeof answer.is_correct === 'boolean'
+                ? answer.is_correct
+                : null,
+            teacher_note:
+              answer.teacher_note || null,
+          });
+        }
+      }
+    }
+  }
+
+  return rows;
 }
 
 async function mapWithConcurrency(
@@ -367,6 +505,42 @@ exports.handler = async (event) => {
     );
   }
 
+
+  const detailMode =
+    normalizeDetailMode(
+      params.detail
+    );
+
+  if (detailMode === null) {
+    return jsonResponse(
+      event,
+      400,
+      {
+        ok: false,
+        error: 'Invalid detail mode',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
+  if (detailMode && !studentCode) {
+    return jsonResponse(
+      event,
+      400,
+      {
+        ok: false,
+        error: 'student_code is required for detail mode',
+      },
+      {
+        'Cache-Control': 'no-store',
+      },
+      requestId
+    );
+  }
+
   try {
     const schoolYear =
       getOperationalSchoolYear();
@@ -390,6 +564,28 @@ exports.handler = async (event) => {
           {
             ok: false,
             error: 'Student not available',
+          },
+          {
+            'Cache-Control': 'no-store',
+          },
+          requestId
+        );
+      }
+
+      if (detailMode === 'evidence') {
+        const rows =
+          await fetchStudentEvidence(
+            student,
+            schoolYear
+          );
+
+        return jsonResponse(
+          event,
+          200,
+          {
+            ok: true,
+            school_year: schoolYear,
+            rows,
           },
           {
             'Cache-Control': 'no-store',

--- a/site/teacher/students/index.html
+++ b/site/teacher/students/index.html
@@ -3604,7 +3604,7 @@
     <script defer src="/web/teacher-shell.js?v=20260331"></script>
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script type="module" src="/web/staleness-utils.js?v=20260408"></script>
-    <script type="module" src="/web/tc-students.js?v=2026072801"></script>
+    <script type="module" src="/web/tc-students.js?v=2026072802"></script>
     <script type="module" src="/web/tc-observation.js?v=20260424"></script>
     <script defer src="/assets/js/class-clock.js" type="module"></script>
     <script>

--- a/site/web/tc-students.js
+++ b/site/web/tc-students.js
@@ -10012,98 +10012,86 @@
    * so opening multiple standards never fires duplicate round-trips.
    */
   async function fetchAllEvidenceForStudent(student) {
-    if (!student?.id) return new Map();
+    if (!student?.code) return new Map();
     if (deseEvidenceCache.has(student.code)) return deseEvidenceCache.get(student.code);
 
     try {
-      const supabase = await getSupabase();
-      if (!supabase) return new Map();
+      const params = new URLSearchParams({
+        student_code: student.code,
+        detail: 'evidence',
+      });
 
-      const now = new Date();
-      const m = now.getMonth() + 1;
-      const schoolYear = m >= 7 ? now.getFullYear() : now.getFullYear() - 1;
-
-      // Query: assignment_instances → assignments + submissions → submission_answers → assignment_items
-      // Filter by student_id + school_year; bucket items by dese_code client-side.
-      // Limit is 1000 to cover essentially all real students without multiple round-trips.
-      const { data, error } = await supabase
-        .from('assignment_instances')
-        .select(`
-          assignment_id,
-          settings,
-          assignments!assignment_id ( id, title ),
-          submissions (
-            submitted_at,
-            submission_answers (
-              earned_points,
-              max_points,
-              is_correct,
-              scored_at,
-              teacher_note,
-              assignment_items!assignment_item_id (
-                id,
-                item_ref,
-                dese_codes,
-                meta
-              )
-            )
-          )
-        `)
-        .eq('student_id', student.id)
-        .eq('school_year', schoolYear)
-        .limit(1000);
-
-      if (error) throw error;
-
-      const buckets = new Map(); // deseCode → Item[]
-
-      for (const instance of data || []) {
-        if (instance?.settings?.non_instructional === true) continue;
-
-        const assignment = instance.assignments;
-        const assignmentTitle = assignment?.title || '';
-        const assignmentId = instance.assignment_id;
-
-        for (const sub of instance.submissions || []) {
-          const dateStr = sub.submitted_at
-            ? new Date(sub.submitted_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-            : null;
-
-          for (const sa of sub.submission_answers || []) {
-            const ai = sa.assignment_items;
-            if (!ai || !Array.isArray(ai.dese_codes) || ai.dese_codes.length === 0) continue;
-            // Exclude ungraded prompts — max_points > 0 is intentional here.
-            // Note: this filter may cause counts to diverge slightly from the student_dese_rollups
-            // RPC, which may count zero-point items differently.  The UI surfaces any divergence.
-            if (typeof sa.max_points !== 'number' || sa.max_points <= 0) continue;
-
-            const earned = typeof sa.earned_points === 'number' ? sa.earned_points : null;
-            const max = typeof sa.max_points === 'number' ? sa.max_points : null;
-            const scorePct = earned !== null && max ? Math.round(earned / max * 100) : null;
-            const questionText = ai.meta?.question || ai.item_ref || null;
-
-            const item = {
-              question_text: questionText,
-              assignment_title: assignmentTitle,
-              assignment_id: assignmentId,
-              date: dateStr,
-              earned_points: earned,
-              max_points: max,
-              is_correct: sa.is_correct,
-              score_pct: scorePct,
-              teacher_note: sa.teacher_note || null,
-            };
-
-            // A single submission_answer can match multiple dese_codes; add to every bucket.
-            for (const code of ai.dese_codes) {
-              if (!buckets.has(code)) buckets.set(code, []);
-              buckets.get(code).push(item);
-            }
-          }
+      const res = await fetch(
+        `/.netlify/functions/teacher-dese-rollups?${params.toString()}`,
+        {
+          method: 'GET',
+          credentials: 'same-origin',
+          headers: {
+            Accept: 'application/json',
+          },
         }
+      );
+
+      if (!res.ok) {
+        throw new Error(`DESE evidence request failed: ${res.status}`);
       }
 
-      // Sort each bucket by date descending (most recent first)
+      const payload = await res.json();
+      const rows = Array.isArray(payload?.rows) ? payload.rows : [];
+      const buckets = new Map();
+
+      for (const row of rows) {
+        if (!row?.dese_code) continue;
+
+        const earned =
+          typeof row.earned_points === 'number'
+            ? row.earned_points
+            : null;
+
+        const max =
+          typeof row.max_points === 'number'
+            ? row.max_points
+            : null;
+
+        const scorePct =
+          earned !== null && max
+            ? Math.round(earned / max * 100)
+            : null;
+
+        const dateStr =
+          row.submitted_at
+            ? new Date(row.submitted_at).toLocaleDateString(
+                'en-US',
+                {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                }
+              )
+            : null;
+
+        const item = {
+          question_text: row.question_text || null,
+          assignment_title: row.assignment_title || '',
+          assignment_id: row.assignment_id || null,
+          date: dateStr,
+          earned_points: earned,
+          max_points: max,
+          is_correct:
+            typeof row.is_correct === 'boolean'
+              ? row.is_correct
+              : null,
+          score_pct: scorePct,
+          teacher_note: row.teacher_note || null,
+        };
+
+        if (!buckets.has(row.dese_code)) {
+          buckets.set(row.dese_code, []);
+        }
+
+        buckets.get(row.dese_code).push(item);
+      }
+
       for (const items of buckets.values()) {
         items.sort((a, b) => {
           if (!a.date && !b.date) return 0;
@@ -10121,11 +10109,6 @@
     }
   }
 
-  /**
-   * Return the evidence items for a single student + DESE standard code.
-   * Delegates to fetchAllEvidenceForStudent so at most one Supabase query
-   * fires per student per data refresh.
-   */
   async function fetchDeseEvidenceItems(student, deseCode) {
     if (!student?.id || !deseCode) return [];
     const buckets = await fetchAllEvidenceForStudent(student);

--- a/tests/non-instructional-dese-evidence.test.cjs
+++ b/tests/non-instructional-dese-evidence.test.cjs
@@ -21,6 +21,7 @@ const migration = read(
   'supabase/migrations/20260725233500_exclude_non_instructional_dese_evidence.sql'
 );
 const students = read('site/web/tc-students.js');
+const endpoint = read('netlify/functions/teacher-dese-rollups.js');
 
 const sqlPredicate =
   "ai.settings->'non_instructional' IS DISTINCT FROM 'true'::jsonb";
@@ -46,21 +47,48 @@ assert.strictEqual(
 );
 
 const evidence = section(
+  endpoint,
+  'async function fetchStudentEvidence(',
+  'async function mapWithConcurrency('
+);
+
+assert.ok(
+  evidence.includes('settings,'),
+  'server DESE evidence query must fetch assignment-instance settings'
+);
+
+assert.ok(
+  evidence.includes(
+    'instance?.settings?.non_instructional === true'
+  ),
+  'server DESE evidence reader must exclude explicit non-instructional instances'
+);
+
+assert.ok(
+  evidence.includes(
+    "typeof answer.max_points !== 'number'"
+  ),
+  'server DESE evidence reader must preserve the graded-item filter'
+);
+
+const browserEvidence = section(
   students,
   '  async function fetchAllEvidenceForStudent(student) {',
   '  async function fetchDeseEvidenceItems(student, deseCode) {'
 );
 
 assert.ok(
-  evidence.includes('settings,'),
-  'DESE evidence-card query must fetch assignment-instance settings'
+  !browserEvidence.includes(
+    ".from('assignment_instances')"
+  ),
+  'browser DESE evidence reader must not query assignment_instances directly'
 );
 
 assert.ok(
-  evidence.includes(
-    'if (instance?.settings?.non_instructional === true) continue;'
+  browserEvidence.includes(
+    "detail: 'evidence'"
   ),
-  'DESE evidence-card reader must exclude explicit non-instructional instances'
+  'browser DESE evidence reader must use authenticated evidence mode'
 );
 
 assert.ok(
@@ -82,7 +110,7 @@ assert.ok(
 
 console.log('✓ student_dese_rollups migration excludes explicit non-instructional instances');
 console.log('✓ historical all_students_dese_rollups migration excludes explicit non-instructional instances');
-console.log('✓ Teacher Center DESE evidence cards exclude marked instances');
+console.log('✓ server-side Teacher Center DESE evidence excludes marked instances');
 console.log('✓ obsolete browser DESE rollup fallback remains removed');
 console.log('✓ Teacher Center DESE rollups use the authenticated server boundary');
 console.log('\nNON-INSTRUCTIONAL DESE EVIDENCE: PASS');

--- a/tests/teacher-dese-rollup-browser-boundary.test.cjs
+++ b/tests/teacher-dese-rollup-browser-boundary.test.cjs
@@ -112,10 +112,24 @@ const evidenceBlock =
   );
 
 assert.ok(
-  evidenceBlock.includes(
+  !evidenceBlock.includes(
     ".from('assignment_instances')"
   ),
-  'T1 must not alter detailed DESE evidence transport'
+  'detailed DESE evidence must not query assignment_instances directly from the browser'
+);
+
+assert.ok(
+  evidenceBlock.includes(
+    '/.netlify/functions/teacher-dese-rollups'
+  ),
+  'detailed DESE evidence must use the authenticated teacher boundary'
+);
+
+assert.ok(
+  evidenceBlock.includes(
+    "detail: 'evidence'"
+  ),
+  'detailed DESE evidence must explicitly request evidence mode'
 );
 
 console.log(
@@ -139,7 +153,7 @@ console.log(
 );
 
 console.log(
-  '✓ detailed evidence path intentionally unchanged for T2'
+  '✓ detailed evidence path uses authenticated server boundary'
 );
 
 console.log();

--- a/tests/teacher-dese-rollups.test.cjs
+++ b/tests/teacher-dese-rollups.test.cjs
@@ -130,6 +130,98 @@ function installMocks() {
         );
       }
 
+      if (
+        url.startsWith(
+          '/rest/v1/assignment_instances?'
+        )
+      ) {
+        return response(
+          200,
+          [
+            {
+              assignment_id: 701,
+              settings: {},
+              assignments: {
+                title: 'Instructional Evidence',
+              },
+              submissions: [
+                {
+                  submitted_at:
+                    '2026-09-01T15:30:00.000Z',
+                  submission_answers: [
+                    {
+                      earned_points: 1,
+                      max_points: 2,
+                      is_correct: false,
+                      teacher_note: 'Keep going',
+                      assignment_items: {
+                        item_ref: 'Q1',
+                        dese_codes: [
+                          '9-10.RL.1.A',
+                        ],
+                        meta: {
+                          question:
+                            'What evidence supports the claim?',
+                        },
+                      },
+                    },
+                    {
+                      earned_points: 0,
+                      max_points: 0,
+                      is_correct: null,
+                      teacher_note: null,
+                      assignment_items: {
+                        item_ref: 'Q2',
+                        dese_codes: [
+                          '9-10.RL.1.A',
+                        ],
+                        meta: {
+                          question:
+                            'Ungraded prompt',
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              assignment_id: 702,
+              settings: {
+                non_instructional: true,
+              },
+              assignments: {
+                title: 'System Test',
+              },
+              submissions: [
+                {
+                  submitted_at:
+                    '2026-09-02T15:30:00.000Z',
+                  submission_answers: [
+                    {
+                      earned_points: 1,
+                      max_points: 1,
+                      is_correct: true,
+                      teacher_note: null,
+                      assignment_items: {
+                        item_ref: 'Q1',
+                        dese_codes: [
+                          '9-10.RL.1.A',
+                        ],
+                        meta: {
+                          question:
+                            'Synthetic system-test item',
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ]
+        );
+      }
+
       throw new Error(
         `Unexpected REST URL: ${url}`
       );
@@ -498,6 +590,92 @@ async function run() {
         assert.strictEqual(
           rpcCalls[0].args.p_student_id,
           student1Id
+        );
+      }
+    );
+
+    await test(
+      'evidence mode uses teacher-owned student and operational year without RPC',
+      async () => {
+        restCalls.length = 0;
+        rpcCalls.length = 0;
+
+        const result =
+          await handler(
+            event({
+              student_code: 'S001',
+              detail: 'evidence',
+            })
+          );
+
+        assert.strictEqual(
+          result.statusCode,
+          200
+        );
+
+        const body =
+          JSON.parse(result.body);
+
+        assert.strictEqual(
+          body.school_year,
+          2026
+        );
+
+        assert.strictEqual(
+          body.rows.length,
+          1,
+          'non-instructional and zero-point evidence must be excluded'
+        );
+
+        assert.deepStrictEqual(
+          body.rows[0],
+          {
+            dese_code: '9-10.RL.1.A',
+            question_text:
+              'What evidence supports the claim?',
+            assignment_title:
+              'Instructional Evidence',
+            assignment_id: 701,
+            submitted_at:
+              '2026-09-01T15:30:00.000Z',
+            earned_points: 1,
+            max_points: 2,
+            is_correct: false,
+            teacher_note: 'Keep going',
+          }
+        );
+
+        assert.strictEqual(
+          rpcCalls.length,
+          0,
+          'evidence mode must not call a DESE RPC'
+        );
+
+        const evidenceCall =
+          restCalls.find(
+            (call) =>
+              call.url.startsWith(
+                '/rest/v1/assignment_instances?'
+              )
+          );
+
+        assert.ok(
+          evidenceCall,
+          'evidence mode must query assignment_instances server-side'
+        );
+
+        assert.ok(
+          evidenceCall.url.includes(
+            `student_id=eq.${student1Id}`
+          ),
+          'evidence query must scope to teacher-owned student id'
+        );
+
+        assert.ok(
+          evidenceCall.url.includes(
+            'school_year=eq.2026'
+          ),
+          'evidence query must use operational school year'
         );
       }
     );


### PR DESCRIPTION
## RC-SEC-01E-T2

Moves detailed per-student DESE evidence behind the existing signed Teacher Center server boundary.

### Security boundary

- requires signed Teacher Center session
- uses signed teacherId for ownership
- permits only active students enrolled in teacher-owned classes
- resolves operational school year server-side
- removes the detailed DESE evidence query from the browser
- preserves non_instructional exclusion
- preserves zero-point exclusion

### Scope

- extends the existing teacher-dese-rollups endpoint with evidence mode
- updates tc-students evidence transport
- updates permanent boundary/regression tests
- bumps tc-students cache version

### Explicitly unchanged

- no database schema change
- no RLS change
- no grants/revokes
- no RPC privilege change
- no production data mutation
- separate goal-progress browser path remains unchanged

### Local certification

- exact six-file scope
- focused T2 tests passed
- full repository suite passed
- committed cache-bust check passed
