### PR TITLE
RC-SEC-01I-D1C2: secure Gradebook score saves

### DIFF
--- a/netlify/functions/teacher-gradebook-save-score.js
+++ b/netlify/functions/teacher-gradebook-save-score.js
@@ -1,0 +1,850 @@
+'use strict';
+
+// Signed Teacher Center Gradebook score writer.
+//
+// Scope:
+//   Existing canonical assignments only.
+//
+// Security boundary:
+//   signed teacherId
+//     -> canonical numeric assignment
+//     -> assignment.class_id
+//     -> exact class.teacher_id == signed teacherId
+//     -> active student
+//     -> active enrollment in that SAME class
+//     -> canonical assignment instance
+//     -> canonical Gradebook submission
+//
+// No authorization is derived from assignment.series, class names,
+// is_teacher_of(), browser instance IDs, or browser submission IDs.
+
+const {
+  generateRequestId,
+  jsonResponse,
+  handleCorsPreFlight,
+} = require('./_lib/http');
+
+const {
+  requireTeacher,
+} = require('./_lib/auth');
+
+const {
+  rest,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = require('./_lib/supa');
+
+const {
+  getCurrentSchoolYear,
+} = require('./_lib/school-year');
+
+const {
+  SESSION_SECRET,
+} = process.env;
+
+const MAX_BODY_BYTES = 8192;
+const MAX_SUBMISSIONS = 500;
+
+function isUuid(value) {
+  return (
+    typeof value === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      .test(value)
+  );
+}
+
+function normalizeAssignmentId(value) {
+  const text =
+    String(value ?? '').trim();
+
+  if (!/^\d+$/.test(text)) {
+    return null;
+  }
+
+  const number =
+    Number(text);
+
+  if (
+    !Number.isSafeInteger(number) ||
+    number <= 0
+  ) {
+    return null;
+  }
+
+  return number;
+}
+
+function normalizeStudentCode(value) {
+  const code =
+    String(value ?? '')
+      .trim()
+      .toUpperCase();
+
+  if (
+    !code ||
+    !/^[A-Z0-9_-]{1,64}$/.test(code)
+  ) {
+    return null;
+  }
+
+  return code;
+}
+
+function normalizeScore(value) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > 100
+  ) {
+    return null;
+  }
+
+  return value;
+}
+
+async function readRows(
+  response,
+  label
+) {
+  if (
+    !response ||
+    response.ok !== true
+  ) {
+    const status =
+      response &&
+      Number.isInteger(response.status)
+        ? response.status
+        : 0;
+
+    let detail = '';
+
+    if (
+      response &&
+      typeof response.text === 'function'
+    ) {
+      detail =
+        await response
+          .text()
+          .catch(() => '');
+    }
+
+    throw new Error(
+      `${label} failed: ${status}` +
+      (
+        detail
+          ? ` ${detail.slice(0, 160)}`
+          : ''
+      )
+    );
+  }
+
+  const body =
+    await response
+      .json()
+      .catch(() => []);
+
+  return Array.isArray(body)
+    ? body
+    : [];
+}
+
+async function requireOk(
+  response,
+  label
+) {
+  if (
+    response &&
+    response.ok === true
+  ) {
+    return;
+  }
+
+  const status =
+    response &&
+    Number.isInteger(response.status)
+      ? response.status
+      : 0;
+
+  let detail = '';
+
+  if (
+    response &&
+    typeof response.text === 'function'
+  ) {
+    detail =
+      await response
+        .text()
+        .catch(() => '');
+  }
+
+  throw new Error(
+    `${label} failed: ${status}` +
+    (
+      detail
+        ? ` ${detail.slice(0, 160)}`
+        : ''
+    )
+  );
+}
+
+function hasAnswers(submission) {
+  return Boolean(
+    submission &&
+    submission.answers &&
+    typeof submission.answers === 'object' &&
+    !Array.isArray(submission.answers) &&
+    Object.keys(submission.answers).length > 0
+  );
+}
+
+function submissionTime(submission) {
+  const value =
+    Date.parse(
+      submission &&
+      submission.submitted_at
+        ? submission.submitted_at
+        : ''
+    );
+
+  return Number.isFinite(value)
+    ? value
+    : 0;
+}
+
+// Match the canonical browser deduplication rule:
+// prefer answered work over empty shells; otherwise prefer newest.
+function selectCanonicalSubmission(
+  submissions
+) {
+  let winner = null;
+
+  for (const submission of submissions) {
+    if (
+      !submission ||
+      !isUuid(submission.id)
+    ) {
+      continue;
+    }
+
+    if (!winner) {
+      winner = submission;
+      continue;
+    }
+
+    const candidateHasAnswers =
+      hasAnswers(submission);
+
+    const winnerHasAnswers =
+      hasAnswers(winner);
+
+    if (
+      candidateHasAnswers &&
+      !winnerHasAnswers
+    ) {
+      winner = submission;
+      continue;
+    }
+
+    if (
+      !candidateHasAnswers &&
+      winnerHasAnswers
+    ) {
+      continue;
+    }
+
+    if (
+      submissionTime(submission) >
+      submissionTime(winner)
+    ) {
+      winner = submission;
+    }
+  }
+
+  return winner;
+}
+
+function noStoreHeaders() {
+  return {
+    'Cache-Control': 'no-store',
+  };
+}
+
+function fail(
+  event,
+  requestId,
+  statusCode,
+  error
+) {
+  return jsonResponse(
+    event,
+    statusCode,
+    {
+      ok: false,
+      error,
+    },
+    noStoreHeaders(),
+    requestId
+  );
+}
+
+exports.handler =
+  async (event) => {
+    const requestId =
+      generateRequestId();
+
+    if (event.httpMethod === 'OPTIONS') {
+      return handleCorsPreFlight(
+        event,
+        ['POST', 'OPTIONS'],
+        ['Content-Type']
+      );
+    }
+
+    if (event.httpMethod !== 'POST') {
+      return fail(
+        event,
+        requestId,
+        405,
+        'Method Not Allowed'
+      );
+    }
+
+    if (!SESSION_SECRET) {
+      return fail(
+        event,
+        requestId,
+        500,
+        'Server not configured'
+      );
+    }
+
+    const teacherAuth =
+      requireTeacher(
+        event,
+        SESSION_SECRET
+      );
+
+    if (!teacherAuth.ok) {
+      return fail(
+        event,
+        requestId,
+        401,
+        'Unauthorized'
+      );
+    }
+
+    if (
+      !SUPABASE_URL ||
+      !SUPABASE_SERVICE_ROLE_KEY
+    ) {
+      return fail(
+        event,
+        requestId,
+        503,
+        'Service unavailable'
+      );
+    }
+
+    const teacherId =
+      teacherAuth.user &&
+      teacherAuth.user.teacherId;
+
+    if (!isUuid(teacherId)) {
+      return fail(
+        event,
+        requestId,
+        403,
+        'Teacher identity unavailable'
+      );
+    }
+
+    const rawBody =
+      event.body || '';
+
+    if (
+      Buffer.byteLength(
+        rawBody,
+        'utf8'
+      ) > MAX_BODY_BYTES
+    ) {
+      return fail(
+        event,
+        requestId,
+        413,
+        'Request body too large'
+      );
+    }
+
+    let body;
+
+    try {
+      body =
+        JSON.parse(
+          rawBody || '{}'
+        );
+    } catch {
+      return fail(
+        event,
+        requestId,
+        400,
+        'Invalid JSON'
+      );
+    }
+
+    const assignmentId =
+      normalizeAssignmentId(
+        body.assignmentId
+      );
+
+    const studentCode =
+      normalizeStudentCode(
+        body.studentCode
+      );
+
+    const score =
+      normalizeScore(
+        body.score
+      );
+
+    if (assignmentId === null) {
+      return fail(
+        event,
+        requestId,
+        400,
+        'Invalid assignmentId'
+      );
+    }
+
+    if (studentCode === null) {
+      return fail(
+        event,
+        requestId,
+        400,
+        'Invalid studentCode'
+      );
+    }
+
+    if (score === null) {
+      return fail(
+        event,
+        requestId,
+        400,
+        'Invalid score'
+      );
+    }
+
+    const schoolYear =
+      getCurrentSchoolYear();
+
+    try {
+      // 1. Resolve the exact canonical assignment.
+      const assignments =
+        await readRows(
+          await rest(
+            '/rest/v1/assignments' +
+            '?select=id,class_id,school_year' +
+            `&id=eq.${encodeURIComponent(assignmentId)}` +
+            '&limit=1'
+          ),
+          'Assignment query'
+        );
+
+      const assignment =
+        assignments[0];
+
+      const assignmentSchoolYear =
+        assignment &&
+        assignment.school_year !== null &&
+        assignment.school_year !== undefined
+          ? Number(
+              assignment.school_year
+            )
+          : null;
+
+      if (
+        !assignment ||
+        !isUuid(
+          assignment.class_id
+        ) ||
+        (
+          assignmentSchoolYear !== null &&
+          assignmentSchoolYear !== schoolYear
+        )
+      ) {
+        return fail(
+          event,
+          requestId,
+          404,
+          'Assignment not found'
+        );
+      }
+
+      const classId =
+        assignment.class_id;
+
+      // 2. The exact class must belong to the signed teacher.
+      const ownedClasses =
+        await readRows(
+          await rest(
+            '/rest/v1/classes' +
+            '?select=id' +
+            `&id=eq.${encodeURIComponent(classId)}` +
+            `&teacher_id=eq.${encodeURIComponent(teacherId)}` +
+            '&limit=1'
+          ),
+          'Class ownership query'
+        );
+
+      if (
+        ownedClasses.length !== 1
+      ) {
+        return fail(
+          event,
+          requestId,
+          404,
+          'Assignment not found'
+        );
+      }
+
+      // 3. Resolve one exact active student by pseudonymous code.
+      const students =
+        await readRows(
+          await rest(
+            '/rest/v1/students' +
+            '?select=id,code,active' +
+            `&code=eq.${encodeURIComponent(studentCode)}` +
+            '&active=eq.true' +
+            '&limit=2'
+          ),
+          'Student query'
+        );
+
+      if (
+        students.length !== 1 ||
+        !isUuid(
+          students[0].id
+        )
+      ) {
+        return fail(
+          event,
+          requestId,
+          404,
+          'Student not found'
+        );
+      }
+
+      const student =
+        students[0];
+
+      // 4. Same-class active enrollment is mandatory.
+      const enrollments =
+        await readRows(
+          await rest(
+            '/rest/v1/class_enrollments' +
+            '?select=class_id,student_id,active' +
+            `&class_id=eq.${encodeURIComponent(classId)}` +
+            `&student_id=eq.${encodeURIComponent(student.id)}` +
+            '&active=eq.true' +
+            '&limit=1'
+          ),
+          'Enrollment query'
+        );
+
+      if (
+        enrollments.length !== 1
+      ) {
+        return fail(
+          event,
+          requestId,
+          404,
+          'Student not found'
+        );
+      }
+
+      // 5. Find the canonical current-year assignment instance.
+      const instanceQueryPath =
+        '/rest/v1/assignment_instances' +
+        '?select=id,assignment_id,student_id,status,settings,school_year' +
+        `&assignment_id=eq.${encodeURIComponent(assignmentId)}` +
+        `&student_id=eq.${encodeURIComponent(student.id)}` +
+        `&or=(school_year.eq.${schoolYear},school_year.is.null)` +
+        '&limit=2';
+
+      let instances =
+        await readRows(
+          await rest(
+            instanceQueryPath
+          ),
+          'Assignment instance query'
+        );
+
+      if (
+        instances.length > 1
+      ) {
+        return fail(
+          event,
+          requestId,
+          409,
+          'Multiple assignment instances found'
+        );
+      }
+
+      let instance =
+        instances[0] || null;
+
+      let createdInstance = false;
+
+      if (!instance) {
+        const createResponse =
+          await rest(
+            '/rest/v1/assignment_instances',
+            {
+              method: 'POST',
+              headers: {
+                Prefer:
+                  'return=representation',
+              },
+              body: JSON.stringify({
+                assignment_id:
+                  assignmentId,
+                student_id:
+                  student.id,
+                status:
+                  'Assigned',
+                settings: {},
+                school_year:
+                  schoolYear,
+              }),
+            }
+          );
+
+        if (
+          createResponse &&
+          createResponse.ok === true
+        ) {
+          instances =
+            await readRows(
+              createResponse,
+              'Assignment instance create'
+            );
+
+          instance =
+            instances[0] || null;
+
+          createdInstance = true;
+        } else if (
+          createResponse &&
+          createResponse.status === 409
+        ) {
+          // Preserve the old atomic-upsert behavior under a race:
+          // another request may have created the unique
+          // (assignment_id, student_id) instance after our initial read.
+          instances =
+            await readRows(
+              await rest(
+                instanceQueryPath
+              ),
+              'Assignment instance conflict reread'
+            );
+
+          if (
+            instances.length !== 1
+          ) {
+            throw new Error(
+              'Assignment instance conflict could not be resolved'
+            );
+          }
+
+          instance =
+            instances[0];
+        } else {
+          await requireOk(
+            createResponse,
+            'Assignment instance create'
+          );
+        }
+      }
+
+      if (
+        !instance ||
+        !isUuid(instance.id)
+      ) {
+        throw new Error(
+          'Assignment instance resolution returned no canonical row'
+        );
+      }
+
+      if (
+        instance.settings &&
+        instance.settings.non_instructional === true
+      ) {
+        return fail(
+          event,
+          requestId,
+          404,
+          'Assignment instance not found'
+        );
+      }
+
+      // 6. Select the same logical submission the Gradebook reader uses.
+      const submissions =
+        await readRows(
+          await rest(
+            '/rest/v1/submissions' +
+            '?select=*' +
+            `&instance_id=eq.${encodeURIComponent(instance.id)}` +
+            `&or=(school_year.eq.${schoolYear},school_year.is.null)` +
+            '&order=submitted_at.desc' +
+            `&limit=${MAX_SUBMISSIONS}`
+          ),
+          'Submissions query'
+        );
+
+      let submission =
+        selectCanonicalSubmission(
+          submissions
+        );
+
+      let createdSubmission = false;
+
+      if (submission) {
+        // Grade edits change the grade only.
+        // submitted_at remains the student's submission timestamp.
+        const updated =
+          await readRows(
+            await rest(
+              '/rest/v1/submissions' +
+              `?id=eq.${encodeURIComponent(submission.id)}`,
+              {
+                method: 'PATCH',
+                headers: {
+                  Prefer:
+                    'return=representation',
+                },
+                body: JSON.stringify({
+                  score_total:
+                    score,
+                }),
+              }
+            ),
+            'Submission score update'
+          );
+
+        submission =
+          updated[0] || null;
+      } else {
+        const created =
+          await readRows(
+            await rest(
+              '/rest/v1/submissions',
+              {
+                method: 'POST',
+                headers: {
+                  Prefer:
+                    'return=representation',
+                },
+                body: JSON.stringify({
+                  instance_id:
+                    instance.id,
+                  answers: {},
+                  score_total:
+                    score,
+                  school_year:
+                    schoolYear,
+                }),
+              }
+            ),
+            'Submission create'
+          );
+
+        submission =
+          created[0] || null;
+
+        createdSubmission = true;
+      }
+
+      if (
+        !submission ||
+        !isUuid(submission.id)
+      ) {
+        throw new Error(
+          'Submission save returned no row'
+        );
+      }
+
+      // 7. Preserve the legacy process_submission side effect server-side.
+      await requireOk(
+        await rest(
+          '/rest/v1/rpc/process_submission',
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              submission_id:
+                submission.id,
+            }),
+          }
+        ),
+        'process_submission'
+      );
+
+      // 8. Preserve the legacy final instance state.
+      const updatedInstances =
+        await readRows(
+          await rest(
+            '/rest/v1/assignment_instances' +
+            `?id=eq.${encodeURIComponent(instance.id)}`,
+            {
+              method: 'PATCH',
+              headers: {
+                Prefer:
+                  'return=representation',
+              },
+              body: JSON.stringify({
+                status:
+                  'Submitted',
+              }),
+            }
+          ),
+          'Assignment instance status update'
+        );
+
+      const updatedInstance =
+        updatedInstances[0] || {
+          ...instance,
+          status: 'Submitted',
+        };
+
+      return jsonResponse(
+        event,
+        200,
+        {
+          ok: true,
+          created_instance:
+            createdInstance,
+          created_submission:
+            createdSubmission,
+          instance: {
+            ...updatedInstance,
+            student_code:
+              studentCode,
+          },
+          submission,
+        },
+        noStoreHeaders(),
+        requestId
+      );
+    } catch (error) {
+      console.error(
+        `[teacher-gradebook-save-score] [${requestId}]`,
+        error
+      );
+
+      return fail(
+        event,
+        requestId,
+        500,
+        'Failed to save Gradebook score'
+      );
+    }
+  };

--- a/site/web/data-adapter.js
+++ b/site/web/data-adapter.js
@@ -1636,6 +1636,37 @@ const remote = {
     return instances;
   },
   
+  async saveGradebookScore({ assignment_id, student_code, score }) {
+    const response = await fetch('/.netlify/functions/teacher-gradebook-save-score', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        assignmentId: assignment_id,
+        studentCode: student_code,
+        score
+      })
+    });
+
+    const result = await response
+      .json()
+      .catch(() => ({
+        ok: false,
+        error: 'Invalid server response'
+      }));
+
+    if (!response.ok || !result.ok) {
+      throw new Error(
+        result.error ||
+        `Gradebook score save failed: ${response.status}`
+      );
+    }
+
+    return result;
+  },
+
   async upsertAssignmentInstance(x) {
     const supabase = await getSupabase();
     if (!supabase) throw new Error('supabase-not-configured');

--- a/site/web/tc-gradebook.js
+++ b/site/web/tc-gradebook.js
@@ -652,50 +652,43 @@
   async function saveScore(studentCode, draftId, score) {
     try {
       if (usingSupabase) {
-        // Use Supabase via data adapter
-        console.log('[gradebook] Saving score to Supabase:', { studentCode, draftId, score });
-        
-        // Find or create assignment instance
-        let instance = assignmentInstancesData.find(
-          (inst) => inst.assignment_id === draftId && inst.student_code === studentCode
-        );
-        
-        if (!instance) {
-          // Create new instance via data adapter
-          const newInstance = await db.upsertAssignmentInstance({
-            id: draftId + "-" + studentCode,
-            assignment_id: draftId,
-            student_code: studentCode,
-            assigned_at: formatDateYYYYMMDD(),
-            status: "Assigned"
-          });
-          instance = newInstance;
-          assignmentInstancesData.push(instance);
+        console.log('[gradebook] Saving score through signed teacher boundary:', {
+          studentCode,
+          draftId,
+          score
+        });
+
+        const saved = await db.saveGradebookScore({
+          assignment_id: draftId,
+          student_code: studentCode,
+          score
+        });
+
+        if (saved.instance) {
+          const instanceIndex = assignmentInstancesData.findIndex(
+            (item) => item.id === saved.instance.id
+          );
+
+          if (instanceIndex >= 0) {
+            assignmentInstancesData[instanceIndex] = saved.instance;
+          } else {
+            assignmentInstancesData.push(saved.instance);
+          }
         }
-        
-        // Find existing submission or create new one
-        const existingSubmission = submissionsData.find((sub) => sub.instance_id === instance.id);
-        
-        if (existingSubmission) {
-          // Update existing submission (addSubmission acts as upsert when id is provided)
-          await db.addSubmission({
-            id: existingSubmission.id,
-            instance_id: instance.id,
-            score_total: score,
-            submitted_at: new Date().toISOString()
-          });
-          existingSubmission.score_total = score;
-        } else {
-          // Create new submission
-          const newSubmission = await db.addSubmission({
-            instance_id: instance.id,
-            score_total: score,
-            submitted_at: new Date().toISOString()
-          });
-          submissionsData.push(newSubmission);
+
+        if (saved.submission) {
+          const submissionIndex = submissionsData.findIndex(
+            (item) => item.id === saved.submission.id
+          );
+
+          if (submissionIndex >= 0) {
+            submissionsData[submissionIndex] = saved.submission;
+          } else {
+            submissionsData.push(saved.submission);
+          }
         }
-        
-        console.log('[gradebook] Score saved to Supabase');
+
+        console.log('[gradebook] Score saved through signed teacher boundary');
       } else {
         // Use localStorage
         console.log('[gradebook] Saving score to localStorage:', { studentCode, draftId, score });

--- a/tests/teacher-gradebook-save-score-browser-boundary.test.cjs
+++ b/tests/teacher-gradebook-save-score-browser-boundary.test.cjs
@@ -1,0 +1,207 @@
+'use strict';
+
+const assert =
+  require('node:assert/strict');
+
+const fs =
+  require('node:fs');
+
+const path =
+  require('node:path');
+
+const root =
+  path.resolve(
+    __dirname,
+    '..'
+  );
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.join(
+      root,
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+const gradebook =
+  read(
+    'site/web/tc-gradebook.js'
+  );
+
+const adapter =
+  read(
+    'site/web/data-adapter.js'
+  );
+
+const saveStart =
+  gradebook.indexOf(
+    '  async function saveScore('
+  );
+
+const saveEnd =
+  gradebook.indexOf(
+    '  // Make a score cell editable',
+    saveStart
+  );
+
+assert.ok(
+  saveStart >= 0 &&
+  saveEnd > saveStart,
+  'canonical saveScore block must exist'
+);
+
+const saveScore =
+  gradebook.slice(
+    saveStart,
+    saveEnd
+  );
+
+assert.ok(
+  saveScore.includes(
+    'db.saveGradebookScore({'
+  ),
+  'remote Gradebook save must use signed boundary adapter'
+);
+
+assert.equal(
+  saveScore.includes(
+    'db.upsertAssignmentInstance('
+  ),
+  false,
+  'normal saveScore must not write assignment_instances through generic browser adapter'
+);
+
+assert.equal(
+  saveScore.includes(
+    'db.addSubmission('
+  ),
+  false,
+  'normal saveScore must not write submissions through generic browser adapter'
+);
+
+assert.equal(
+  saveScore.includes(
+    'addSubmission acts as upsert'
+  ),
+  false,
+  'false legacy upsert assumption must be retired from canonical saveScore'
+);
+
+const manualStart =
+  gradebook.indexOf(
+    '  async function openManualAssignmentModal('
+  );
+
+assert.ok(
+  manualStart >= 0,
+  'MANUAL_* workflow must still exist'
+);
+
+const manualRegion =
+  gradebook.slice(
+    manualStart
+  );
+
+assert.ok(
+  manualRegion.includes(
+    "const assignmentId = 'MANUAL_' + uid;"
+  ),
+  'D1C2 must not rewrite MANUAL_* workflow'
+);
+
+assert.ok(
+  manualRegion.includes(
+    'db.upsertAssignmentInstance({'
+  ),
+  'MANUAL_* instance writer must remain untouched'
+);
+
+assert.ok(
+  manualRegion.includes(
+    'db.addSubmission({'
+  ),
+  'MANUAL_* submission writer must remain untouched'
+);
+
+const remoteStart =
+  adapter.indexOf(
+    'const remote = {'
+  );
+
+assert.ok(
+  remoteStart >= 0,
+  'remote adapter object must exist'
+);
+
+const remote =
+  adapter.slice(
+    remoteStart
+  );
+
+const gradebookMethodStart =
+  remote.indexOf(
+    '  async saveGradebookScore('
+  );
+
+const nextMethodStart =
+  remote.indexOf(
+    '\n  async upsertAssignmentInstance(',
+    gradebookMethodStart
+  );
+
+assert.ok(
+  gradebookMethodStart >= 0 &&
+  nextMethodStart > gradebookMethodStart,
+  'remote saveGradebookScore method must exist before legacy upsert method'
+);
+
+const gradebookMethod =
+  remote.slice(
+    gradebookMethodStart,
+    nextMethodStart
+  );
+
+assert.ok(
+  gradebookMethod.includes(
+    '/.netlify/functions/teacher-gradebook-save-score'
+  ),
+  'remote adapter must POST to signed Gradebook endpoint'
+);
+
+assert.equal(
+  gradebookMethod.includes(
+    ".from('submissions')"
+  ),
+  false
+);
+
+assert.equal(
+  gradebookMethod.includes(
+    ".from('assignment_instances')"
+  ),
+  false
+);
+
+assert.ok(
+  remote.includes(
+    '  async upsertAssignmentInstance('
+  ),
+  'legacy generic instance writer must remain for later Library/Hub slices'
+);
+
+assert.ok(
+  remote.includes(
+    '  async addSubmission('
+  ),
+  'legacy generic submission writer must remain for later Library/Hub slices'
+);
+
+console.log(
+  'PASS: normal Gradebook score save uses signed canonical boundary'
+);
+
+console.log(
+  'PASS: MANUAL_*, Library/Hub generic mutation bridge remains outside D1C2'
+);

--- a/tests/teacher-gradebook-save-score.test.cjs
+++ b/tests/teacher-gradebook-save-score.test.cjs
@@ -1,0 +1,967 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+
+const endpointPath =
+  path.resolve(
+    __dirname,
+    '../netlify/functions/teacher-gradebook-save-score.js'
+  );
+
+const TEACHER_ID =
+  '11111111-1111-4111-8111-111111111111';
+
+const CLASS_ID =
+  '22222222-2222-4222-8222-222222222222';
+
+const STUDENT_ID =
+  '33333333-3333-4333-8333-333333333333';
+
+const INSTANCE_ID =
+  '44444444-4444-4444-8444-444444444444';
+
+const NEW_INSTANCE_ID =
+  '55555555-5555-4555-8555-555555555555';
+
+const ANSWERED_SUBMISSION_ID =
+  '66666666-6666-4666-8666-666666666666';
+
+const EMPTY_SUBMISSION_ID =
+  '77777777-7777-4777-8777-777777777777';
+
+const NEW_SUBMISSION_ID =
+  '88888888-8888-4888-8888-888888888888';
+
+let authResult;
+let fixtures;
+let calls;
+
+function response(
+  status,
+  data
+) {
+  return {
+    ok:
+      status >= 200 &&
+      status < 300,
+    status,
+    async json() {
+      return data;
+    },
+    async text() {
+      return JSON.stringify(data);
+    },
+  };
+}
+
+function resetFixtures() {
+  authResult = {
+    ok: true,
+    user: {
+      role: 'teacher',
+      teacherId: TEACHER_ID,
+    },
+  };
+
+  calls = [];
+
+  fixtures = {
+    assignmentExists: true,
+    teacherOwnsClass: true,
+    studentExists: true,
+    enrollmentActive: true,
+    instanceCreateConflict: false,
+    instance: {
+      id: INSTANCE_ID,
+      assignment_id: 101,
+      student_id: STUDENT_ID,
+      status: 'Assigned',
+      settings: {},
+      school_year: 2025,
+    },
+    submissions: [],
+  };
+}
+
+function parseBody(options) {
+  if (
+    !options ||
+    !options.body
+  ) {
+    return null;
+  }
+
+  return JSON.parse(
+    options.body
+  );
+}
+
+async function restMock(
+  url,
+  options = {}
+) {
+  const method =
+    options.method || 'GET';
+
+  calls.push({
+    url,
+    method,
+    body:
+      parseBody(options),
+  });
+
+  if (
+    url.startsWith(
+      '/rest/v1/assignments?'
+    )
+  ) {
+    return response(
+      200,
+      fixtures.assignmentExists
+        ? [
+            {
+              id: 101,
+              class_id: CLASS_ID,
+              school_year: 2025,
+            },
+          ]
+        : []
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/classes?'
+    )
+  ) {
+    return response(
+      200,
+      fixtures.teacherOwnsClass
+        ? [{ id: CLASS_ID }]
+        : []
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/students?'
+    )
+  ) {
+    return response(
+      200,
+      fixtures.studentExists
+        ? [
+            {
+              id: STUDENT_ID,
+              code: 'S001',
+              active: true,
+            },
+          ]
+        : []
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/class_enrollments?'
+    )
+  ) {
+    return response(
+      200,
+      fixtures.enrollmentActive
+        ? [
+            {
+              class_id: CLASS_ID,
+              student_id: STUDENT_ID,
+              active: true,
+            },
+          ]
+        : []
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/assignment_instances?'
+    ) &&
+    method === 'GET'
+  ) {
+    return response(
+      200,
+      fixtures.instance
+        ? [fixtures.instance]
+        : []
+    );
+  }
+
+  if (
+    url ===
+      '/rest/v1/assignment_instances' &&
+    method === 'POST'
+  ) {
+    const body =
+      parseBody(options);
+
+    if (
+      fixtures.instanceCreateConflict
+    ) {
+      fixtures.instance = {
+        id: NEW_INSTANCE_ID,
+        ...body,
+      };
+
+      return response(
+        409,
+        {
+          code: '23505',
+          message:
+            'duplicate key value violates unique constraint',
+        }
+      );
+    }
+
+    fixtures.instance = {
+      id: NEW_INSTANCE_ID,
+      ...body,
+    };
+
+    return response(
+      201,
+      [fixtures.instance]
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/assignment_instances?id=eq.'
+    ) &&
+    method === 'PATCH'
+  ) {
+    const body =
+      parseBody(options);
+
+    fixtures.instance = {
+      ...fixtures.instance,
+      ...body,
+    };
+
+    return response(
+      200,
+      [fixtures.instance]
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/submissions?'
+    ) &&
+    method === 'GET'
+  ) {
+    return response(
+      200,
+      fixtures.submissions
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/submissions?id=eq.'
+    ) &&
+    method === 'PATCH'
+  ) {
+    const submissionId =
+      decodeURIComponent(
+        url
+          .split('id=eq.')[1]
+          .split('&')[0]
+      );
+
+    const index =
+      fixtures.submissions.findIndex(
+        (item) =>
+          item.id === submissionId
+      );
+
+    assert.ok(
+      index >= 0,
+      'PATCH must target an existing submission'
+    );
+
+    const body =
+      parseBody(options);
+
+    fixtures.submissions[index] = {
+      ...fixtures.submissions[index],
+      ...body,
+    };
+
+    return response(
+      200,
+      [fixtures.submissions[index]]
+    );
+  }
+
+  if (
+    url === '/rest/v1/submissions' &&
+    method === 'POST'
+  ) {
+    const body =
+      parseBody(options);
+
+    const created = {
+      id: NEW_SUBMISSION_ID,
+      submitted_at:
+        '2026-07-29T20:00:00.000Z',
+      review_status: 'pending',
+      submission_type: 'initial',
+      source_type: 'portal',
+      ...body,
+    };
+
+    fixtures.submissions.push(
+      created
+    );
+
+    return response(
+      201,
+      [created]
+    );
+  }
+
+  if (
+    url ===
+      '/rest/v1/rpc/process_submission' &&
+    method === 'POST'
+  ) {
+    return response(
+      204,
+      null
+    );
+  }
+
+  throw new Error(
+    `Unexpected REST call: ${method} ${url}`
+  );
+}
+
+const originalLoad =
+  Module._load;
+
+Module._load =
+  function patchedLoad(
+    request,
+    parent,
+    isMain
+  ) {
+    if (
+      parent &&
+      parent.filename === endpointPath
+    ) {
+      if (
+        request === './_lib/http'
+      ) {
+        return {
+          generateRequestId:
+            () => 'gradebook-test',
+          jsonResponse:
+            (
+              _event,
+              statusCode,
+              data,
+              headers
+            ) => ({
+              statusCode,
+              headers,
+              body:
+                JSON.stringify(data),
+            }),
+          handleCorsPreFlight:
+            () => ({
+              statusCode: 204,
+              body: '',
+            }),
+        };
+      }
+
+      if (
+        request === './_lib/auth'
+      ) {
+        return {
+          requireTeacher:
+            () => authResult,
+        };
+      }
+
+      if (
+        request === './_lib/supa'
+      ) {
+        return {
+          rest:
+            restMock,
+          SUPABASE_URL:
+            'https://example.supabase.co',
+          SUPABASE_SERVICE_ROLE_KEY:
+            'test-service-role',
+        };
+      }
+
+      if (
+        request === './_lib/school-year'
+      ) {
+        return {
+          getCurrentSchoolYear:
+            () => 2025,
+        };
+      }
+    }
+
+    return originalLoad(
+      request,
+      parent,
+      isMain
+    );
+  };
+
+process.env.SESSION_SECRET =
+  'test-session-secret';
+
+delete require.cache[endpointPath];
+
+const {
+  handler,
+} = require(endpointPath);
+
+Module._load =
+  originalLoad;
+
+function event(body) {
+  return {
+    httpMethod: 'POST',
+    headers: {},
+    body:
+      JSON.stringify(body),
+  };
+}
+
+function payload(result) {
+  return JSON.parse(
+    result.body
+  );
+}
+
+async function run() {
+  let passed = 0;
+
+  resetFixtures();
+
+  authResult = {
+    ok: false,
+  };
+
+  let result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 80,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    401
+  );
+
+  assert.equal(
+    calls.length,
+    0
+  );
+
+  console.log(
+    'OK unauthenticated request stops before Supabase'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  result =
+    await handler(
+      event({
+        assignmentId:
+          'MANUAL_NOT_CANONICAL',
+        studentCode: 'S001',
+        score: 80,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    400
+  );
+
+  assert.equal(
+    calls.length,
+    0
+  );
+
+  console.log(
+    'OK non-canonical MANUAL_* assignment IDs are rejected'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.teacherOwnsClass =
+    false;
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 80,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    404
+  );
+
+  assert.equal(
+    calls.some(
+      (call) =>
+        call.method !== 'GET'
+    ),
+    false
+  );
+
+  console.log(
+    'OK another teacher class fails before mutation'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.enrollmentActive =
+    false;
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 80,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    404
+  );
+
+  assert.equal(
+    calls.some(
+      (call) =>
+        call.method !== 'GET'
+    ),
+    false
+  );
+
+  console.log(
+    'OK same-class active enrollment is mandatory'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.instance.settings = {
+    non_instructional: true,
+  };
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 80,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    404
+  );
+
+  assert.equal(
+    calls.some(
+      (call) =>
+        call.method !== 'GET'
+    ),
+    false
+  );
+
+  console.log(
+    'OK non-instructional instance fails closed'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.submissions = [
+    {
+      id: EMPTY_SUBMISSION_ID,
+      instance_id: INSTANCE_ID,
+      answers: {},
+      score_total: null,
+      submitted_at:
+        '2026-03-10T12:00:00.000Z',
+      review_status: 'pending',
+      submission_type: 'resubmission',
+      original_submission_id:
+        ANSWERED_SUBMISSION_ID,
+      feedback: 'keep me',
+      school_year: 2025,
+    },
+    {
+      id: ANSWERED_SUBMISSION_ID,
+      instance_id: INSTANCE_ID,
+      answers: {
+        q1: 'A',
+      },
+      score_total: 50,
+      submitted_at:
+        '2026-02-10T12:00:00.000Z',
+      review_status: 'finalized',
+      submission_type: 'initial',
+      original_submission_id: null,
+      feedback: 'preserve me',
+      school_year: 2025,
+    },
+  ];
+
+  const originalSubmittedAt =
+    fixtures.submissions[1]
+      .submitted_at;
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 0,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    200
+  );
+
+  const updatedPayload =
+    payload(result);
+
+  assert.equal(
+    updatedPayload.submission.id,
+    ANSWERED_SUBMISSION_ID,
+    'answered work must beat newer empty shell'
+  );
+
+  assert.equal(
+    updatedPayload.submission.score_total,
+    0,
+    'score zero must remain numeric zero'
+  );
+
+  assert.equal(
+    updatedPayload.submission.submitted_at,
+    originalSubmittedAt,
+    'teacher grade edit must preserve submitted_at'
+  );
+
+  assert.equal(
+    updatedPayload.submission.review_status,
+    'finalized'
+  );
+
+  assert.equal(
+    updatedPayload.submission.feedback,
+    'preserve me'
+  );
+
+  assert.deepEqual(
+    updatedPayload.submission.answers,
+    {
+      q1: 'A',
+    }
+  );
+
+  const submissionPatches =
+    calls.filter(
+      (call) =>
+        call.method === 'PATCH' &&
+        call.url.startsWith(
+          '/rest/v1/submissions?id=eq.'
+        )
+    );
+
+  assert.equal(
+    submissionPatches.length,
+    1
+  );
+
+  assert.deepEqual(
+    submissionPatches[0].body,
+    {
+      score_total: 0,
+    },
+    'existing grade edit must PATCH score_total only'
+  );
+
+  assert.equal(
+    calls.filter(
+      (call) =>
+        call.method === 'POST' &&
+        call.url ===
+          '/rest/v1/submissions'
+    ).length,
+    0,
+    'existing grade must not manufacture a duplicate submission'
+  );
+
+  assert.equal(
+    calls.filter(
+      (call) =>
+        call.url ===
+          '/rest/v1/rpc/process_submission'
+    ).length,
+    1,
+    'legacy processing side effect remains server-side'
+  );
+
+  assert.equal(
+    fixtures.instance.status,
+    'Submitted'
+  );
+
+  console.log(
+    'OK existing answered submission is updated without duplicate or timestamp rewrite'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.instance =
+    null;
+
+  fixtures.submissions =
+    [];
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 75,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    200
+  );
+
+  const createdPayload =
+    payload(result);
+
+  assert.equal(
+    createdPayload.created_instance,
+    true
+  );
+
+  assert.equal(
+    createdPayload.created_submission,
+    true
+  );
+
+  assert.equal(
+    createdPayload.submission.score_total,
+    75
+  );
+
+  assert.deepEqual(
+    createdPayload.submission.answers,
+    {}
+  );
+
+  assert.equal(
+    createdPayload.submission.school_year,
+    2025
+  );
+
+  assert.equal(
+    createdPayload.instance.status,
+    'Submitted'
+  );
+
+  const instanceCreate =
+    calls.find(
+      (call) =>
+        call.method === 'POST' &&
+        call.url ===
+          '/rest/v1/assignment_instances'
+    );
+
+  assert.ok(
+    instanceCreate
+  );
+
+  assert.deepEqual(
+    instanceCreate.body,
+    {
+      assignment_id: 101,
+      student_id: STUDENT_ID,
+      status: 'Assigned',
+      settings: {},
+      school_year: 2025,
+    }
+  );
+
+  const submissionCreate =
+    calls.find(
+      (call) =>
+        call.method === 'POST' &&
+        call.url ===
+          '/rest/v1/submissions'
+    );
+
+  assert.ok(
+    submissionCreate
+  );
+
+  assert.deepEqual(
+    submissionCreate.body,
+    {
+      instance_id:
+        NEW_INSTANCE_ID,
+      answers: {},
+      score_total: 75,
+      school_year: 2025,
+    }
+  );
+
+  console.log(
+    'OK missing instance/submission are created canonically'
+  );
+
+  passed++;
+
+  resetFixtures();
+
+  fixtures.instance =
+    null;
+
+  fixtures.instanceCreateConflict =
+    true;
+
+  fixtures.submissions =
+    [];
+
+  result =
+    await handler(
+      event({
+        assignmentId: 101,
+        studentCode: 'S001',
+        score: 65,
+      })
+    );
+
+  assert.equal(
+    result.statusCode,
+    200
+  );
+
+  const racePayload =
+    payload(result);
+
+  assert.equal(
+    racePayload.created_instance,
+    false,
+    'request losing instance-create race must reuse canonical row'
+  );
+
+  assert.equal(
+    racePayload.created_submission,
+    true
+  );
+
+  assert.equal(
+    racePayload.instance.id,
+    NEW_INSTANCE_ID
+  );
+
+  assert.equal(
+    racePayload.submission.instance_id,
+    NEW_INSTANCE_ID
+  );
+
+  assert.equal(
+    racePayload.submission.score_total,
+    65
+  );
+
+  const instanceReads =
+    calls.filter(
+      (call) =>
+        call.method === 'GET' &&
+        call.url.startsWith(
+          '/rest/v1/assignment_instances?'
+        )
+    );
+
+  assert.equal(
+    instanceReads.length,
+    2,
+    'race recovery must re-read exact canonical instance'
+  );
+
+  assert.equal(
+    calls.filter(
+      (call) =>
+        call.method === 'POST' &&
+        call.url ===
+          '/rest/v1/assignment_instances'
+    ).length,
+    1
+  );
+
+  console.log(
+    'OK concurrent instance creation conflict reuses canonical instance'
+  );
+
+  passed++;
+
+  console.log();
+  console.log(
+    `${passed} passed, 0 failed`
+  );
+
+  console.log(
+    'RC-SEC-01I-D1C2 teacher Gradebook score endpoint tests PASS'
+  );
+}
+
+run().catch(
+  (error) => {
+    console.error(error);
+    process.exitCode = 1;
+  }
+);


### PR DESCRIPTION
## RC-SEC-01I-D1C2

Moves the normal canonical-assignment Gradebook score-save path behind a signed teacher server boundary.

### Security boundary

- signed teacher session
- canonical numeric assignment
- exact assignment class
- exact signed-teacher class ownership
- active student
- active same-class enrollment
- canonical assignment instance
- canonical Gradebook submission

No authorization is derived from legacy class-name/series inference, browser-supplied instance IDs, or browser-supplied submission IDs.

### Data-integrity behavior

- existing Gradebook submission is updated rather than duplicated
- teacher grade edits preserve the original `submitted_at`
- score `0` remains numeric zero
- answered submissions retain precedence over newer empty shells
- missing canonical assignment instances are created safely
- concurrent instance-creation conflicts recover the canonical unique row
- legacy `process_submission` side effect remains server-side
- resulting assignment-instance status remains `Submitted`

### Scope intentionally excluded

- `MANUAL_*` Gradebook workflow
- Library result workflows
- Hub
- Teacher Archive
- database privilege/RLS containment
- RC-13D historical retirement

### Verification completed before push

- targeted D1C2 endpoint tests: PASS
- browser-boundary regression: PASS
- instance-creation race regression: PASS
- critical donor/security regressions: PASS
- full lint: PASS
- full unit suite: PASS
- full test suite: PASS
- smoke: PASS
- committed-history cache-bust check: PASS
- exact five-file committed scope: PASS
- database/schema/data mutation: NONE

Feature commit:
`368021c3d850ba7ca6a56f0f92d4cf1540c2a408`

Parent:
`4b0fde600b9069a397cb1ad1a1bcac60e6a6d27a`
