### PR TITLE
RC-YEAR-02A: prevent inactive students from re-entering active workflows

### DIFF
--- a/netlify/functions/teacher-assignment-instances-list.js
+++ b/netlify/functions/teacher-assignment-instances-list.js
@@ -330,8 +330,10 @@ exports.handler =
         await readRows(
           await rest(
             '/rest/v1/assignment_instances' +
-            '?select=id,assignment_id,student_id,assigned_at,due_at,status,settings,school_year,students!inner(code,name)' +
+            '?select=id,assignment_id,student_id,assigned_at,due_at,status,settings,school_year,students!inner(code,name,active,archived_at)' +
             `&assignment_id=in.(${assignmentIds.map(encodeURIComponent).join(',')})` +
+            '&students.active=eq.true' +
+            '&students.archived_at=is.null' +
             `&or=(school_year.eq.${schoolYear},school_year.is.null)` +
             `&limit=${MAX_INSTANCES_QUERY_LIMIT}`
           ),
@@ -378,7 +380,9 @@ exports.handler =
 
         if (
           !student ||
-          !student.code
+          !student.code ||
+          student.active === false ||
+          Boolean(student.archived_at)
         ) {
           continue;
         }

--- a/netlify/functions/teacher-issue-assignment.js
+++ b/netlify/functions/teacher-issue-assignment.js
@@ -171,7 +171,7 @@ exports.handler = async (event) => {
 
   try {
     // First, fetch student details to get student_code for each student_id
-    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name&id=in.(${student_ids.map(id => `"${id}"`).join(',')})`;
+    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name,active,archived_at&id=in.(${student_ids.map(id => `"${id}"`).join(',')})`;
     
     console.log(`[teacher-issue-assignment] [${requestId}] Fetching student details`);
     
@@ -194,6 +194,27 @@ exports.handler = async (event) => {
     if (!students || students.length === 0) {
       console.log(`[teacher-issue-assignment] [${requestId}] No students found for provided IDs`);
       return jsonResponse(event, 404, { ok: false, error: 'No students found for provided IDs' }, {}, requestId);
+    }
+
+    const inactiveStudents = students.filter(
+      student =>
+        !student ||
+        student.active === false ||
+        Boolean(student.archived_at)
+    );
+
+    if (inactiveStudents.length > 0) {
+      return jsonResponse(
+        event,
+        400,
+        {
+          ok: false,
+          error:
+            'One or more selected students are inactive or archived'
+        },
+        { 'Cache-Control': 'no-store' },
+        requestId
+      );
     }
 
     console.log(`[teacher-issue-assignment] [${requestId}] Found ${students.length} students`);

--- a/netlify/functions/teacher-issue-draft.js
+++ b/netlify/functions/teacher-issue-draft.js
@@ -871,7 +871,7 @@ async function issueDraftCore({ draft, teacherUsername, teacherUUID, requestId }
   
   try {
     // Primary: try class_enrollments table (UUID-based junction table)
-    const classEnrollmentsUrl = `${SUPABASE_URL}/rest/v1/class_enrollments?select=student_id,students!inner(id,code,name)&class_id=eq.${encodeURIComponent(targetClass.id)}`;
+    const classEnrollmentsUrl = `${SUPABASE_URL}/rest/v1/class_enrollments?select=student_id,students!inner(id,code,name,active,archived_at)&class_id=eq.${encodeURIComponent(targetClass.id)}&active=eq.true&students.active=eq.true&students.archived_at=is.null`;
     
     console.log(`[teacher-issue-draft] [${requestId}] Fetching class enrollments from class_enrollments table`);
     
@@ -933,7 +933,7 @@ async function issueDraftCore({ draft, teacherUsername, teacherUUID, requestId }
           // For PostgREST 'in' operator with text fields, wrap each value in quotes
           // Since we've validated that codes only contain [a-zA-Z0-9_-], quoting is safe
           const quotedCodes = validCodes.map(code => `"${code}"`);
-          const studentsLookupUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code&code=in.(${quotedCodes.join(',')})`;
+          const studentsLookupUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,active,archived_at&code=in.(${quotedCodes.join(',')})&active=eq.true&archived_at=is.null`;
           
           const studentsLookupResponse = await fetch(studentsLookupUrl, {
             method: 'GET',
@@ -1012,7 +1012,7 @@ async function issueDraftCore({ draft, teacherUsername, teacherUUID, requestId }
             // For PostgREST 'in' operator with text fields, wrap each value in quotes
             // Since we've validated that codes only contain [a-zA-Z0-9_-], quoting is safe
             const quotedCodes = validCodes.map(code => `"${code}"`);
-            const studentsLookupUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code&code=in.(${quotedCodes.join(',')})`;
+            const studentsLookupUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,active,archived_at&code=in.(${quotedCodes.join(',')})&active=eq.true&archived_at=is.null`;
             
             const studentsLookupResponse = await fetch(studentsLookupUrl, {
               method: 'GET',
@@ -1436,7 +1436,7 @@ async function issueDraftCore({ draft, teacherUsername, teacherUUID, requestId }
   } else {
     // Note: studentIds come from database enrollment query above, already validated as UUIDs by Supabase
     // PostgREST syntax requires wrapping UUIDs in double quotes for `in` operator
-    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name&id=in.(${studentIds.map(id => `"${id}"`).join(',')})`;
+    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name,active,archived_at&id=in.(${studentIds.map(id => `"${id}"`).join(',')})&active=eq.true&archived_at=is.null`;
     
     console.log(`[teacher-issue-draft] [${requestId}] Fetching student details`);
     
@@ -1490,7 +1490,7 @@ async function issueDraftCore({ draft, teacherUsername, teacherUUID, requestId }
       if (Array.isArray(draft.additionalStudentCodes) && draft.additionalStudentCodes.length > 0) {
         const additionalCodes = draft.additionalStudentCodes.map(c => c.trim().toUpperCase()).filter(Boolean);
         if (additionalCodes.length > 0) {
-          const additionalStudentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name&code=in.(${additionalCodes.join(',')})`;
+          const additionalStudentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name,active,archived_at&code=in.(${additionalCodes.join(',')})&active=eq.true&archived_at=is.null`;
           try {
             const additionalStudentsResponse = await fetch(additionalStudentsUrl, {
               method: 'GET',

--- a/netlify/functions/teacher-issue-to-student.js
+++ b/netlify/functions/teacher-issue-to-student.js
@@ -196,7 +196,7 @@ exports.handler = async (event) => {
     // Normalize codes to uppercase to match DB storage convention
     const normalizedCodes = student_codes.map(c => c.trim().toUpperCase());
     const quotedCodes = normalizedCodes.map(c => `"${c}"`).join(',');
-    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name&code=in.(${quotedCodes})`;
+    const studentsUrl = `${SUPABASE_URL}/rest/v1/students?select=id,code,name,active,archived_at&code=in.(${quotedCodes})`;
     const studentsResponse = await fetch(studentsUrl, {
       method: 'GET',
       headers: {
@@ -213,6 +213,27 @@ exports.handler = async (event) => {
 
     if (!Array.isArray(students) || students.length === 0) {
       return jsonResponse(event, 404, { ok: false, error: `No students found for codes: ${normalizedCodes.join(', ')}` }, { 'Cache-Control': 'no-store' }, requestId);
+    }
+
+    const inactiveStudents = students.filter(
+      student =>
+        !student ||
+        student.active === false ||
+        Boolean(student.archived_at)
+    );
+
+    if (inactiveStudents.length > 0) {
+      return jsonResponse(
+        event,
+        400,
+        {
+          ok: false,
+          error:
+            'One or more selected students are inactive or archived'
+        },
+        { 'Cache-Control': 'no-store' },
+        requestId
+      );
     }
 
     // Warn about any codes not found

--- a/tests/inactive-student-operational-guard.test.cjs
+++ b/tests/inactive-student-operational-guard.test.cjs
@@ -1,0 +1,175 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.join(process.cwd(), relativePath),
+    'utf8'
+  );
+}
+
+console.log(
+  'Running inactive-student operational guard tests...\n'
+);
+
+const issueDraft = read(
+  'netlify/functions/teacher-issue-draft.js'
+);
+
+assert.ok(
+  issueDraft.includes(
+    'students!inner(id,code,name,active,archived_at)'
+  )
+);
+
+assert.ok(
+  issueDraft.includes(
+    '&active=eq.true' +
+    '&students.active=eq.true' +
+    '&students.archived_at=is.null'
+  )
+);
+
+assert.strictEqual(
+  (
+    issueDraft.match(
+      /&active=eq\.true&archived_at=is\.null/g
+    ) || []
+  ).length,
+  4,
+  'Every draft student lookup must exclude inactive or archived students'
+);
+
+console.log(
+  '✓ teacher-issue-draft filters every issuance path'
+);
+
+const issueToStudent = read(
+  'netlify/functions/teacher-issue-to-student.js'
+);
+
+assert.ok(
+  issueToStudent.includes(
+    'select=id,code,name,active,archived_at'
+  )
+);
+
+assert.ok(
+  issueToStudent.includes(
+    'student.active === false'
+  )
+);
+
+assert.ok(
+  issueToStudent.includes(
+    'Boolean(student.archived_at)'
+  )
+);
+
+assert.ok(
+  issueToStudent.indexOf(
+    'const inactiveStudents'
+  ) <
+  issueToStudent.indexOf(
+    '// Step 3: Build instance rows'
+  )
+);
+
+console.log(
+  '✓ teacher-issue-to-student rejects inactive or archived students'
+);
+
+const issueAssignment = read(
+  'netlify/functions/teacher-issue-assignment.js'
+);
+
+assert.ok(
+  issueAssignment.includes(
+    'select=id,code,name,active,archived_at'
+  )
+);
+
+assert.ok(
+  issueAssignment.includes(
+    'student.active === false'
+  )
+);
+
+assert.ok(
+  issueAssignment.includes(
+    'Boolean(student.archived_at)'
+  )
+);
+
+assert.ok(
+  issueAssignment.indexOf(
+    'const inactiveStudents'
+  ) <
+  issueAssignment.indexOf(
+    '// Build instances to upsert'
+  )
+);
+
+console.log(
+  '✓ teacher-issue-assignment rejects inactive or archived students'
+);
+
+const instanceList = read(
+  'netlify/functions/teacher-assignment-instances-list.js'
+);
+
+assert.ok(
+  instanceList.includes(
+    'students!inner(code,name,active,archived_at)'
+  )
+);
+
+assert.ok(
+  instanceList.includes(
+    '&students.active=eq.true'
+  )
+);
+
+assert.ok(
+  instanceList.includes(
+    '&students.archived_at=is.null'
+  )
+);
+
+assert.ok(
+  instanceList.includes(
+    'student.active === false'
+  )
+);
+
+assert.ok(
+  instanceList.includes(
+    'Boolean(student.archived_at)'
+  )
+);
+
+console.log(
+  '✓ active instance reader excludes inactive or archived students'
+);
+
+const submissions = read(
+  'netlify/functions/teacher-submissions.js'
+);
+
+assert.ok(
+  submissions.includes(
+    'student.active === false'
+  ),
+  'Existing Teacher submissions guard must remain intact'
+);
+
+console.log(
+  '✓ existing Teacher submissions guard remains intact'
+);
+
+console.log(
+  '\nRC-YEAR-02A INACTIVE-STUDENT OPERATIONAL GUARD: PASS'
+);

--- a/tests/teacher-assignment-instances-list.test.cjs
+++ b/tests/teacher-assignment-instances-list.test.cjs
@@ -512,13 +512,39 @@ async function run() {
     ['S000', 'S001']
   );
 
+  const zeroRow =
+    payload.instances.find(
+      (row) =>
+        row.id ===
+        '99999999-9999-4999-8999-999999999999'
+    );
+
+  assert.ok(
+    zeroRow,
+    'Active synthetic row must remain visible'
+  );
+
+  assert.strictEqual(
+    zeroRow.student_name,
+    'Synthetic Zero'
+  );
+
+  assert.strictEqual(
+    zeroRow.due_at,
+    null
+  );
+
+  assert.deepStrictEqual(
+    zeroRow.settings,
+    {}
+  );
+
   console.log(
     '✓ shared-reader field and student-code ordering contract preserved'
   );
 
-  // 6. Preserve legacy shared-reader behavior: active enrollment
-  // is the authorization requirement; students.active is not an
-  // additional visibility filter.
+  // 6. Exclude inactive or archived students even when a stale
+  // active enrollment remains in the class-enrollment table.
   installMocks();
 
   fixtures.instances = [
@@ -537,6 +563,26 @@ async function run() {
         code: 'S003',
         name: 'Synthetic Three',
         active: false,
+        archived_at: null,
+      },
+    },
+    {
+      id:
+        '88888888-8888-4888-8888-888888888888',
+      assignment_id: 101,
+      student_id: studentA,
+      assigned_at:
+        '2026-09-01T15:05:00.000Z',
+      due_at: null,
+      status: 'Assigned',
+      settings: {},
+      school_year: 2026,
+      students: {
+        code: 'S004',
+        name: 'Synthetic Archived',
+        active: true,
+        archived_at:
+          '2026-07-31T12:00:00.000Z',
       },
     },
   ];
@@ -550,31 +596,12 @@ async function run() {
     body(result);
 
   assert.deepStrictEqual(
-    payload.instances.map(
-      (row) => row.id
-    ),
-    [
-      '99999999-9999-4999-8999-999999999999',
-    ]
-  );
-
-  assert.strictEqual(
-    payload.instances[0].student_name,
-    'Synthetic Three'
-  );
-
-  assert.strictEqual(
-    payload.instances[0].due_at,
-    null
-  );
-
-  assert.deepStrictEqual(
-    payload.instances[0].settings,
-    {}
+    payload.instances,
+    []
   );
 
   console.log(
-    '✓ active same-class enrollment remains the visibility requirement'
+    '✓ inactive and archived students excluded despite stale active enrollments'
   );
 
   // 7. Preserve current-school-year/NULL and 5000-row query contract.
@@ -609,8 +636,29 @@ async function run() {
     )
   );
 
+  assert.ok(
+    instanceCall.url.includes(
+      'students!inner(code,name,active,archived_at)'
+    ),
+    'Assignment-instance query must load student operational state'
+  );
+
+  assert.ok(
+    instanceCall.url.includes(
+      'students.active=eq.true'
+    ),
+    'Assignment-instance query must require active students'
+  );
+
+  assert.ok(
+    instanceCall.url.includes(
+      'students.archived_at=is.null'
+    ),
+    'Assignment-instance query must exclude archived students'
+  );
+
   console.log(
-    '✓ existing school-year/NULL and query-limit contract preserved'
+    '✓ school-year/NULL, active-student, archive, and query-limit contracts preserved'
   );
 
   // 8. Query failures fail closed rather than returning unscoped data.


### PR DESCRIPTION
## Goal

Prevent inactive or archived students from receiving or re-entering active assignment workflows when stale active enrollment rows remain.

## Changes

- require active, non-archived students during class-draft issuance
- reject inactive or archived students during direct code-based issuance
- reject inactive or archived students during ID-based issuance
- exclude inactive or archived students from the active assignment-instance reader
- retain the existing Teacher submissions inactive-student guard
- replace the obsolete regression contract that treated active enrollment alone as sufficient
- add permanent inactive and archived student regression coverage

## Verification

- syntax checks passed for all changed JavaScript files
- `git diff --check` passed
- inactive-student operational guard test passed
- teacher assignment-instance endpoint tests passed
- teacher issue-draft school-year provenance test passed
- focused issuance tests passed
- focused test failures: 0

## Boundaries

- no production or database changes
- no enrollment cleanup
- no Supabase schema, RLS, auth, or grant changes
- no merge or deployment performed
