### PR TITLE
RC-SEC-02B4: disambiguate quarterly progress grouping

### DIFF
--- a/supabase/migrations/20260802004500_goal_progress_server_only.sql
+++ b/supabase/migrations/20260802004500_goal_progress_server_only.sql
@@ -34,7 +34,7 @@ select
   min(gp.date) as first_date,
   max(gp.date) as last_date
 from public.goal_progress gp
-group by gp.goal_id, gp.student_id, school_year, quarter;
+group by gp.goal_id, gp.student_id, 3, 4;
 
 COMMENT ON VIEW public.goal_progress_quarter_avg IS
   'Quarterly averages of goal progress. Quarter logic: Q1=Jul-Sep, Q2=Oct-Dec, Q3=Jan-Mar, Q4=Apr-Jun (school year basis)';

--- a/tests/teacher-goal-progress-server-boundary.test.cjs
+++ b/tests/teacher-goal-progress-server-boundary.test.cjs
@@ -201,10 +201,17 @@ assert(
 );
 
 assert(
-  /group by gp\.goal_id, gp\.student_id, school_year, quarter/i.test(
+  /group by gp\.goal_id, gp\.student_id, 3, 4/i.test(
     migration
   ),
-  'quarterly view must preserve historical grouping'
+  'quarterly view must group by the calculated school-year and quarter outputs'
+);
+
+assert(
+  !/group by gp\.goal_id, gp\.student_id, school_year, quarter/i.test(
+    migration
+  ),
+  'quarterly view must reject ambiguous alias grouping when school_year is also a physical column'
 );
 
 assert(


### PR DESCRIPTION
## Goal

Correct the still-unapplied RC-SEC-02B4 migration so the quarterly goal-progress view can be created against the current production schema.

## Root cause

Production `goal_progress` contains a physical `school_year` column. PostgreSQL resolved the historical `GROUP BY school_year, quarter` names against input columns rather than the calculated output aliases, producing SQLSTATE `42803`.

The failed migration transaction rolled back completely and remains unapplied.

## Changes

- use `GROUP BY gp.goal_id, gp.student_id, 3, 4`
- require positional grouping in the permanent regression
- reject the ambiguous historical alias-grouping form

## Scope

- `supabase/migrations/20260802004500_goal_progress_server_only.sql`
- `tests/teacher-goal-progress-server-boundary.test.cjs`

## Verification

- focused RC-SEC-02B4 regression passed
- complete unit suite passed under `TZ=UTC`
- repository lint completed with zero errors
- no deployment or database mutation is included
