### PR TITLE
RC-SEC-02B4: restore goal progress quarterly view

### DIFF
--- a/supabase/migrations/20260802004500_goal_progress_server_only.sql
+++ b/supabase/migrations/20260802004500_goal_progress_server_only.sql
@@ -9,6 +9,36 @@
 ALTER TABLE public.goal_progress
   ADD COLUMN IF NOT EXISTS notes text;
 
+-- Restore the canonical quarterly aggregate expected by the
+-- authenticated teacher goal-progress endpoint. Production drifted
+-- without this historical view even though the server contract retained it.
+create or replace view public.goal_progress_quarter_avg as
+select
+  gp.goal_id,
+  gp.student_id,
+  -- Determine school year: if month >= 7, year stays same; else year - 1
+  case
+    when extract(month from gp.date) >= 7 then extract(year from gp.date)
+    else extract(year from gp.date) - 1
+  end as school_year,
+  -- Determine quarter based on month
+  case
+    when extract(month from gp.date) in (7, 8, 9) then 'Q1'
+    when extract(month from gp.date) in (10, 11, 12) then 'Q2'
+    when extract(month from gp.date) in (1, 2, 3) then 'Q3'
+    when extract(month from gp.date) in (4, 5, 6) then 'Q4'
+    else 'Unknown'
+  end as quarter,
+  round(avg(gp.value), 1) as avg_value,
+  count(*) as measurement_count,
+  min(gp.date) as first_date,
+  max(gp.date) as last_date
+from public.goal_progress gp
+group by gp.goal_id, gp.student_id, school_year, quarter;
+
+COMMENT ON VIEW public.goal_progress_quarter_avg IS
+  'Quarterly averages of goal progress. Quarter logic: Q1=Jul-Sep, Q2=Oct-Dec, Q3=Jan-Mar, Q4=Apr-Jun (school year basis)';
+
 ALTER TABLE public.goal_progress
   ENABLE ROW LEVEL SECURITY;
 

--- a/tests/teacher-goal-progress-server-boundary.test.cjs
+++ b/tests/teacher-goal-progress-server-boundary.test.cjs
@@ -134,6 +134,89 @@ assert(
   'published teacher browser code must have no direct quarterly-view access'
 );
 
+
+const quarterViewCreateIndex =
+  migration.search(
+    /CREATE OR REPLACE VIEW\s+public\.goal_progress_quarter_avg\s+AS/i
+  );
+
+const quarterViewRevokeIndex =
+  migration.search(
+    /REVOKE ALL PRIVILEGES[\s\S]*?ON TABLE\s+public\.goal_progress_quarter_avg/i
+  );
+
+const quarterViewGrantIndex =
+  migration.search(
+    /GRANT SELECT[\s\S]*?ON TABLE\s+public\.goal_progress_quarter_avg[\s\S]*?TO service_role/i
+  );
+
+assert(
+  quarterViewCreateIndex >= 0,
+  'migration must restore the canonical quarterly aggregate view'
+);
+
+assert(
+  /when extract\(month from gp\.date\) >= 7 then extract\(year from gp\.date\)[\s\S]*?else extract\(year from gp\.date\) - 1/i.test(
+    migration
+  ),
+  'quarterly view must preserve the historical school-year calculation'
+);
+
+for (
+  const [months, quarter] of [
+    ['7, 8, 9', 'Q1'],
+    ['10, 11, 12', 'Q2'],
+    ['1, 2, 3', 'Q3'],
+    ['4, 5, 6', 'Q4'],
+  ]
+) {
+  assert(
+    new RegExp(
+      `when extract\\(month from gp\\.date\\) in \\(${months}\\) then '${quarter}'`,
+      'i'
+    ).test(migration),
+    `quarterly view must preserve the historical ${quarter} mapping`
+  );
+}
+
+assert(
+  /round\(avg\(gp\.value\), 1\) as avg_value/i.test(
+    migration
+  ),
+  'quarterly view must preserve historical average calculation'
+);
+
+assert(
+  /count\(\*\) as measurement_count/i.test(
+    migration
+  ),
+  'quarterly view must preserve measurement counts'
+);
+
+assert(
+  /min\(gp\.date\) as first_date[\s\S]*?max\(gp\.date\) as last_date/i.test(
+    migration
+  ),
+  'quarterly view must preserve first and last measurement dates'
+);
+
+assert(
+  /group by gp\.goal_id, gp\.student_id, school_year, quarter/i.test(
+    migration
+  ),
+  'quarterly view must preserve historical grouping'
+);
+
+assert(
+  quarterViewCreateIndex < quarterViewRevokeIndex,
+  'quarterly view must be created before its browser privileges are revoked'
+);
+
+assert(
+  quarterViewRevokeIndex < quarterViewGrantIndex,
+  'quarterly view browser revocation must precede its service-role grant'
+);
+
 assert(
   /ADD COLUMN IF NOT EXISTS notes text/i.test(
     migration


### PR DESCRIPTION
## Goal

Correct the still-pending RC-SEC-02B4 production migration by restoring the canonical `goal_progress_quarter_avg` view before applying its server-only privilege boundary.

## Context

The first production migration attempt failed and rolled back because the migration tried to revoke privileges from `public.goal_progress_quarter_avg`, but that historical view was missing from production.

The target migration remains unapplied.

## Changes

- restore the canonical historical quarterly-average view
- preserve the established school-year and Q1–Q4 calculations
- create the view before revoking browser-role privileges
- retain service-role access for the authenticated teacher endpoint
- add permanent migration-contract and ordering regressions

## Scope

Exactly two files:

- `supabase/migrations/20260802004500_goal_progress_server_only.sql`
- `tests/teacher-goal-progress-server-boundary.test.cjs`

## Verification

- restored view matches both historical definitions exactly
- focused RC-SEC-02B4 regression passed
- complete unit suite passed under `TZ=UTC`
- repository lint completed with zero errors
- no database migration, migration repair, or manual deployment is included in this PR-opening step
