### PR TITLE
test: align local e2e assignment schema

### DIFF
--- a/tests/local-e2e/schema.sql
+++ b/tests/local-e2e/schema.sql
@@ -266,6 +266,14 @@ CREATE TABLE public.assignments (
   source_type text NOT NULL DEFAULT 'portal'
     CHECK (source_type IN ('portal', 'google_form', 'import')),
   school_year integer,
+
+  -- Local E2E support for current assignment catalog reader.
+  -- These fields mirror the application's behavioral contract only;
+  -- this minimal harness schema is not the canonical production schema.
+  unit_id text,
+  section_id text,
+  tags jsonb NOT NULL DEFAULT '[]'::jsonb,
+
   finalized_at timestamptz
 );
 


### PR DESCRIPTION
## RC-FLOW-02D — Local E2E harness alignment

This PR preserves the harness-only schema alignment verified during the RC-FLOW-02B classroom-core certification.

### Scope

- adds local E2E support for assignment catalog fields:
  - `unit_id`
  - `section_id`
  - `tags`
- changes only `tests/local-e2e/schema.sql`
- does not change application code
- does not define or modify production schema

### Verification

RC-FLOW-02B successfully certified the isolated synthetic workflow:

Teacher Work → targeted student delivery → autosave → fresh-login resume → submission → objective scoring → Teacher Review → finalize → Gradebook → Student result/details → IEP goal evidence → Reporting → non-target isolation.

The harness change was then preserved independently as RC-FLOW-02C.

### Boundary

- no production data was used
- no production Supabase mutation
- no application-code changes
- no merge performed as part of this slice
