### PR TITLE
RC-E2E-02A: isolate localhost browser Supabase

### DIFF
--- a/netlify/edge-functions/student-entry-redirect.js
+++ b/netlify/edge-functions/student-entry-redirect.js
@@ -14,6 +14,71 @@
  * Related: PR 265 - Session-only student authentication
  */
 
+
+const LOCAL_SUPABASE_CONNECT_SOURCE =
+  "http://127.0.0.1:54321";
+
+function isLocalBrowserHost(url) {
+  return (
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "::1"
+  );
+}
+
+function addConnectSource(policy, source) {
+  if (!policy || policy.includes(source)) {
+    return policy;
+  }
+
+  return policy.replace(
+    /connect-src\s+([^;]*)/,
+    (match, sources) =>
+      `connect-src ${sources.trim()} ${source}`
+  );
+}
+
+function applyLocalSupabaseCsp(response, url) {
+  if (!isLocalBrowserHost(url)) {
+    return response;
+  }
+
+  for (const headerName of [
+    "Content-Security-Policy",
+    "Content-Security-Policy-Report-Only",
+  ]) {
+    const currentPolicy =
+      response.headers.get(headerName);
+
+    if (!currentPolicy) {
+      continue;
+    }
+
+    response.headers.set(
+      headerName,
+      addConnectSource(
+        currentPolicy,
+        LOCAL_SUPABASE_CONNECT_SOURCE
+      )
+    );
+  }
+
+  return response;
+}
+
+async function nextWithLocalSupabaseCsp(
+  context,
+  url
+) {
+  const response =
+    await context.next();
+
+  return applyLocalSupabaseCsp(
+    response,
+    url
+  );
+}
+
 export default async (request, context) => {
   const url = new URL(request.url);
   const path = url.pathname;
@@ -21,7 +86,10 @@ export default async (request, context) => {
   // Only process the base student portal paths (/student and /student/)
   // Other paths like /student/test-portal-b.html should pass through
   if (path !== '/student' && path !== '/student/') {
-    return context.next();
+    return nextWithLocalSupabaseCsp(
+      context,
+      url
+    );
   }
 
   // Check for valid auto-login deep link parameters
@@ -45,5 +113,8 @@ export default async (request, context) => {
   // This includes:
   // - No query parameters (direct access to login UI)
   // - Valid auto-login deep link (auto=1 with valid code)
-  return context.next();
+  return nextWithLocalSupabaseCsp(
+    context,
+    url
+  );
 };

--- a/netlify/edge-functions/teacher-auth-guard.js
+++ b/netlify/edge-functions/teacher-auth-guard.js
@@ -56,6 +56,58 @@ function redirectToTeacherLogin(url) {
   });
 }
 
+
+const LOCAL_SUPABASE_CONNECT_SOURCE =
+  "http://127.0.0.1:54321";
+
+function isLocalBrowserHost(url) {
+  return (
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "::1"
+  );
+}
+
+function addConnectSource(policy, source) {
+  if (!policy || policy.includes(source)) {
+    return policy;
+  }
+
+  return policy.replace(
+    /connect-src\s+([^;]*)/,
+    (match, sources) =>
+      `connect-src ${sources.trim()} ${source}`
+  );
+}
+
+function applyLocalSupabaseCsp(response, url) {
+  if (!isLocalBrowserHost(url)) {
+    return response;
+  }
+
+  for (const headerName of [
+    "Content-Security-Policy",
+    "Content-Security-Policy-Report-Only",
+  ]) {
+    const currentPolicy =
+      response.headers.get(headerName);
+
+    if (!currentPolicy) {
+      continue;
+    }
+
+    response.headers.set(
+      headerName,
+      addConnectSource(
+        currentPolicy,
+        LOCAL_SUPABASE_CONNECT_SOURCE
+      )
+    );
+  }
+
+  return response;
+}
+
 export default async (request, context) => {
   const url = new URL(request.url);
 
@@ -92,7 +144,10 @@ export default async (request, context) => {
       "teacher-session-valid"
     );
 
-    return response;
+    return applyLocalSupabaseCsp(
+      response,
+      url
+    );
   } catch (_err) {
     // Authentication infrastructure failure must not expose Teacher Center.
     return redirectToTeacherLogin(url);

--- a/netlify/functions/browser-supabase-config.js
+++ b/netlify/functions/browser-supabase-config.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * Return the public Supabase URL and anonymous key used by the current
+ * Netlify Dev process. This endpoint is intentionally available only when
+ * the request host is localhost.
+ */
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function isLocalHost(hostHeader) {
+  const host = String(hostHeader || '')
+    .trim()
+    .toLowerCase();
+
+  return (
+    host === 'localhost' ||
+    host.startsWith('localhost:') ||
+    host === '127.0.0.1' ||
+    host.startsWith('127.0.0.1:') ||
+    host === '[::1]' ||
+    host.startsWith('[::1]:')
+  );
+}
+
+exports.handler = async (event = {}) => {
+  if (event.httpMethod !== 'GET') {
+    return json(405, {
+      ok: false,
+      error: 'Method Not Allowed',
+    });
+  }
+
+  const headers = event.headers || {};
+  const requestHost =
+    headers.host ||
+    headers.Host ||
+    headers['x-forwarded-host'] ||
+    headers['X-Forwarded-Host'];
+
+  if (!isLocalHost(requestHost)) {
+    return json(404, {
+      ok: false,
+      error: 'Not Found',
+    });
+  }
+
+  const url =
+    process.env.SUPABASE_URL_RUNTIME ||
+    process.env.SUPABASE_URL ||
+    '';
+
+  const anonKey =
+    process.env.SUPABASE_ANON_KEY_RUNTIME ||
+    process.env.SUPABASE_ANON_KEY ||
+    '';
+
+  if (!url || !anonKey) {
+    return json(503, {
+      ok: false,
+      error: 'Local Supabase browser configuration unavailable',
+    });
+  }
+
+  return json(200, {
+    ok: true,
+    url,
+    anonKey,
+  });
+};

--- a/site/web/supabase-client.js
+++ b/site/web/supabase-client.js
@@ -7,6 +7,70 @@ let createClient = null;
 let supabaseLoadError = null;
 let cachedClient = null;
 let lastConfig = null;
+let localRuntimeConfig = null;
+
+const LOCAL_RUNTIME_CONFIG_ENDPOINT =
+  '/.netlify/functions/browser-supabase-config';
+
+function isLocalBrowserHost() {
+  return (
+    location.hostname === 'localhost' ||
+    location.hostname === '127.0.0.1' ||
+    location.hostname === '::1'
+  );
+}
+
+async function loadLocalRuntimeConfig() {
+  if (!isLocalBrowserHost()) return;
+
+  localRuntimeConfig = {
+    url: null,
+    key: null,
+  };
+
+  try {
+    const response = await fetch(
+      LOCAL_RUNTIME_CONFIG_ENDPOINT,
+      {
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const url =
+      typeof payload.url === 'string'
+        ? payload.url.trim()
+        : '';
+    const key =
+      typeof payload.anonKey === 'string'
+        ? payload.anonKey.trim()
+        : '';
+
+    if (!url || !key) {
+      throw new Error('incomplete local runtime configuration');
+    }
+
+    localRuntimeConfig = {
+      url,
+      key,
+    };
+
+    console.log(
+      '[supabase-client] Using local runtime Supabase configuration'
+    );
+  } catch (err) {
+    console.warn(
+      '[supabase-client] Local runtime Supabase configuration unavailable; browser remote access disabled.',
+      err.message
+    );
+  }
+}
 
 // Load @supabase/supabase-js@2 from vendored file (CSP-compliant, no external CDNs)
 // The vendored file at /vendor/supabase-js@2.mjs provides deterministic loading
@@ -24,8 +88,9 @@ async function loadSupabaseClient() {
   }
 }
 
-// Attempt to load the Supabase client
+// Attempt to load the Supabase client and localhost runtime configuration.
 await loadSupabaseClient();
+await loadLocalRuntimeConfig();
 
 // Read config from localStorage using unified keys with legacy fallback
 const UNIFIED_PREFIX = 'rc_unified_';
@@ -46,6 +111,21 @@ function getStoredValue(unifiedKey, legacyKeys = []) {
 }
 
 function readCurrentConfig() {
+  // Localhost must use the explicit Netlify Dev runtime configuration.
+  // Never fall through to the production window globals when this request is
+  // running against the isolated local E2E application.
+  if (isLocalBrowserHost()) {
+    const url = localRuntimeConfig?.url || null;
+    const key = localRuntimeConfig?.key || null;
+
+    return {
+      url,
+      key,
+      useRemote: Boolean(url && key),
+      optOut: false,
+    };
+  }
+
   const storedUrl = getStoredValue('supabase_url', ['supabase_url']);
   const storedKey = getStoredValue('supabase_anon', ['supabase_key', 'supabase_anon']);
   const useRemote = getStoredValue('use_supabase', ['use_remote', 'use_supabase']) === 'true';

--- a/tests/local-browser-supabase-isolation.test.cjs
+++ b/tests/local-browser-supabase-isolation.test.cjs
@@ -1,0 +1,279 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.resolve(__dirname, '..', relativePath),
+    'utf8'
+  );
+}
+
+const clientSource =
+  read('site/web/supabase-client.js');
+
+const functionSource =
+  read('netlify/functions/browser-supabase-config.js');
+
+const teacherGuardSource =
+  read('netlify/edge-functions/teacher-auth-guard.js');
+
+const studentRedirectSource =
+  read('netlify/edge-functions/student-entry-redirect.js');
+
+assert.ok(
+  clientSource.includes(
+    "'/.netlify/functions/browser-supabase-config'"
+  ),
+  'localhost client must request the runtime public-config endpoint'
+);
+
+assert.ok(
+  clientSource.includes(
+    'await loadLocalRuntimeConfig();'
+  ),
+  'localhost runtime configuration must load before adapter use'
+);
+
+const readConfigStart =
+  clientSource.indexOf('function readCurrentConfig()');
+
+const localBranch =
+  clientSource.indexOf(
+    'if (isLocalBrowserHost())',
+    readConfigStart
+  );
+
+const productionGlobals =
+  clientSource.indexOf(
+    'const url = window.SUPABASE_URL || storedUrl;',
+    readConfigStart
+  );
+
+assert.ok(
+  localBranch > readConfigStart,
+  'readCurrentConfig must contain a localhost branch'
+);
+
+assert.ok(
+  productionGlobals > localBranch,
+  'localhost branch must run before production window globals'
+);
+
+const localConfigBlock =
+  clientSource.slice(localBranch, productionGlobals);
+
+assert.ok(
+  localConfigBlock.includes('localRuntimeConfig?.url'),
+  'localhost must read the runtime URL'
+);
+
+assert.ok(
+  localConfigBlock.includes('localRuntimeConfig?.key'),
+  'localhost must read the runtime anonymous key'
+);
+
+assert.ok(
+  !localConfigBlock.includes('window.SUPABASE_URL'),
+  'localhost must not fall through to the production URL'
+);
+
+assert.ok(
+  !localConfigBlock.includes('window.SUPABASE_ANON_KEY'),
+  'localhost must not fall through to the production anonymous key'
+);
+
+assert.ok(
+  functionSource.includes('SUPABASE_URL_RUNTIME'),
+  'function must prefer the runtime Supabase URL'
+);
+
+assert.ok(
+  functionSource.includes('SUPABASE_ANON_KEY_RUNTIME'),
+  'function must prefer the runtime anonymous key'
+);
+
+assert.ok(
+  !functionSource.includes('SUPABASE_SERVICE_ROLE_KEY'),
+  'function must never expose the service-role key'
+);
+
+
+for (const [label, edgeSource] of [
+  ['teacher guard', teacherGuardSource],
+  ['student redirect', studentRedirectSource],
+]) {
+  assert.ok(
+    edgeSource.includes(
+      'http://127.0.0.1:54321'
+    ),
+    `${label} must allow the local Supabase API`
+  );
+
+  assert.ok(
+    edgeSource.includes(
+      'isLocalBrowserHost'
+    ),
+    `${label} CSP change must be localhost-scoped`
+  );
+
+  assert.ok(
+    edgeSource.includes(
+      'Content-Security-Policy'
+    ),
+    `${label} must patch the enforced CSP header`
+  );
+
+  assert.ok(
+    edgeSource.includes(
+      'Content-Security-Policy-Report-Only'
+    ),
+    `${label} must patch the report-only CSP header`
+  );
+
+  assert.ok(
+    edgeSource.includes(
+      'applyLocalSupabaseCsp'
+    ),
+    `${label} must apply the local CSP helper`
+  );
+}
+
+const savedEnv = {
+  SUPABASE_URL_RUNTIME:
+    process.env.SUPABASE_URL_RUNTIME,
+  SUPABASE_ANON_KEY_RUNTIME:
+    process.env.SUPABASE_ANON_KEY_RUNTIME,
+  SUPABASE_SERVICE_ROLE_KEY:
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+};
+
+(async () => {
+  try {
+    process.env.SUPABASE_URL_RUNTIME =
+      'http://127.0.0.1:54321';
+
+    process.env.SUPABASE_ANON_KEY_RUNTIME =
+      'synthetic-local-anon-key';
+
+    process.env.SUPABASE_SERVICE_ROLE_KEY =
+      'synthetic-service-role-must-not-appear';
+
+    const modulePath =
+      require.resolve(
+        '../netlify/functions/browser-supabase-config'
+      );
+
+    delete require.cache[modulePath];
+
+    const { handler } =
+      require(modulePath);
+
+    const localResponse =
+      await handler({
+        httpMethod: 'GET',
+        headers: {
+          host: 'localhost:8888',
+        },
+      });
+
+    assert.strictEqual(
+      localResponse.statusCode,
+      200,
+      'localhost GET must return configuration'
+    );
+
+    const localBody =
+      JSON.parse(localResponse.body);
+
+    assert.deepStrictEqual(
+      localBody,
+      {
+        ok: true,
+        url: 'http://127.0.0.1:54321',
+        anonKey: 'synthetic-local-anon-key',
+      },
+      'localhost response must contain only public runtime configuration'
+    );
+
+    assert.ok(
+      !localResponse.body.includes(
+        'synthetic-service-role-must-not-appear'
+      ),
+      'service-role key must not appear in the response'
+    );
+
+    assert.strictEqual(
+      localResponse.headers['Cache-Control'],
+      'no-store',
+      'runtime browser configuration must not be cached'
+    );
+
+    const productionResponse =
+      await handler({
+        httpMethod: 'GET',
+        headers: {
+          host: 'reinischclassroom.com',
+        },
+      });
+
+    assert.strictEqual(
+      productionResponse.statusCode,
+      404,
+      'endpoint must not expose configuration on production hosts'
+    );
+
+    const postResponse =
+      await handler({
+        httpMethod: 'POST',
+        headers: {
+          host: 'localhost:8888',
+        },
+      });
+
+    assert.strictEqual(
+      postResponse.statusCode,
+      405,
+      'endpoint must reject non-GET methods'
+    );
+
+    console.log(
+      '✓ localhost browser config uses explicit Netlify Dev runtime values'
+    );
+
+    console.log(
+      '✓ localhost cannot fall through to production Supabase globals'
+    );
+
+    console.log(
+      '✓ service-role key is never exposed'
+    );
+
+    console.log(
+      '✓ public-config endpoint is unavailable on production hosts'
+    );
+
+
+    console.log(
+      '✓ Teacher and Student page responses allow local Supabase only on localhost'
+    );
+
+    console.log();
+    console.log(
+      'RC-E2E-02A focused boundary tests PASS'
+    );
+  } finally {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Goal

Ensure browser-side Supabase traffic during local E2E testing uses the isolated local Supabase stack and cannot silently fall through to production.

## Changes

- add a localhost-only public runtime configuration endpoint
- make the browser Supabase client fail closed on localhost
- allow the local Supabase API through CSP only for localhost Teacher and Student responses
- preserve the existing production Supabase configuration and global CSP
- add focused browser-isolation boundary tests

## Verification

- focused RC-E2E-02A boundary test passed
- nearby Teacher browser-boundary tests passed
- actual headless-browser teacher login passed
- Students page displayed only `E2E01` and `E2E99`
- seven browser Supabase requests went to `127.0.0.1:54321`
- zero browser requests went to any production `supabase.co` host
- service-role credentials are not exposed
- production-global `netlify.toml` CSP is unchanged

## Scope

No Supabase schema, RLS, authentication, production data, Netlify settings, or deployments were changed.
