### PR TITLE
RC-SEC-01I-D1C3A: sign Library paper assignment creation

### DIFF
--- a/netlify/functions/teacher-paper-assignment-create.js
+++ b/netlify/functions/teacher-paper-assignment-create.js
@@ -1,0 +1,435 @@
+'use strict';
+
+// Signed Teacher Center paper-assignment creator.
+//
+// Scope:
+//   Remote Library "Upload Paper Assignment" creation only.
+//
+// Security boundary:
+//   signed teacherId
+//     -> exact requested class name
+//     -> classes.teacher_id == signed teacherId
+//     -> canonical class UUID
+//     -> canonical numeric assignments row
+//
+// The browser may request a class NAME from the existing picker.
+// It may not supply or authorize class_id, assignment type, series,
+// school year, or teacher ownership.
+//
+// No authorization fallback:
+//   - no unscoped class-name lookup
+//   - no class adoption
+//   - no auto-create class
+//   - no series-based authorization
+//   - no lookupActiveTeacherId()
+//   - no is_teacher_of()
+
+const {
+  generateRequestId,
+  handleCorsPreFlight,
+} = require('./_lib/http');
+
+const {
+  requireTeacher,
+} = require('./_lib/auth');
+
+const {
+  rest,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = require('./_lib/supa');
+
+const {
+  getCurrentSchoolYear,
+} = require('./_lib/school-year');
+
+const {
+  SESSION_SECRET,
+} = process.env;
+
+const MAX_BODY_BYTES = 65536;
+const MAX_TITLE_LENGTH = 500;
+const MAX_CLASS_NAME_LENGTH = 200;
+const MAX_PAGE_LENGTH = 4096;
+
+function isUuid(value) {
+  return (
+    typeof value === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      .test(value)
+  );
+}
+
+function cleanRequiredText(
+  value,
+  maxLength
+) {
+  const text =
+    typeof value === 'string'
+      ? value.trim()
+      : '';
+
+  if (
+    !text ||
+    text.length > maxLength
+  ) {
+    return null;
+  }
+
+  return text;
+}
+
+function normalizeMeta(value) {
+  if (
+    value === undefined ||
+    value === null
+  ) {
+    return {};
+  }
+
+  if (
+    typeof value !== 'object' ||
+    Array.isArray(value)
+  ) {
+    return null;
+  }
+
+  return value;
+}
+
+function response(
+  statusCode,
+  requestId,
+  payload
+) {
+  return {
+    statusCode,
+    headers: {
+      'Content-Type':
+        'application/json; charset=utf-8',
+      'Cache-Control':
+        'no-store',
+      'X-Request-Id':
+        requestId,
+    },
+    body:
+      JSON.stringify(payload),
+  };
+}
+
+function fail(
+  requestId,
+  statusCode,
+  error
+) {
+  return response(
+    statusCode,
+    requestId,
+    {
+      ok: false,
+      error,
+    }
+  );
+}
+
+async function readRows(
+  restResponse,
+  label
+) {
+  if (
+    !restResponse ||
+    restResponse.ok !== true
+  ) {
+    const status =
+      restResponse &&
+      Number.isInteger(restResponse.status)
+        ? restResponse.status
+        : 0;
+
+    let detail = '';
+
+    if (
+      restResponse &&
+      typeof restResponse.text === 'function'
+    ) {
+      detail =
+        await restResponse
+          .text()
+          .catch(() => '');
+    }
+
+    throw new Error(
+      `${label} failed: ${status}` +
+      (
+        detail
+          ? ` ${detail.slice(0, 160)}`
+          : ''
+      )
+    );
+  }
+
+  const body =
+    await restResponse
+      .json()
+      .catch(() => []);
+
+  return Array.isArray(body)
+    ? body
+    : [];
+}
+
+exports.handler =
+  async (event) => {
+    const requestId =
+      generateRequestId();
+
+    if (event.httpMethod === 'OPTIONS') {
+      return handleCorsPreFlight(
+        event,
+        ['POST', 'OPTIONS'],
+        ['Content-Type']
+      );
+    }
+
+    if (event.httpMethod !== 'POST') {
+      return fail(
+        requestId,
+        405,
+        'Method Not Allowed'
+      );
+    }
+
+    if (!SESSION_SECRET) {
+      return fail(
+        requestId,
+        500,
+        'Server not configured'
+      );
+    }
+
+    const teacherAuth =
+      requireTeacher(
+        event,
+        SESSION_SECRET
+      );
+
+    if (!teacherAuth.ok) {
+      return fail(
+        requestId,
+        401,
+        'Unauthorized'
+      );
+    }
+
+    if (
+      !SUPABASE_URL ||
+      !SUPABASE_SERVICE_ROLE_KEY
+    ) {
+      return fail(
+        requestId,
+        503,
+        'Service unavailable'
+      );
+    }
+
+    const teacherId =
+      teacherAuth.user &&
+      teacherAuth.user.teacherId;
+
+    if (!isUuid(teacherId)) {
+      return fail(
+        requestId,
+        403,
+        'Teacher identity unavailable'
+      );
+    }
+
+    const rawBody =
+      event.body || '';
+
+    if (
+      Buffer.byteLength(
+        rawBody,
+        'utf8'
+      ) > MAX_BODY_BYTES
+    ) {
+      return fail(
+        requestId,
+        413,
+        'Request body too large'
+      );
+    }
+
+    let body;
+
+    try {
+      body =
+        JSON.parse(
+          rawBody || '{}'
+        );
+    } catch {
+      return fail(
+        requestId,
+        400,
+        'Invalid JSON'
+      );
+    }
+
+    const title =
+      cleanRequiredText(
+        body.title,
+        MAX_TITLE_LENGTH
+      );
+
+    const className =
+      cleanRequiredText(
+        body.className,
+        MAX_CLASS_NAME_LENGTH
+      );
+
+    const page =
+      cleanRequiredText(
+        body.page,
+        MAX_PAGE_LENGTH
+      );
+
+    const meta =
+      normalizeMeta(
+        body.meta
+      );
+
+    if (!title) {
+      return fail(
+        requestId,
+        400,
+        'Invalid title'
+      );
+    }
+
+    if (!className) {
+      return fail(
+        requestId,
+        400,
+        'Invalid className'
+      );
+    }
+
+    if (!page) {
+      return fail(
+        requestId,
+        400,
+        'Invalid page'
+      );
+    }
+
+    if (meta === null) {
+      return fail(
+        requestId,
+        400,
+        'Invalid meta'
+      );
+    }
+
+    const schoolYear =
+      getCurrentSchoolYear();
+
+    try {
+      // Resolve the requested display name ONLY within classes
+      // canonically owned by the signed teacher.
+      const ownedClasses =
+        await readRows(
+          await rest(
+            '/rest/v1/classes' +
+            '?select=id,name,teacher_id' +
+            `&name=eq.${encodeURIComponent(className)}` +
+            `&teacher_id=eq.${encodeURIComponent(teacherId)}` +
+            '&limit=2'
+          ),
+          'Owned class query'
+        );
+
+      if (
+        ownedClasses.length !== 1 ||
+        !isUuid(
+          ownedClasses[0].id
+        )
+      ) {
+        return fail(
+          requestId,
+          404,
+          'Class not found'
+        );
+      }
+
+      const classId =
+        ownedClasses[0].id;
+
+      const assignmentMeta = {
+        ...meta,
+        paper: true,
+      };
+
+      const assignmentPayload = {
+        title,
+        type: 'paper',
+        series: className,
+        page,
+        meta: assignmentMeta,
+        class_id: classId,
+        school_year: schoolYear,
+      };
+
+      const created =
+        await readRows(
+          await rest(
+            '/rest/v1/assignments' +
+            '?select=id,title,type,series,page,meta,class_id,school_year',
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type':
+                  'application/json',
+                Prefer:
+                  'return=representation',
+              },
+              body:
+                JSON.stringify(
+                  assignmentPayload
+                ),
+            }
+          ),
+          'Paper assignment create'
+        );
+
+      if (
+        created.length !== 1 ||
+        created[0].class_id !== classId ||
+        created[0].type !== 'paper'
+      ) {
+        throw new Error(
+          'Paper assignment create returned unexpected representation'
+        );
+      }
+
+      return response(
+        201,
+        requestId,
+        {
+          ok: true,
+          assignment:
+            created[0],
+        }
+      );
+    } catch (error) {
+      console.error(
+        `[teacher-paper-assignment-create] [${requestId}]`,
+        error
+      );
+
+      return fail(
+        requestId,
+        500,
+        'Could not create paper assignment'
+      );
+    }
+  };

--- a/site/web/data-adapter.js
+++ b/site/web/data-adapter.js
@@ -1529,6 +1529,39 @@ const remote = {
     });
   },
 
+  // Create a paper assignment through the signed Teacher Center boundary.
+  async createPaperAssignment({ title, class_name, page, meta }) {
+    const response = await fetch('/.netlify/functions/teacher-paper-assignment-create', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        title,
+        className: class_name,
+        page,
+        meta
+      })
+    });
+
+    const result = await response
+      .json()
+      .catch(() => ({
+        ok: false,
+        error: 'Invalid server response'
+      }));
+
+    if (!response.ok || !result.ok || !result.assignment) {
+      throw new Error(
+        result.error ||
+        `Paper assignment create failed: ${response.status}`
+      );
+    }
+
+    return result.assignment;
+  },
+
   // Upload a paper assignment file to Supabase Storage (bucket: assignments)
   // Returns the public URL on success, throws on failure
   async uploadPaperFile(file, storagePath) {

--- a/site/web/tc-library.js
+++ b/site/web/tc-library.js
@@ -9287,10 +9287,13 @@
     // Class
     const classSelect = document.createElement('select');
     classSelect.id = 'up_class';
+    classSelect.required = Boolean(isRemote);
     classSelect.style.cssText = fieldStyle;
     const defaultClassOpt = document.createElement('option');
     defaultClassOpt.value = '';
-    defaultClassOpt.textContent = '\u2014 Select class (optional) \u2014';
+    defaultClassOpt.textContent = isRemote
+      ? '\u2014 Select class \u2014'
+      : '\u2014 Select class (optional) \u2014';
     classSelect.appendChild(defaultClassOpt);
     CANON_CLASSES.forEach(cls => {
       const opt = document.createElement('option');
@@ -9298,7 +9301,7 @@
       opt.textContent = cls;
       classSelect.appendChild(opt);
     });
-    form.appendChild(makeField('Class', false, classSelect));
+    form.appendChild(makeField('Class', Boolean(isRemote), classSelect));
 
     // Student Code
     const studentInput = document.createElement('input');
@@ -9487,6 +9490,12 @@
       return;
     }
 
+    if (isRemote && !className) {
+      showInlineError('Class is required for paper assignments.');
+      overlay.querySelector('#up_class').focus();
+      return;
+    }
+
     if (scoreEarned !== null) {
       if (!studentCode) {
         showInlineError('Student Code is required when entering a grade.');
@@ -9578,10 +9587,9 @@
 
         let newAssignment;
         try {
-          newAssignment = await db.createAssignment({
+          newAssignment = await db.createPaperAssignment({
             title,
-            type: 'paper',
-            series: className || null,
+            class_name: className,
             page: paperUploadUrl,
             meta: assignmentMeta,
           });

--- a/tests/teacher-paper-assignment-create-browser-boundary.test.cjs
+++ b/tests/teacher-paper-assignment-create-browser-boundary.test.cjs
@@ -1,0 +1,232 @@
+'use strict';
+
+const assert =
+  require('node:assert/strict');
+
+const fs =
+  require('node:fs');
+
+const path =
+  require('node:path');
+
+const root =
+  path.resolve(
+    __dirname,
+    '..'
+  );
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.join(
+      root,
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+const library =
+  read(
+    'site/web/tc-library.js'
+  );
+
+const adapter =
+  read(
+    'site/web/data-adapter.js'
+  );
+
+const uploadStart =
+  library.indexOf(
+    '  async function uploadPaperAssignment('
+  );
+
+const successStart =
+  library.indexOf(
+    '      // Success',
+    uploadStart
+  );
+
+assert.ok(
+  uploadStart >= 0 &&
+  successStart > uploadStart,
+  'paper upload workflow must exist'
+);
+
+const uploadRegion =
+  library.slice(
+    uploadStart,
+    successStart
+  );
+
+const remoteStart =
+  uploadRegion.indexOf(
+    '      if (isRemote) {'
+  );
+
+const localStart =
+  uploadRegion.indexOf(
+    '      } else {',
+    remoteStart
+  );
+
+assert.ok(
+  remoteStart >= 0 &&
+  localStart > remoteStart,
+  'remote/local paper branches must remain distinct'
+);
+
+const remoteRegion =
+  uploadRegion.slice(
+    remoteStart,
+    localStart
+  );
+
+const localRegion =
+  uploadRegion.slice(
+    localStart
+  );
+
+assert.ok(
+  remoteRegion.includes(
+    'newAssignment = await db.createPaperAssignment({'
+  ),
+  'remote paper path must use signed paper create boundary'
+);
+
+assert.equal(
+  remoteRegion.includes(
+    'db.createAssignment({'
+  ),
+  false,
+  'remote paper path must not directly create assignments'
+);
+
+assert.ok(
+  localRegion.includes(
+    'const newAssignment = await db.createAssignment({'
+  ),
+  'local paper path must retain existing local createAssignment behavior'
+);
+
+assert.ok(
+  localRegion.includes(
+    "type: 'paper'"
+  ),
+  'local paper assignment type must remain unchanged'
+);
+
+assert.ok(
+  library.includes(
+    'classSelect.required = Boolean(isRemote);'
+  ),
+  'remote paper class picker must be required'
+);
+
+assert.ok(
+  uploadRegion.includes(
+    'if (isRemote && !className) {'
+  ),
+  'remote paper submit must fail before upload when class is missing'
+);
+
+assert.ok(
+  uploadRegion.includes(
+    "showInlineError('Class is required for paper assignments.');"
+  ),
+  'remote missing-class failure must be visible to teacher'
+);
+
+const adapterRemoteStart =
+  adapter.indexOf(
+    'const remote = {'
+  );
+
+assert.ok(
+  adapterRemoteStart >= 0,
+  'remote adapter object must exist'
+);
+
+const adapterRemote =
+  adapter.slice(
+    adapterRemoteStart
+  );
+
+const paperMethodStart =
+  adapterRemote.indexOf(
+    '  async createPaperAssignment('
+  );
+
+const paperMethodEnd =
+  adapterRemote.indexOf(
+    '\n  async uploadPaperFile(',
+    paperMethodStart
+  );
+
+assert.ok(
+  paperMethodStart >= 0 &&
+  paperMethodEnd > paperMethodStart,
+  'remote createPaperAssignment adapter method must exist'
+);
+
+const paperMethod =
+  adapterRemote.slice(
+    paperMethodStart,
+    paperMethodEnd
+  );
+
+assert.ok(
+  paperMethod.includes(
+    '/.netlify/functions/teacher-paper-assignment-create'
+  ),
+  'paper adapter must call signed server endpoint'
+);
+
+assert.ok(
+  paperMethod.includes(
+    "credentials: 'include'"
+  ),
+  'paper adapter must send teacher session cookie'
+);
+
+assert.equal(
+  paperMethod.includes(
+    ".from('assignments')"
+  ),
+  false,
+  'paper adapter method must not directly write assignments table'
+);
+
+const genericCreateCalls =
+  (
+    library.match(
+      /db\.createAssignment\s*\(/g
+    ) || []
+  ).length;
+
+assert.equal(
+  genericCreateCalls,
+  3,
+  'only local paper + existing clone/general createAssignment callers should remain'
+);
+
+assert.ok(
+  library.includes(
+    'newAssignment = await db.createAssignment(newAssignmentPayload);'
+  ),
+  'clone/general Library creation must remain untouched'
+);
+
+assert.ok(
+  adapterRemote.includes(
+    '  async createAssignment('
+  ),
+  'generic remote createAssignment must remain for later scoped work'
+);
+
+console.log(
+  'PASS: remote Library paper creation uses signed canonical boundary'
+);
+
+console.log(
+  'PASS: local paper workflow and clone/general Library creation remain untouched'
+);

--- a/tests/teacher-paper-assignment-create.test.cjs
+++ b/tests/teacher-paper-assignment-create.test.cjs
@@ -1,0 +1,550 @@
+'use strict';
+
+const assert =
+  require('node:assert/strict');
+
+const Module =
+  require('node:module');
+
+const path =
+  require('node:path');
+
+const endpointPath =
+  path.resolve(
+    __dirname,
+    '../netlify/functions/teacher-paper-assignment-create.js'
+  );
+
+const TEACHER_ID =
+  '11111111-1111-4111-8111-111111111111';
+
+const OTHER_TEACHER_ID =
+  '99999999-9999-4999-8999-999999999999';
+
+const CLASS_ID =
+  '22222222-2222-4222-8222-222222222222';
+
+const CLASS_NAME =
+  'Language Arts 1 SC';
+
+let authResult;
+let fixtures;
+let calls;
+
+function restResponse(
+  status,
+  data
+) {
+  return {
+    ok:
+      status >= 200 &&
+      status < 300,
+    status,
+    async json() {
+      return data;
+    },
+    async text() {
+      return JSON.stringify(
+        data
+      );
+    },
+  };
+}
+
+function parseBody(options) {
+  if (
+    !options ||
+    !options.body
+  ) {
+    return null;
+  }
+
+  return JSON.parse(
+    options.body
+  );
+}
+
+function reset() {
+  authResult = {
+    ok: true,
+    user: {
+      role: 'teacher',
+      teacherId: TEACHER_ID,
+    },
+  };
+
+  fixtures = {
+    ownedClassMatches: 1,
+  };
+
+  calls = [];
+}
+
+async function restMock(
+  url,
+  options = {}
+) {
+  const method =
+    options.method || 'GET';
+
+  const body =
+    parseBody(options);
+
+  calls.push({
+    url,
+    method,
+    body,
+    headers:
+      options.headers || {},
+  });
+
+  if (
+    url.startsWith(
+      '/rest/v1/classes?'
+    )
+  ) {
+    if (
+      fixtures.ownedClassMatches === 0
+    ) {
+      return restResponse(
+        200,
+        []
+      );
+    }
+
+    if (
+      fixtures.ownedClassMatches === 2
+    ) {
+      return restResponse(
+        200,
+        [
+          {
+            id: CLASS_ID,
+            name: CLASS_NAME,
+            teacher_id: TEACHER_ID,
+          },
+          {
+            id:
+              '33333333-3333-4333-8333-333333333333',
+            name: CLASS_NAME,
+            teacher_id: TEACHER_ID,
+          },
+        ]
+      );
+    }
+
+    return restResponse(
+      200,
+      [
+        {
+          id: CLASS_ID,
+          name: CLASS_NAME,
+          teacher_id: TEACHER_ID,
+        },
+      ]
+    );
+  }
+
+  if (
+    url.startsWith(
+      '/rest/v1/assignments?'
+    ) &&
+    method === 'POST'
+  ) {
+    return restResponse(
+      201,
+      [
+        {
+          id: 901,
+          ...body,
+        },
+      ]
+    );
+  }
+
+  throw new Error(
+    `Unexpected REST call: ${method} ${url}`
+  );
+}
+
+const originalLoad =
+  Module._load;
+
+process.env.SESSION_SECRET =
+  'test-session-secret';
+
+Module._load =
+  function patchedLoad(
+    request,
+    parent,
+    isMain
+  ) {
+    if (
+      request === './_lib/http'
+    ) {
+      return {
+        generateRequestId() {
+          return 'req-test';
+        },
+        handleCorsPreFlight() {
+          return {
+            statusCode: 204,
+            headers: {},
+            body: '',
+          };
+        },
+      };
+    }
+
+    if (
+      request === './_lib/auth'
+    ) {
+      return {
+        requireTeacher() {
+          return authResult;
+        },
+      };
+    }
+
+    if (
+      request === './_lib/supa'
+    ) {
+      return {
+        rest: restMock,
+        SUPABASE_URL:
+          'https://example.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY:
+          'service-role-test',
+      };
+    }
+
+    if (
+      request === './_lib/school-year'
+    ) {
+      return {
+        getCurrentSchoolYear() {
+          return 2025;
+        },
+      };
+    }
+
+    return originalLoad.call(
+      this,
+      request,
+      parent,
+      isMain
+    );
+  };
+
+delete require.cache[
+  require.resolve(endpointPath)
+];
+
+const {
+  handler,
+} = require(endpointPath);
+
+Module._load =
+  originalLoad;
+
+function parseResponse(result) {
+  return {
+    statusCode:
+      result.statusCode,
+    body:
+      result.body
+        ? JSON.parse(result.body)
+        : null,
+  };
+}
+
+async function invoke(
+  body,
+  method = 'POST'
+) {
+  return parseResponse(
+    await handler({
+      httpMethod: method,
+      headers: {},
+      body:
+        body === undefined
+          ? ''
+          : JSON.stringify(body),
+    })
+  );
+}
+
+async function test(
+  name,
+  fn
+) {
+  try {
+    reset();
+    await fn();
+    console.log(
+      `PASS: ${name}`
+    );
+  } catch (error) {
+    console.error(
+      `FAIL: ${name}`
+    );
+    throw error;
+  }
+}
+
+(async () => {
+  await test(
+    'unauthenticated request fails closed',
+    async () => {
+      authResult = {
+        ok: false,
+      };
+
+      const result =
+        await invoke({
+          title: 'Paper',
+          className: CLASS_NAME,
+          page: 'https://example.test/paper.pdf',
+          meta: {},
+        });
+
+      assert.equal(
+        result.statusCode,
+        401
+      );
+
+      assert.equal(
+        calls.length,
+        0
+      );
+    }
+  );
+
+  await test(
+    'remote paper creation requires class name',
+    async () => {
+      const result =
+        await invoke({
+          title: 'Paper',
+          className: '',
+          page: 'https://example.test/paper.pdf',
+          meta: {},
+        });
+
+      assert.equal(
+        result.statusCode,
+        400
+      );
+
+      assert.equal(
+        calls.length,
+        0
+      );
+    }
+  );
+
+  await test(
+    'class not owned by signed teacher fails closed',
+    async () => {
+      fixtures.ownedClassMatches = 0;
+
+      const result =
+        await invoke({
+          title: 'Paper',
+          className: CLASS_NAME,
+          page: 'https://example.test/paper.pdf',
+          meta: {},
+        });
+
+      assert.equal(
+        result.statusCode,
+        404
+      );
+
+      assert.equal(
+        calls.length,
+        1
+      );
+
+      assert.ok(
+        calls[0].url.includes(
+          `teacher_id=eq.${encodeURIComponent(TEACHER_ID)}`
+        )
+      );
+
+      assert.equal(
+        calls.some(
+          call =>
+            call.method === 'POST'
+        ),
+        false
+      );
+    }
+  );
+
+  await test(
+    'ambiguous owned class lookup fails closed',
+    async () => {
+      fixtures.ownedClassMatches = 2;
+
+      const result =
+        await invoke({
+          title: 'Paper',
+          className: CLASS_NAME,
+          page: 'https://example.test/paper.pdf',
+          meta: {},
+        });
+
+      assert.equal(
+        result.statusCode,
+        404
+      );
+
+      assert.equal(
+        calls.some(
+          call =>
+            call.method === 'POST'
+        ),
+        false
+      );
+    }
+  );
+
+  await test(
+    'valid teacher-owned class creates canonical paper assignment',
+    async () => {
+      const result =
+        await invoke({
+          title: '  Paper Evidence  ',
+          className: CLASS_NAME,
+          page:
+            'https://example.test/paper.pdf',
+          meta: {
+            paper: false,
+            original_filename:
+              'paper.pdf',
+          },
+
+          // These browser values must have no authority.
+          classId:
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          teacherId:
+            OTHER_TEACHER_ID,
+          type:
+            'html',
+          series:
+            'Definitely Not The Class',
+          school_year:
+            1900,
+        });
+
+      assert.equal(
+        result.statusCode,
+        201
+      );
+
+      assert.equal(
+        result.body.ok,
+        true
+      );
+
+      assert.equal(
+        result.body.assignment.id,
+        901
+      );
+
+      const classCall =
+        calls.find(
+          call =>
+            call.url.startsWith(
+              '/rest/v1/classes?'
+            )
+        );
+
+      assert.ok(
+        classCall
+      );
+
+      assert.ok(
+        classCall.url.includes(
+          `name=eq.${encodeURIComponent(CLASS_NAME)}`
+        )
+      );
+
+      assert.ok(
+        classCall.url.includes(
+          `teacher_id=eq.${encodeURIComponent(TEACHER_ID)}`
+        )
+      );
+
+      assert.equal(
+        classCall.method,
+        'GET',
+        'canonical class resolution must be read-only'
+      );
+
+      assert.equal(
+        calls.some(
+          call =>
+            call.url.startsWith('/rest/v1/classes') &&
+            call.method !== 'GET'
+        ),
+        false,
+        'paper creation must never create, adopt, patch, or otherwise mutate classes'
+      );
+
+      const createCall =
+        calls.find(
+          call =>
+            call.method === 'POST' &&
+            call.url.startsWith(
+              '/rest/v1/assignments?'
+            )
+        );
+
+      assert.ok(
+        createCall
+      );
+
+      assert.deepEqual(
+        createCall.body,
+        {
+          title:
+            'Paper Evidence',
+          type:
+            'paper',
+          series:
+            CLASS_NAME,
+          page:
+            'https://example.test/paper.pdf',
+          meta: {
+            paper: true,
+            original_filename:
+              'paper.pdf',
+          },
+          class_id:
+            CLASS_ID,
+          school_year:
+            2025,
+        }
+      );
+
+      assert.equal(
+        createCall.headers.Prefer,
+        'return=representation'
+      );
+    }
+  );
+
+  console.log();
+  console.log(
+    'PASS: teacher-paper-assignment-create targeted endpoint tests'
+  );
+})().catch(
+  error => {
+    console.error(
+      error
+    );
+    process.exitCode = 1;
+  }
+);


### PR DESCRIPTION
## RC-SEC-01I-D1C3A

Moves remote Library paper-assignment creation behind a signed Teacher Center boundary.

### Security boundary

- signed teacher session
- signed `teacherId`
- exact requested class name scoped to `classes.teacher_id`
- exactly one canonical teacher-owned `class_id`
- server-controlled `type = paper`
- server-controlled `series`
- server-controlled `school_year`
- server-enforced `meta.paper = true`

The browser cannot authorize or override `class_id`, `teacherId`, assignment type, series, or school year.

No fallback through `lookupActiveTeacherId()`, `is_teacher_of()`, unscoped class-name lookup, class adoption, or class auto-creation.

### Preserved

- local paper workflow
- Library clone/general `createAssignment`
- paper file upload/delete behavior
- submission archive/result workflow for later D1C3B
- Gradebook MANUAL workflow for later D1C3C

### Production prerequisite

The production `assignment_type` enum was separately verified and additively extended with `paper` only.

This PR contains no Supabase migration, schema, RLS, auth, or production-data changes.

### QA

- targeted paper endpoint failure drills passed
- browser-boundary regression passed
- permanent no-class-mutation guard passed
- Library/D1C2 donor regressions passed
- repository lint passed
- full test suite passed
- smoke suite passed
- exact five-file feature scope verified

### Held

- D1C3B
- D1C3C
- D1C4
- T3 DB containment
- RC-13D
