### PR TITLE
RC-SEC-01G: protect Teacher Review answer reads

### DIFF
--- a/netlify/functions/teacher-review-submission-answers.js
+++ b/netlify/functions/teacher-review-submission-answers.js
@@ -1,0 +1,605 @@
+'use strict';
+
+// Teacher-only submission-answer reader.
+//
+// GET /.netlify/functions/teacher-review-submission-answers?submission_id=<uuid>
+//
+// Security boundary:
+//   signed teacher session
+//     -> signed teacherId
+//     -> teacher-owned class
+//     -> active enrollment
+//     -> submission's student
+//     -> service-role answer read
+//
+// The browser is never trusted to establish ownership.
+
+const {
+  generateRequestId,
+  jsonResponse,
+  handleCorsPreFlight,
+} = require('./_lib/http');
+
+const {
+  requireTeacher,
+} = require('./_lib/auth');
+
+const {
+  rest,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = require('./_lib/supa');
+
+const {
+  SESSION_SECRET,
+} = process.env;
+
+function isUuid(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    .test(String(value || ''));
+}
+
+async function readJson(response, label) {
+  if (!response || response.ok !== true) {
+    const status =
+      response && Number.isInteger(response.status)
+        ? response.status
+        : 0;
+
+    let detail = '';
+
+    if (
+      response &&
+      typeof response.text === 'function'
+    ) {
+      detail =
+        await response
+          .text()
+          .catch(() => '');
+    }
+
+    throw new Error(
+      `${label} failed: ${status}` +
+      (detail ? ` ${detail.slice(0, 160)}` : '')
+    );
+  }
+
+  const body = await response.json();
+
+  return Array.isArray(body)
+    ? body
+    : [];
+}
+
+async function fetchOwnedClassIds(teacherId) {
+  const response =
+    await rest(
+      '/rest/v1/classes' +
+      '?select=id' +
+      `&teacher_id=eq.${encodeURIComponent(teacherId)}`
+    );
+
+  const rows =
+    await readJson(
+      response,
+      'Teacher classes query'
+    );
+
+  return [
+    ...new Set(
+      rows
+        .map((row) => row && row.id)
+        .filter(isUuid)
+    ),
+  ];
+}
+
+async function teacherOwnsStudent(
+  teacherId,
+  studentId
+) {
+  const classIds =
+    await fetchOwnedClassIds(
+      teacherId
+    );
+
+  if (classIds.length === 0) {
+    return false;
+  }
+
+  const response =
+    await rest(
+      '/rest/v1/class_enrollments' +
+      '?select=student_id,active' +
+      '&active=eq.true' +
+      `&student_id=eq.${encodeURIComponent(studentId)}` +
+      '&class_id=in.(' +
+      classIds
+        .map(encodeURIComponent)
+        .join(',') +
+      ')' +
+      '&limit=1'
+    );
+
+  const rows =
+    await readJson(
+      response,
+      'Teacher enrollment query'
+    );
+
+  return rows.some(
+    (row) =>
+      row &&
+      row.active !== false &&
+      row.student_id === studentId
+  );
+}
+
+async function fetchSubmission(
+  submissionId
+) {
+  const response =
+    await rest(
+      '/rest/v1/submissions' +
+      '?select=id,instance_id' +
+      `&id=eq.${encodeURIComponent(submissionId)}` +
+      '&limit=1'
+    );
+
+  const rows =
+    await readJson(
+      response,
+      'Submission query'
+    );
+
+  return rows[0] || null;
+}
+
+async function fetchInstance(
+  instanceId
+) {
+  const response =
+    await rest(
+      '/rest/v1/assignment_instances' +
+      '?select=id,student_id' +
+      `&id=eq.${encodeURIComponent(instanceId)}` +
+      '&limit=1'
+    );
+
+  const rows =
+    await readJson(
+      response,
+      'Assignment instance query'
+    );
+
+  return rows[0] || null;
+}
+
+async function fetchAnswers(
+  submissionId
+) {
+  const response =
+    await rest(
+      '/rest/v1/submission_answers' +
+      '?select=' +
+      [
+        'id',
+        'submission_id',
+        'assignment_item_id',
+        'raw_answer',
+        'is_correct',
+        'earned_points',
+        'max_points',
+        'teacher_note',
+        'scored_at',
+        'assignment_items!assignment_item_id(' +
+          'id,item_ref,answer_type,points,meta' +
+        ')',
+      ].join(',') +
+      `&submission_id=eq.${encodeURIComponent(submissionId)}`
+    );
+
+  return readJson(
+    response,
+    'Submission answers query'
+  );
+}
+
+async function fetchMappings(itemIds) {
+  if (itemIds.length === 0) {
+    return [];
+  }
+
+  const response =
+    await rest(
+      '/rest/v1/assignment_item_mappings' +
+      '?select=item_id,dese_codes,goal_codes,weight' +
+      '&item_id=in.(' +
+      itemIds
+        .map((id) =>
+          encodeURIComponent(String(id))
+        )
+        .join(',') +
+      ')'
+    );
+
+  if (!response || response.ok !== true) {
+    console.warn(
+      '[teacher-review-submission-answers] ' +
+      'Mapping enrichment query failed; returning answers without mappings'
+    );
+
+    return [];
+  }
+
+  const body =
+    await response
+      .json()
+      .catch(() => []);
+
+  return Array.isArray(body)
+    ? body
+    : [];
+}
+
+function flattenAnswers(
+  rows,
+  mappings
+) {
+  const mappingsByItemId =
+    new Map();
+
+  for (const mapping of mappings) {
+    if (
+      mapping &&
+      mapping.item_id != null
+    ) {
+      mappingsByItemId.set(
+        String(mapping.item_id),
+        mapping
+      );
+    }
+  }
+
+  return rows.map((answer) => {
+    const nestedItem =
+      Array.isArray(
+        answer.assignment_items
+      )
+        ? answer.assignment_items[0]
+        : answer.assignment_items;
+
+    const item =
+      nestedItem || {};
+
+    const mapping =
+      mappingsByItemId.get(
+        String(
+          answer.assignment_item_id
+        )
+      ) || {};
+
+    return {
+      id: answer.id,
+      submission_id:
+        answer.submission_id,
+      item_id:
+        answer.assignment_item_id,
+      raw_answer:
+        answer.raw_answer,
+      is_correct:
+        answer.is_correct,
+      earned_points:
+        answer.earned_points,
+      max_points:
+        answer.max_points,
+      teacher_note:
+        answer.teacher_note,
+      scored_at:
+        answer.scored_at,
+      item_ref:
+        item.item_ref,
+      answer_type:
+        item.answer_type,
+      points:
+        item.points,
+      meta:
+        item.meta,
+      dese_codes:
+        mapping.dese_codes || [],
+      goal_codes:
+        mapping.goal_codes || [],
+      weight:
+        mapping.weight || 1.0,
+    };
+  });
+}
+
+exports.handler =
+  async (event) => {
+    const requestId =
+      generateRequestId();
+
+    console.log(
+      '[teacher-review-submission-answers] ' +
+      `[${requestId}] Request received`
+    );
+
+    if (
+      event.httpMethod === 'OPTIONS'
+    ) {
+      return handleCorsPreFlight(
+        event,
+        ['GET', 'OPTIONS'],
+        ['Content-Type']
+      );
+    }
+
+    if (
+      event.httpMethod !== 'GET'
+    ) {
+      return jsonResponse(
+        event,
+        405,
+        {
+          ok: false,
+          error: 'Method Not Allowed',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    if (!SESSION_SECRET) {
+      return jsonResponse(
+        event,
+        500,
+        {
+          ok: false,
+          error: 'Server not configured',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    const teacherAuth =
+      requireTeacher(
+        event,
+        SESSION_SECRET
+      );
+
+    if (!teacherAuth.ok) {
+      return jsonResponse(
+        event,
+        401,
+        {
+          ok: false,
+          error: 'Unauthorized',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    if (
+      !SUPABASE_URL ||
+      !SUPABASE_SERVICE_ROLE_KEY
+    ) {
+      return jsonResponse(
+        event,
+        503,
+        {
+          ok: false,
+          error: 'Service unavailable',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    const teacherId =
+      teacherAuth.user &&
+      teacherAuth.user.teacherId;
+
+    if (!isUuid(teacherId)) {
+      console.warn(
+        '[teacher-review-submission-answers] ' +
+        `[${requestId}] ` +
+        'Verified teacher session has no usable teacherId'
+      );
+
+      return jsonResponse(
+        event,
+        403,
+        {
+          ok: false,
+          error: 'Teacher identity unavailable',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    const params =
+      event.queryStringParameters || {};
+
+    const submissionId =
+      String(
+        params.submission_id || ''
+      ).trim();
+
+    if (!isUuid(submissionId)) {
+      return jsonResponse(
+        event,
+        400,
+        {
+          ok: false,
+          error: 'Invalid submission_id',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+
+    try {
+      const submission =
+        await fetchSubmission(
+          submissionId
+        );
+
+      if (
+        !submission ||
+        !isUuid(
+          submission.instance_id
+        )
+      ) {
+        return jsonResponse(
+          event,
+          404,
+          {
+            ok: false,
+            error: 'Submission not found',
+          },
+          {
+            'Cache-Control': 'no-store',
+          },
+          requestId
+        );
+      }
+
+      const instance =
+        await fetchInstance(
+          submission.instance_id
+        );
+
+      if (
+        !instance ||
+        !isUuid(instance.student_id)
+      ) {
+        return jsonResponse(
+          event,
+          404,
+          {
+            ok: false,
+            error: 'Submission not found',
+          },
+          {
+            'Cache-Control': 'no-store',
+          },
+          requestId
+        );
+      }
+
+      const ownsStudent =
+        await teacherOwnsStudent(
+          teacherId,
+          instance.student_id
+        );
+
+      if (!ownsStudent) {
+        console.warn(
+          '[teacher-review-submission-answers] ' +
+          `[${requestId}] ` +
+          'Submission outside signed teacher ownership'
+        );
+
+        return jsonResponse(
+          event,
+          404,
+          {
+            ok: false,
+            error: 'Submission not found',
+          },
+          {
+            'Cache-Control': 'no-store',
+          },
+          requestId
+        );
+      }
+
+      const answerRows =
+        await fetchAnswers(
+          submissionId
+        );
+
+      const itemIds =
+        [
+          ...new Set(
+            answerRows
+              .map(
+                (row) =>
+                  row &&
+                  row.assignment_item_id
+              )
+              .filter(
+                (value) =>
+                  value != null
+              )
+              .map(String)
+          ),
+        ];
+
+      const mappings =
+        await fetchMappings(
+          itemIds
+        );
+
+      const answers =
+        flattenAnswers(
+          answerRows,
+          mappings
+        );
+
+      console.log(
+        '[teacher-review-submission-answers] ' +
+        `[${requestId}] ` +
+        `Returning ${answers.length} answer(s)`
+      );
+
+      return jsonResponse(
+        event,
+        200,
+        {
+          ok: true,
+          answers,
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    } catch (err) {
+      console.error(
+        '[teacher-review-submission-answers] ' +
+        `[${requestId}] Error:`,
+        err
+      );
+
+      return jsonResponse(
+        event,
+        500,
+        {
+          ok: false,
+          error:
+            'Failed to fetch submission answers',
+        },
+        {
+          'Cache-Control': 'no-store',
+        },
+        requestId
+      );
+    }
+  };

--- a/site/teacher/review/index.html
+++ b/site/teacher/review/index.html
@@ -1038,7 +1038,7 @@
   <script src="/web/supabase-config.js"></script>
   <script defer src="/web/teacher-shell.js"></script>
   <script src="/web/rc-modal.js"></script>
-  <script type="module" src="/web/tc-review.js?v=20260329"></script>
+  <script type="module" src="/web/tc-review.js?v=2026072901"></script>
   <script defer src="/assets/js/class-clock.js" type="module"></script>
   <script type="module" src="/web/tc-observation.js"></script>
 </body>

--- a/site/web/data-adapter.js
+++ b/site/web/data-adapter.js
@@ -2435,63 +2435,38 @@ const remote = {
    * @returns {Array} Submission answers with item details and mappings
    */
   async listSubmissionAnswers(submissionId) {
-    const supabase = await getSupabase();
-    if (!supabase) throw new Error('supabase-not-configured');
-    
-    const { data, error } = await supabase
-      .from('submission_answers')
-      .select(`
-        *,
-        assignment_items!assignment_item_id(
-          id,
-          item_ref,
-          answer_type,
-          points,
-          meta
-        )
-      `)
-      .eq('submission_id', submissionId);
-    
-    if (error) throw error;
-    
-    // Fetch mappings separately for items that have them
-    const itemIds = (data || []).map(a => a.assignment_item_id).filter(Boolean);
-    let mappingsByItemId = {};
-    if (itemIds.length > 0) {
-      const { data: mappings } = await supabase
-        .from('assignment_item_mappings')
-        .select('*')
-        .in('item_id', itemIds);
-      (mappings || []).forEach(m => {
-        mappingsByItemId[m.item_id] = m;
-      });
+    const response = await fetch(
+      '/.netlify/functions/teacher-review-submission-answers' +
+      `?submission_id=${encodeURIComponent(submissionId)}`,
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Accept': 'application/json'
+        }
+      }
+    );
+
+    if (!response.ok) {
+      const err = await response
+        .json()
+        .catch(() => ({
+          error: 'Unknown error'
+        }));
+
+      throw new Error(
+        err.error ||
+        `Load submission answers failed: ${response.status}`
+      );
     }
-    
-    // Flatten the nested structure
-    return (data || []).map(answer => {
-      const item = answer.assignment_items || {};
-      const mapping = mappingsByItemId[answer.assignment_item_id] || {};
-      
-      return {
-        id: answer.id,
-        submission_id: answer.submission_id,
-        item_id: answer.assignment_item_id,
-        raw_answer: answer.raw_answer,
-        is_correct: answer.is_correct,
-        earned_points: answer.earned_points,
-        max_points: answer.max_points,
-        teacher_note: answer.teacher_note,
-        scored_at: answer.scored_at,
-        item_ref: item.item_ref,
-        answer_type: item.answer_type,
-        points: item.points,
-        meta: item.meta,
-        dese_codes: mapping.dese_codes || [],
-        goal_codes: mapping.goal_codes || [],
-        weight: mapping.weight || 1.0
-      };
-    });
+
+    const result = await response.json();
+
+    return Array.isArray(result.answers)
+      ? result.answers
+      : [];
   },
+
 
   /**
    * Update or create a submission answer with teacher scoring

--- a/site/web/tc-review.js
+++ b/site/web/tc-review.js
@@ -5,7 +5,7 @@
   if (!location.pathname.startsWith("/teacher/review")) return;
 
   // Import data adapter for Supabase/localStorage abstraction
-  const { db, isRemote } = await import('/web/data-adapter.js');
+  const { db, isRemote } = await import('/web/data-adapter.js?v=2026072901');
   const { getSupabase, getSupabaseConfig } = await import('/web/supabase-client.js');
   const { getAssignmentItems } = await import('/web/assignment-mapping-db.js');
   const { CANON_CLASSES, CLASS_DISPLAY } = await import('/web/constants.js');
@@ -264,13 +264,11 @@
       const supabase = await getSupabase();
       if (!supabase) return;
 
-      // Subscribe to submission_answers changes (for manual scoring)
+      // Submission changes are used only as a debounced reload signal.
+      // submission_answers is intentionally not subscribed here; Review reads
+      // those rows through the signed teacher endpoint.
       realtimeChannel = supabase
         .channel('review-tab-updates')
-        .on('postgres_changes', 
-          { event: '*', schema: 'public', table: 'submission_answers' },
-          handleRealtimeUpdate
-        )
         .on('postgres_changes',
           { event: '*', schema: 'public', table: 'submissions' },
           handleRealtimeUpdate

--- a/tests/teacher-review-answer-browser-boundary.test.cjs
+++ b/tests/teacher-review-answer-browser-boundary.test.cjs
@@ -1,0 +1,158 @@
+'use strict';
+
+const assert =
+  require('assert');
+
+const fs =
+  require('fs');
+
+const path =
+  require('path');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.resolve(
+      __dirname,
+      '..',
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+const adapter =
+  read(
+    'site/web/data-adapter.js'
+  );
+
+const review =
+  read(
+    'site/web/tc-review.js'
+  );
+
+const reviewHtml =
+  read(
+    'site/teacher/review/index.html'
+  );
+
+const endpoint =
+  '/.netlify/functions/teacher-review-submission-answers';
+
+const firstReader =
+  adapter.indexOf(
+    'async listSubmissionAnswers(submissionId)'
+  );
+
+const secondReader =
+  adapter.indexOf(
+    'async listSubmissionAnswers(submissionId)',
+    firstReader + 1
+  );
+
+const nextMethod =
+  adapter.indexOf(
+    'async updateSubmissionAnswer',
+    secondReader
+  );
+
+assert.ok(
+  firstReader >= 0,
+  'local listSubmissionAnswers implementation must remain'
+);
+
+assert.ok(
+  secondReader > firstReader,
+  'remote listSubmissionAnswers implementation must remain'
+);
+
+assert.ok(
+  nextMethod > secondReader,
+  'remote answer-reader block must be identifiable'
+);
+
+const remoteReader =
+  adapter.slice(
+    secondReader,
+    nextMethod
+  );
+
+assert.ok(
+  remoteReader.includes(
+    endpoint
+  ),
+  'remote Review answer reader must use signed teacher endpoint'
+);
+
+assert.ok(
+  remoteReader.includes(
+    "credentials: 'include'"
+  ),
+  'remote Review answer reader must send teacher session cookie'
+);
+
+assert.ok(
+  !remoteReader.includes(
+    ".from('submission_answers')"
+  ),
+  'remote Review answer reader must not query submission_answers directly'
+);
+
+assert.ok(
+  !adapter.includes(
+    ".from('submission_answers')"
+  ),
+  'data-adapter must contain no direct Supabase submission_answers reader'
+);
+
+assert.ok(
+  !review.includes(
+    "table: 'submission_answers'"
+  ),
+  'Teacher Review must not subscribe directly to submission_answers'
+);
+
+assert.ok(
+  review.includes(
+    "table: 'submissions'"
+  ),
+  'existing submissions reload signal must remain'
+);
+
+assert.ok(
+  review.includes(
+    "/web/data-adapter.js?v=2026072901"
+  ),
+  'Teacher Review must request the versioned data-adapter'
+);
+
+assert.ok(
+  reviewHtml.includes(
+    '/web/tc-review.js?v=2026072901'
+  ),
+  'Teacher Review HTML must cache-bust the changed Review module'
+);
+
+console.log(
+  '✓ remote Review answers use signed teacher endpoint'
+);
+
+console.log(
+  '✓ browser direct submission_answers reader removed'
+);
+
+console.log(
+  '✓ dead submission_answers realtime listener removed'
+);
+
+console.log(
+  '✓ submissions reload listener preserved'
+);
+
+console.log(
+  '✓ Review module and data-adapter cache-busted'
+);
+
+console.log();
+console.log(
+  'RC-SEC-01G browser-boundary tests PASS'
+);

--- a/tests/teacher-review-submission-answers.test.cjs
+++ b/tests/teacher-review-submission-answers.test.cjs
@@ -1,0 +1,556 @@
+'use strict';
+
+const assert =
+  require('assert');
+
+const path =
+  require('path');
+
+process.env.SESSION_SECRET =
+  'rc-sec-01g-test-secret';
+
+const endpointPath =
+  path.resolve(
+    __dirname,
+    '../netlify/functions/teacher-review-submission-answers.js'
+  );
+
+const authPath =
+  require.resolve(
+    '../netlify/functions/_lib/auth'
+  );
+
+const supaPath =
+  require.resolve(
+    '../netlify/functions/_lib/supa'
+  );
+
+const teacherId =
+  '11111111-1111-4111-8111-111111111111';
+
+const classId =
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const studentId =
+  '22222222-2222-4222-8222-222222222222';
+
+const outsideStudentId =
+  '33333333-3333-4333-8333-333333333333';
+
+const submissionId =
+  '44444444-4444-4444-8444-444444444444';
+
+const instanceId =
+  '55555555-5555-4555-8555-555555555555';
+
+let authResult;
+let restCalls;
+let restHandler;
+
+function response(status, body) {
+  return {
+    ok:
+      status >= 200 &&
+      status < 300,
+
+    status,
+
+    async json() {
+      return body;
+    },
+
+    async text() {
+      return JSON.stringify(body);
+    },
+  };
+}
+
+function installMocks() {
+  authResult = {
+    ok: true,
+    user: {
+      role: 'teacher',
+      username: 'teacher_test',
+      teacherId,
+    },
+  };
+
+  restCalls = [];
+
+  restHandler =
+    async (url) => {
+      if (
+        url.startsWith(
+          '/rest/v1/submissions?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            id: submissionId,
+            instance_id: instanceId,
+          }]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/assignment_instances?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            id: instanceId,
+            student_id: studentId,
+          }]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/classes?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            id: classId,
+          }]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/class_enrollments?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            student_id: studentId,
+            active: true,
+          }]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/submission_answers?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            id:
+              '66666666-6666-4666-8666-666666666666',
+            submission_id:
+              submissionId,
+            assignment_item_id:
+              701,
+            raw_answer: {
+              value: 'A',
+            },
+            is_correct:
+              true,
+            earned_points:
+              2,
+            max_points:
+              2,
+            teacher_note:
+              'Nice work',
+            scored_at:
+              '2026-09-01T15:30:00.000Z',
+            assignment_items: {
+              id: 701,
+              item_ref: 'Q1',
+              answer_type: 'mcq',
+              points: 2,
+              meta: {
+                question:
+                  'Test question',
+                correct: 'A',
+              },
+            },
+          }]
+        );
+      }
+
+      if (
+        url.startsWith(
+          '/rest/v1/assignment_item_mappings?'
+        )
+      ) {
+        return response(
+          200,
+          [{
+            item_id: 701,
+            dese_codes: [
+              '9-10.RL.1.A',
+            ],
+            goal_codes: [
+              'READ-COMP',
+            ],
+            weight: 1.5,
+          }]
+        );
+      }
+
+      throw new Error(
+        `Unexpected REST call: ${url}`
+      );
+    };
+
+  require.cache[authPath] = {
+    id: authPath,
+    filename: authPath,
+    loaded: true,
+    exports: {
+      requireTeacher() {
+        return authResult;
+      },
+    },
+  };
+
+  require.cache[supaPath] = {
+    id: supaPath,
+    filename: supaPath,
+    loaded: true,
+    exports: {
+      SUPABASE_URL:
+        'https://example.supabase.co',
+
+      SUPABASE_SERVICE_ROLE_KEY:
+        'service-role-test-key',
+
+      async rest(url, init) {
+        restCalls.push({
+          url,
+          init,
+        });
+
+        return restHandler(
+          url,
+          init
+        );
+      },
+    },
+  };
+
+  delete require.cache[
+    require.resolve(endpointPath)
+  ];
+}
+
+function loadHandler() {
+  return require(endpointPath)
+    .handler;
+}
+
+function event(query = {}) {
+  return {
+    httpMethod: 'GET',
+    headers: {},
+    queryStringParameters: query,
+  };
+}
+
+function body(result) {
+  return JSON.parse(
+    result.body
+  );
+}
+
+async function test(
+  name,
+  fn
+) {
+  try {
+    installMocks();
+
+    await fn();
+
+    console.log(
+      `✓ ${name}`
+    );
+  } catch (err) {
+    console.error(
+      `✗ ${name}`
+    );
+
+    throw err;
+  }
+}
+
+(async () => {
+  console.log(
+    '--- teacher-review-submission-answers tests ---'
+  );
+
+  await test(
+    'unauthenticated request returns 401 before Supabase access',
+    async () => {
+      authResult = {
+        ok: false,
+      };
+
+      const result =
+        await loadHandler()(
+          event({
+            submission_id:
+              submissionId,
+          })
+        );
+
+      assert.strictEqual(
+        result.statusCode,
+        401
+      );
+
+      assert.strictEqual(
+        restCalls.length,
+        0
+      );
+    }
+  );
+
+  await test(
+    'verified session without teacherId returns 403 before Supabase access',
+    async () => {
+      authResult = {
+        ok: true,
+        user: {
+          role: 'teacher',
+          username:
+            'teacher_test',
+          teacherId: null,
+        },
+      };
+
+      const result =
+        await loadHandler()(
+          event({
+            submission_id:
+              submissionId,
+          })
+        );
+
+      assert.strictEqual(
+        result.statusCode,
+        403
+      );
+
+      assert.strictEqual(
+        restCalls.length,
+        0
+      );
+    }
+  );
+
+  await test(
+    'invalid submission_id returns 400 before Supabase access',
+    async () => {
+      const result =
+        await loadHandler()(
+          event({
+            submission_id:
+              'not-a-uuid',
+          })
+        );
+
+      assert.strictEqual(
+        result.statusCode,
+        400
+      );
+
+      assert.strictEqual(
+        restCalls.length,
+        0
+      );
+    }
+  );
+
+  await test(
+    'owned submission returns exact flattened Review answer shape',
+    async () => {
+      const result =
+        await loadHandler()(
+          event({
+            submission_id:
+              submissionId,
+          })
+        );
+
+      assert.strictEqual(
+        result.statusCode,
+        200
+      );
+
+      const payload =
+        body(result);
+
+      assert.deepStrictEqual(
+        payload.answers,
+        [{
+          id:
+            '66666666-6666-4666-8666-666666666666',
+          submission_id:
+            submissionId,
+          item_id:
+            701,
+          raw_answer: {
+            value: 'A',
+          },
+          is_correct:
+            true,
+          earned_points:
+            2,
+          max_points:
+            2,
+          teacher_note:
+            'Nice work',
+          scored_at:
+            '2026-09-01T15:30:00.000Z',
+          item_ref:
+            'Q1',
+          answer_type:
+            'mcq',
+          points:
+            2,
+          meta: {
+            question:
+              'Test question',
+            correct:
+              'A',
+          },
+          dese_codes: [
+            '9-10.RL.1.A',
+          ],
+          goal_codes: [
+            'READ-COMP',
+          ],
+          weight:
+            1.5,
+        }]
+      );
+
+      assert.ok(
+        restCalls.some(
+          ({ url }) =>
+            url.includes(
+              `teacher_id=eq.${teacherId}`
+            )
+        ),
+        'class lookup must scope by signed teacherId'
+      );
+
+      assert.ok(
+        restCalls.some(
+          ({ url }) =>
+            url.startsWith(
+              '/rest/v1/submission_answers?'
+            )
+        ),
+        'owned submission must reach answer read'
+      );
+    }
+  );
+
+  await test(
+    'outside-teacher submission returns 404 before answer read',
+    async () => {
+      restHandler =
+        async (url) => {
+          if (
+            url.startsWith(
+              '/rest/v1/submissions?'
+            )
+          ) {
+            return response(
+              200,
+              [{
+                id: submissionId,
+                instance_id:
+                  instanceId,
+              }]
+            );
+          }
+
+          if (
+            url.startsWith(
+              '/rest/v1/assignment_instances?'
+            )
+          ) {
+            return response(
+              200,
+              [{
+                id:
+                  instanceId,
+                student_id:
+                  outsideStudentId,
+              }]
+            );
+          }
+
+          if (
+            url.startsWith(
+              '/rest/v1/classes?'
+            )
+          ) {
+            return response(
+              200,
+              [{
+                id: classId,
+              }]
+            );
+          }
+
+          if (
+            url.startsWith(
+              '/rest/v1/class_enrollments?'
+            )
+          ) {
+            return response(
+              200,
+              []
+            );
+          }
+
+          throw new Error(
+            `Answer read must not occur: ${url}`
+          );
+        };
+
+      const result =
+        await loadHandler()(
+          event({
+            submission_id:
+              submissionId,
+          })
+        );
+
+      assert.strictEqual(
+        result.statusCode,
+        404
+      );
+
+      assert.ok(
+        !restCalls.some(
+          ({ url }) =>
+            url.startsWith(
+              '/rest/v1/submission_answers?'
+            )
+        ),
+        'outside submission must not reach submission_answers'
+      );
+    }
+  );
+
+  console.log();
+  console.log(
+    'RC-SEC-01G endpoint tests PASS'
+  );
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## RC-SEC-01G — signed Teacher Review submission-answer read boundary

### Goal

Remove Teacher Review's browser-direct read access to `submission_answers` by moving the live remote reader behind a signed Teacher Center server boundary.

### What changed

- adds `teacher-review-submission-answers`
- requires the signed teacher session
- requires a valid signed `teacherId`
- validates submission → assignment instance → student
- requires active enrollment in a class owned by the signed teacher
- returns 404 for submissions outside that teacher's ownership
- reads submission answers with the server service-role boundary only after authorization
- preserves the existing flattened Review answer contract
- removes the browser-direct `submission_answers` read
- removes the inert `submission_answers` realtime listener
- preserves the existing `submissions` reload listener
- preserves the local/non-remote adapter implementation
- cache-busts the changed Review assets

### Test plan completed

- unauthenticated request → 401 before Supabase access
- verified session without teacherId → 403 before Supabase access
- invalid submission_id → 400 before Supabase access
- owned submission → exact existing flattened answer shape
- outside-teacher submission → 404 before answer read
- browser direct `submission_answers` reader absent
- browser `submission_answers` realtime listener absent
- `submissions` reload listener preserved
- targeted endpoint tests passed
- browser-boundary tests passed
- full `npm test` passed
- lint passed
- committed-history cache-bust check passed

### Certified commit

`42a5733a417a60c86ebba5bd663fca03bbde0d1e`

Parent / production baseline:

`1e2c3e50fc31a2bbb9103979e153c2490a4b5caa`

### Explicitly not in this slice

- no database changes
- no GRANT / REVOKE changes
- no RLS changes
- no data mutation
- no deployment or production mutation
- no change to `teacher-review-save` ownership behavior

The separate `teacher-review-save` ownership authorization finding remains reserved for RC-SEC-01H.
