### PR TITLE
RC-RESET-02: retire unsafe Close Year UI

### DIFF
--- a/site/teacher/admin/index.html
+++ b/site/teacher/admin/index.html
@@ -186,15 +186,6 @@
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
             </svg>
           </span><span class="tc-label">Admin</span></a>
-          <a data-href="/teacher/close-year/" href="/teacher/close-year/"><span class="tc-icon">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-              <line x1="16" y1="2" x2="16" y2="6"></line>
-              <line x1="8" y1="2" x2="8" y2="6"></line>
-              <line x1="3" y1="10" x2="21" y2="10"></line>
-              <polyline points="9 16 11 18 15 14"></polyline>
-            </svg>
-          </span><span class="tc-label">Close Year</span></a>
           <a data-href="/teacher/reporting/" href="/teacher/reporting/"><span class="tc-icon">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>

--- a/site/teacher/ai-builder/index.html
+++ b/site/teacher/ai-builder/index.html
@@ -904,15 +904,6 @@
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
               </svg>
             </span><span class="tc-label">Admin</span></a>
-            <a data-href="/teacher/close-year/" href="/teacher/close-year/"><span class="tc-icon">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                <line x1="16" y1="2" x2="16" y2="6"></line>
-                <line x1="8" y1="2" x2="8" y2="6"></line>
-                <line x1="3" y1="10" x2="21" y2="10"></line>
-                <polyline points="9 16 11 18 15 14"></polyline>
-              </svg>
-            </span><span class="tc-label">Close Year</span></a>
             <a data-href="/teacher/reporting/" href="/teacher/reporting/"><span class="tc-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>

--- a/site/teacher/archive/index.html
+++ b/site/teacher/archive/index.html
@@ -347,15 +347,6 @@
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
             </svg>
           </span><span class="tc-label">Admin</span></a>
-          <a data-href="/teacher/close-year/" href="/teacher/close-year/"><span class="tc-icon">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-              <line x1="16" y1="2" x2="16" y2="6"></line>
-              <line x1="8" y1="2" x2="8" y2="6"></line>
-              <line x1="3" y1="10" x2="21" y2="10"></line>
-              <polyline points="9 16 11 18 15 14"></polyline>
-            </svg>
-          </span><span class="tc-label">Close Year</span></a>
           <a data-href="/teacher/reporting/" href="/teacher/reporting/"><span class="tc-icon">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>

--- a/site/teacher/close-year/index.html
+++ b/site/teacher/close-year/index.html
@@ -395,7 +395,7 @@
           <polyline points="9 22 9 12 15 12 15 22"></polyline>
         </svg>
       </a>
-      <div class="tc-title">Teacher Center — Close School Year</div>
+      <div class="tc-title">Teacher Center — School-Year Closeout</div>
     </header>
 
     <div class="tc-shell">
@@ -477,15 +477,6 @@
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
             </svg>
           </span><span class="tc-label">Admin</span></a>
-          <a data-href="/teacher/close-year/" href="/teacher/close-year/"><span class="tc-icon">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-              <line x1="16" y1="2" x2="16" y2="6"></line>
-              <line x1="8" y1="2" x2="8" y2="6"></line>
-              <line x1="3" y1="10" x2="21" y2="10"></line>
-              <polyline points="9 16 11 18 15 14"></polyline>
-            </svg>
-          </span><span class="tc-label">Close Year</span></a>
           <a data-href="/teacher/reporting/" href="/teacher/reporting/"><span class="tc-icon">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -521,28 +512,34 @@
       </aside>
 
       <main class="tc-main">
-        <div class="cy-card">
+        <div class="cy-card" data-close-year-retired="true">
           <div class="cy-title">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-              <line x1="16" y1="2" x2="16" y2="6"></line>
-              <line x1="8" y1="2" x2="8" y2="6"></line>
-              <line x1="3" y1="10" x2="21" y2="10"></line>
-              <polyline points="9 16 11 18 15 14"></polyline>
-            </svg>
-            Close School Year
+            School-Year Closeout Temporarily Unavailable
           </div>
-          <div class="cy-subtitle">Safely transition all data from the current school year to the next.</div>
-          <div id="cyStepIndicator" class="cy-step-indicator">
-            <!-- Rendered by tc-close-year.js -->
-          </div>
-        </div>
 
-        <div id="cyWizard">
-          <!-- Wizard steps rendered by tc-close-year.js -->
-          <div class="cy-loading">
-            <div class="cy-spinner"></div>
-            Loading…
+          <div class="cy-desc">
+            This feature has been temporarily retired while historical
+            assignments, submissions, grades, and IEP goal-progress records
+            are being reviewed for safe school-year handling.
+          </div>
+
+          <div class="cy-alert warn" role="status">
+            No assignments, submissions, grades, or goal-progress records
+            have been deleted or changed.
+          </div>
+
+          <div class="cy-desc">
+            Existing curriculum, reusable assignment sources, presentations,
+            and toolkits remain available and are not affected.
+          </div>
+
+          <div class="cy-btn-row">
+            <a class="cy-btn primary" href="/teacher/">
+              Return to Teacher Center
+            </a>
+            <a class="cy-btn" href="/teacher/archive/">
+              Open Archive
+            </a>
           </div>
         </div>
       </main>
@@ -551,6 +548,5 @@
 
   <script defer src="/web/teacher-shell.js"></script>
   <script src="/web/rc-modal.js"></script>
-  <script type="module" src="/web/tc-close-year.js"></script>
 </body>
 </html>

--- a/site/teacher/work/index.html
+++ b/site/teacher/work/index.html
@@ -431,15 +431,6 @@
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
               </svg>
             </span><span class="tc-label">Admin</span></a>
-            <a data-href="/teacher/close-year/" href="/teacher/close-year/"><span class="tc-icon">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                <line x1="16" y1="2" x2="16" y2="6"></line>
-                <line x1="8" y1="2" x2="8" y2="6"></line>
-                <line x1="3" y1="10" x2="21" y2="10"></line>
-                <polyline points="9 16 11 18 15 14"></polyline>
-              </svg>
-            </span><span class="tc-label">Close Year</span></a>
             <a data-href="/teacher/reporting/" href="/teacher/reporting/"><span class="tc-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>

--- a/tests/close-year-ui-retired.test.cjs
+++ b/tests/close-year-ui-retired.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.join(repoRoot, relativePath),
+    'utf8'
+  );
+}
+
+const navigationFiles = [
+  'site/teacher/admin/index.html',
+  'site/teacher/ai-builder/index.html',
+  'site/teacher/archive/index.html',
+  'site/teacher/work/index.html',
+  'site/teacher/close-year/index.html',
+];
+
+test('Close Year is absent from teacher navigation', () => {
+  for (const relativePath of navigationFiles) {
+    const html = read(relativePath);
+
+    assert.doesNotMatch(
+      html,
+      /href="\/teacher\/close-year\/"/,
+      `${relativePath} must not link to the retired Close Year route`
+    );
+
+    assert.doesNotMatch(
+      html,
+      /<span class="tc-label">Close Year<\/span>/,
+      `${relativePath} must not display a Close Year navigation label`
+    );
+  }
+});
+
+test('direct Close Year route is non-operational', () => {
+  const html = read('site/teacher/close-year/index.html');
+
+  assert.match(
+    html,
+    /data-close-year-retired="true"/
+  );
+
+  assert.match(
+    html,
+    /School-Year Closeout Temporarily Unavailable/
+  );
+
+  assert.match(
+    html,
+    /No assignments, submissions, grades, or goal-progress records/
+  );
+
+  assert.doesNotMatch(
+    html,
+    /src="\/web\/tc-close-year\.js"/
+  );
+
+  assert.doesNotMatch(
+    html,
+    /id="cyWizard"/
+  );
+
+  assert.doesNotMatch(
+    html,
+    /id="cyStepIndicator"/
+  );
+});


### PR DESCRIPTION
## Goal

Temporarily retire the unsafe Close School Year teacher interface while preserving all historical data and backend archive infrastructure.

## Changes

- removed Close Year navigation links from teacher-facing pages
- converted `/teacher/close-year/` into a non-operational retirement notice
- removed the Close Year wizard JavaScript from that route
- added regression coverage proving the links and operational wizard are absent

## Why

The existing wizard derives the school year from the current date and could target the new 2026–2027 year. Its interface also advertises assignment clearing even though the server correctly blocks that destructive action.

Repairing the full workflow is deferred until after the beginning-of-school deadline.

## Data and infrastructure impact

- no assignments changed
- no submissions changed
- no grades changed
- no IEP goal-progress data changed
- no Supabase schema, RLS, or auth changes
- no Netlify configuration changes
- backend close-year functions remain intact

## Validation

- `node --test tests/close-year-ui-retired.test.cjs`
- `node --test tests/submission-archive-server-boundary.test.cjs`
- `git diff --check`
