### PR TITLE
RC-SEC-01I-D1C2F: remove stale Gradebook processing RPC

### DIFF
--- a/netlify/functions/teacher-gradebook-save-score.js
+++ b/netlify/functions/teacher-gradebook-save-score.js
@@ -773,22 +773,7 @@ exports.handler =
         );
       }
 
-      // 7. Preserve the legacy process_submission side effect server-side.
-      await requireOk(
-        await rest(
-          '/rest/v1/rpc/process_submission',
-          {
-            method: 'POST',
-            body: JSON.stringify({
-              submission_id:
-                submission.id,
-            }),
-          }
-        ),
-        'process_submission'
-      );
-
-      // 8. Preserve the legacy final instance state.
+      // 7. Preserve the legacy final instance state.
       const updatedInstances =
         await readRows(
           await rest(

--- a/tests/teacher-gradebook-save-score.test.cjs
+++ b/tests/teacher-gradebook-save-score.test.cjs
@@ -330,17 +330,6 @@ async function restMock(
     );
   }
 
-  if (
-    url ===
-      '/rest/v1/rpc/process_submission' &&
-    method === 'POST'
-  ) {
-    return response(
-      204,
-      null
-    );
-  }
-
   throw new Error(
     `Unexpected REST call: ${method} ${url}`
   );
@@ -432,6 +421,20 @@ delete require.cache[endpointPath];
 const {
   handler,
 } = require(endpointPath);
+
+const endpointSource =
+  require('node:fs').readFileSync(
+    endpointPath,
+    'utf8'
+  );
+
+assert.equal(
+  endpointSource.includes(
+    '/rest/v1/rpc/process_submission'
+  ),
+  false,
+  'signed Gradebook writer must not contain stale process_submission RPC'
+);
 
 Module._load =
   originalLoad;
@@ -742,8 +745,8 @@ async function run() {
         call.url ===
           '/rest/v1/rpc/process_submission'
     ).length,
-    1,
-    'legacy processing side effect remains server-side'
+    0,
+    'Gradebook save must never invoke stale process_submission RPC'
   );
 
   assert.equal(


### PR DESCRIPTION
## RC-SEC-01I-D1C2F

Removes the stale `process_submission` RPC call from the signed Gradebook score writer.

Production reconnaissance proved the live RPC references `submissions.processed` and `submissions.updated_at`, while neither column exists in the production `submissions` table.

### Preserved

- signed teacher authentication
- canonical numeric assignment resolution
- exact teacher-owned class boundary
- active student lookup
- active same-class enrollment requirement
- canonical assignment-instance resolution and race handling
- canonical submission selection
- score create/update semantics
- final assignment-instance status of `Submitted`

### Permanent regression

The signed Gradebook writer must not contain or invoke `/rest/v1/rpc/process_submission`.

### Scope

Exactly two files:

- `netlify/functions/teacher-gradebook-save-score.js`
- `tests/teacher-gradebook-save-score.test.cjs`

### QA

- Gradebook endpoint tests: 8 passed
- browser-boundary regression: passed
- repository lint: passed
- full test suite: passed
- smoke suite: passed
- exact two-file scope verified

### Not included

- generic browser `addSubmission()`
- deletion or modification of the production RPC
- Library / D1C3B
- schema / RLS / auth changes
- production data changes
