### PR TITLE
RC-GOAL-04B: scope goal progress writes to teacher

### DIFF
--- a/netlify/functions/teacher-goal-progress.js
+++ b/netlify/functions/teacher-goal-progress.js
@@ -841,12 +841,66 @@ async function findStudent(
 
   params.set(
     'select',
-    'id,code,name,class_id',
+    'id,code,name,class_id,active,archived_at',
   );
 
   params.set(
     'code',
     `eq.${studentCode}`,
+  );
+
+  params.set(
+    'active',
+    'eq.true',
+  );
+
+  params.set(
+    'archived_at',
+    'is.null',
+  );
+
+  params.set(
+    'limit',
+    '1',
+  );
+
+  const rows =
+    await getRows(
+      'students',
+      params,
+    );
+
+  return rows[0] || null;
+}
+
+async function findActiveStudentById(
+  studentId,
+) {
+  if (!UUID_PATTERN.test(studentId || '')) {
+    return null;
+  }
+
+  const params =
+    new URLSearchParams();
+
+  params.set(
+    'select',
+    'id,code,name,class_id,active,archived_at',
+  );
+
+  params.set(
+    'id',
+    `eq.${studentId}`,
+  );
+
+  params.set(
+    'active',
+    'eq.true',
+  );
+
+  params.set(
+    'archived_at',
+    'is.null',
   );
 
   params.set(
@@ -872,7 +926,7 @@ async function findGoal(
 
   params.set(
     'select',
-    'id,code,student_id',
+    'id,code,student_id,status,active',
   );
 
   params.set(
@@ -886,6 +940,11 @@ async function findGoal(
   );
 
   params.set(
+    'active',
+    'eq.true',
+  );
+
+  params.set(
     'limit',
     '1',
   );
@@ -896,101 +955,333 @@ async function findGoal(
       params,
     );
 
-  return rows[0] || null;
+  const goal =
+    rows[0] || null;
+
+  if (!goal) {
+    return null;
+  }
+
+  const status =
+    (
+      normalizeString(
+        goal.status,
+        50,
+      ) || ''
+    ).toLowerCase();
+
+  if (
+    status === 'closed' ||
+    status === 'archived'
+  ) {
+    return null;
+  }
+
+  return goal;
 }
 
-async function resolveClassId(
+function classMatchesCode(
+  classRow,
   classCode,
-  defaultClassId,
 ) {
-  if (!classCode) {
-    return defaultClassId || null;
-  }
-
-  const params =
-    new URLSearchParams();
-
-  params.set(
-    'select',
-    'id,code,name',
-  );
-
-  params.set(
-    'name',
-    `eq.${classCode}`,
-  );
-
-  params.set(
-    'limit',
-    '1',
-  );
-
-  let rows =
-    await getRows(
-      'classes',
-      params,
+  const requested =
+    normalizeString(
+      classCode,
+      150,
     );
 
-  if (rows.length === 0) {
-    params.delete('name');
-
-    params.set(
-      'code',
-      `eq.${classCode}`,
-    );
-
-    rows =
-      await getRows(
-        'classes',
-        params,
-      );
-  }
-
-  return rows[0]?.id ||
-    defaultClassId ||
-    null;
-}
-
-async function validateInstance(
-  instanceId,
-  studentId,
-) {
-  if (!instanceId) {
-    return true;
-  }
-
-  if (!UUID_PATTERN.test(instanceId)) {
+  if (!requested) {
     return false;
   }
 
-  const params =
+  const needle =
+    requested.toLowerCase();
+
+  return [
+    classRow?.code,
+    classRow?.name,
+  ].some(value => {
+    const normalized =
+      normalizeString(
+        value,
+        150,
+      );
+
+    return (
+      normalized &&
+      normalized.toLowerCase() ===
+        needle
+    );
+  });
+}
+
+async function ownedEnrollmentClasses(
+  studentId,
+  teacherId,
+) {
+  if (
+    !UUID_PATTERN.test(studentId || '') ||
+    !UUID_PATTERN.test(teacherId || '')
+  ) {
+    return [];
+  }
+
+  const enrollmentParams =
     new URLSearchParams();
 
-  params.set(
+  enrollmentParams.set(
     'select',
-    'id,student_id',
+    'class_id',
   );
 
-  params.set(
+  enrollmentParams.set(
+    'student_id',
+    `eq.${studentId}`,
+  );
+
+  enrollmentParams.set(
+    'active',
+    'eq.true',
+  );
+
+  const enrollments =
+    await getRows(
+      'class_enrollments',
+      enrollmentParams,
+    );
+
+  const classIds = [
+    ...new Set(
+      enrollments
+        .map(row => row?.class_id)
+        .filter(id =>
+          UUID_PATTERN.test(id || '')
+        ),
+    ),
+  ];
+
+  if (classIds.length === 0) {
+    return [];
+  }
+
+  const classParams =
+    new URLSearchParams();
+
+  classParams.set(
+    'select',
+    'id,code,name,teacher_id',
+  );
+
+  classParams.set(
+    'id',
+    inFilter(classIds),
+  );
+
+  classParams.set(
+    'teacher_id',
+    `eq.${teacherId}`,
+  );
+
+  const classes =
+    await getRows(
+      'classes',
+      classParams,
+    );
+
+  return classes.filter(row =>
+    UUID_PATTERN.test(row?.id || '')
+  );
+}
+
+async function resolveAuthorizedClassId(
+  studentId,
+  teacherId,
+  defaultClassId,
+  classCode,
+) {
+  const ownedClasses =
+    await ownedEnrollmentClasses(
+      studentId,
+      teacherId,
+    );
+
+  if (ownedClasses.length === 0) {
+    return null;
+  }
+
+  if (classCode) {
+    const requestedClass =
+      ownedClasses.find(row =>
+        classMatchesCode(
+          row,
+          classCode,
+        )
+      );
+
+    return requestedClass?.id || null;
+  }
+
+  if (
+    defaultClassId &&
+    ownedClasses.some(
+      row =>
+        row.id === defaultClassId
+    )
+  ) {
+    return defaultClassId;
+  }
+
+  return ownedClasses[0]?.id || null;
+}
+
+async function resolveAuthorizedInstance(
+  instanceId,
+  studentId,
+  teacherId,
+) {
+  if (!instanceId) {
+    return {
+      ok: true,
+      classId: null,
+    };
+  }
+
+  if (
+    !UUID_PATTERN.test(instanceId) ||
+    !UUID_PATTERN.test(studentId || '') ||
+    !UUID_PATTERN.test(teacherId || '')
+  ) {
+    return {
+      ok: false,
+      classId: null,
+    };
+  }
+
+  const instanceParams =
+    new URLSearchParams();
+
+  instanceParams.set(
+    'select',
+    'id,student_id,assignment_id',
+  );
+
+  instanceParams.set(
     'id',
     `eq.${instanceId}`,
   );
 
-  params.set(
+  instanceParams.set(
     'limit',
     '1',
   );
 
-  const rows =
+  const instances =
     await getRows(
       'assignment_instances',
-      params,
+      instanceParams,
     );
 
-  return (
-    rows.length === 1 &&
-    rows[0].student_id === studentId
+  const instance =
+    instances[0] || null;
+
+  if (
+    !instance ||
+    instance.student_id !== studentId ||
+    instance.assignment_id === null ||
+    instance.assignment_id === undefined
+  ) {
+    return {
+      ok: false,
+      classId: null,
+    };
+  }
+
+  const assignmentParams =
+    new URLSearchParams();
+
+  assignmentParams.set(
+    'select',
+    'id,class_id',
   );
+
+  assignmentParams.set(
+    'id',
+    `eq.${String(
+      instance.assignment_id
+    ).trim()}`,
+  );
+
+  assignmentParams.set(
+    'limit',
+    '1',
+  );
+
+  const assignments =
+    await getRows(
+      'assignments',
+      assignmentParams,
+    );
+
+  const assignment =
+    assignments[0] || null;
+
+  if (
+    !assignment ||
+    !UUID_PATTERN.test(
+      assignment.class_id || ''
+    )
+  ) {
+    return {
+      ok: false,
+      classId: null,
+    };
+  }
+
+  const classParams =
+    new URLSearchParams();
+
+  classParams.set(
+    'select',
+    'id,teacher_id',
+  );
+
+  classParams.set(
+    'id',
+    `eq.${assignment.class_id}`,
+  );
+
+  classParams.set(
+    'teacher_id',
+    `eq.${teacherId}`,
+  );
+
+  classParams.set(
+    'limit',
+    '1',
+  );
+
+  const classes =
+    await getRows(
+      'classes',
+      classParams,
+    );
+
+  if (
+    classes.length !== 1 ||
+    classes[0].id !==
+      assignment.class_id
+  ) {
+    return {
+      ok: false,
+      classId: null,
+    };
+  }
+
+  return {
+    ok: true,
+    classId:
+      assignment.class_id,
+  };
 }
 
 async function insertRows(
@@ -1064,7 +1355,28 @@ async function insertRows(
 
 async function insertProgress(
   body,
+  rawTeacherId,
 ) {
+  const teacherId =
+    normalizeString(
+      rawTeacherId,
+      50,
+    );
+
+  if (
+    !teacherId ||
+    !UUID_PATTERN.test(teacherId)
+  ) {
+    return {
+      status: 403,
+      body: {
+        ok: false,
+        error:
+          'Teacher write context unavailable',
+      },
+    };
+  }
+
   const studentCode =
     normalizeCode(
       body.student_code,
@@ -1161,20 +1473,20 @@ async function insertProgress(
       50,
     );
 
-  if (
-    !(
-      await validateInstance(
-        assignmentInstanceId,
-        student.id,
-      )
-    )
-  ) {
+  const instanceAuthorization =
+    await resolveAuthorizedInstance(
+      assignmentInstanceId,
+      student.id,
+      teacherId,
+    );
+
+  if (!instanceAuthorization.ok) {
     return {
-      status: 400,
+      status: 403,
       body: {
         ok: false,
         error:
-          'Invalid assignment instance for student',
+          'Write target unavailable',
       },
     };
   }
@@ -1185,11 +1497,64 @@ async function insertProgress(
       150,
     );
 
-  const classId =
-    await resolveClassId(
-      classCode,
-      student.class_id,
-    );
+  let classId = null;
+
+  if (instanceAuthorization.classId) {
+    const ownedClasses =
+      await ownedEnrollmentClasses(
+        student.id,
+        teacherId,
+      );
+
+    const instanceClass =
+      ownedClasses.find(
+        row =>
+          row.id ===
+            instanceAuthorization.classId
+      );
+
+    if (
+      !instanceClass ||
+      (
+        classCode &&
+        !classMatchesCode(
+          instanceClass,
+          classCode,
+        )
+      )
+    ) {
+      return {
+        status: 403,
+        body: {
+          ok: false,
+          error:
+            'Write target unavailable',
+        },
+      };
+    }
+
+    classId =
+      instanceClass.id;
+  } else {
+    classId =
+      await resolveAuthorizedClassId(
+        student.id,
+        teacherId,
+        student.class_id,
+        classCode,
+      );
+  }
+
+  if (!classId) {
+    return {
+      status: 403,
+      body: {
+        ok: false,
+        error:
+          'Write target unavailable',
+      },
+    };
+  }
 
   const source =
     normalizeString(
@@ -1247,7 +1612,14 @@ async function insertProgress(
 
 async function insertBatch(
   body,
+  rawTeacherId,
 ) {
+  const teacherId =
+    normalizeString(
+      rawTeacherId,
+      50,
+    );
+
   const studentId =
     normalizeString(
       body.student_id,
@@ -1266,6 +1638,8 @@ async function insertBatch(
       : [];
 
   if (
+    !teacherId ||
+    !UUID_PATTERN.test(teacherId) ||
     !studentId ||
     !UUID_PATTERN.test(studentId) ||
     !assignmentInstanceId ||
@@ -1275,29 +1649,77 @@ async function insertBatch(
     goalRollups.length === 0
   ) {
     return {
-      status: 400,
+      status:
+        teacherId &&
+        UUID_PATTERN.test(teacherId)
+          ? 400
+          : 403,
       body: {
         ok: false,
         error:
-          'student_id, assignment_instance_id, and goal_rollups are required',
+          teacherId &&
+          UUID_PATTERN.test(teacherId)
+            ? 'student_id, assignment_instance_id, and goal_rollups are required'
+            : 'Teacher write context unavailable',
       },
     };
   }
 
+  const student =
+    await findActiveStudentById(
+      studentId,
+    );
+
+  if (!student) {
+    return {
+      status: 404,
+      body: {
+        ok: false,
+        error: 'Student not found',
+      },
+    };
+  }
+
+  const instanceAuthorization =
+    await resolveAuthorizedInstance(
+      assignmentInstanceId,
+      studentId,
+      teacherId,
+    );
+
   if (
-    !(
-      await validateInstance(
-        assignmentInstanceId,
-        studentId,
-      )
-    )
+    !instanceAuthorization.ok ||
+    !instanceAuthorization.classId
   ) {
     return {
-      status: 400,
+      status: 403,
       body: {
         ok: false,
         error:
-          'Invalid assignment instance for student',
+          'Write target unavailable',
+      },
+    };
+  }
+
+  const ownedClasses =
+    await ownedEnrollmentClasses(
+      studentId,
+      teacherId,
+    );
+
+  if (
+    !ownedClasses.some(
+      row =>
+        row.id ===
+          instanceAuthorization.classId
+    )
+  ) {
+    return {
+      status: 403,
+      body: {
+        ok: false,
+        error:
+          'Write target unavailable',
       },
     };
   }
@@ -1338,7 +1760,7 @@ async function insertBatch(
 
   params.set(
     'select',
-    'id,code,student_id',
+    'id,code,student_id,status,active',
   );
 
   params.set(
@@ -1356,15 +1778,36 @@ async function insertBatch(
     ),
   );
 
+  params.set(
+    'active',
+    'eq.true',
+  );
+
   const goals =
     await getRows(
       'goals',
       params,
     );
 
+  const activeGoals =
+    goals.filter(goal => {
+      const status =
+        (
+          normalizeString(
+            goal?.status,
+            50,
+          ) || ''
+        ).toLowerCase();
+
+      return (
+        status !== 'closed' &&
+        status !== 'archived'
+      );
+    });
+
   const goalByCode =
     new Map(
-      goals.map(goal => [
+      activeGoals.map(goal => [
         goal.code,
         goal,
       ]),
@@ -1388,6 +1831,8 @@ async function insertBatch(
         return {
           goal_id: goal.id,
           student_id: studentId,
+          class_id:
+            instanceAuthorization.classId,
           assignment_instance_id:
             assignmentInstanceId,
           date,
@@ -1664,12 +2109,18 @@ exports.handler =
           await listProgress(body);
       } else if (action === 'insert') {
         result =
-          await insertProgress(body);
+          await insertProgress(
+            body,
+            authResult?.user?.teacherId,
+          );
       } else if (
         action === 'insert_batch'
       ) {
         result =
-          await insertBatch(body);
+          await insertBatch(
+            body,
+            authResult?.user?.teacherId,
+          );
       } else if (
         action === 'quarter_averages'
       ) {

--- a/netlify/functions/teacher-goal-progress.js
+++ b/netlify/functions/teacher-goal-progress.js
@@ -1131,7 +1131,9 @@ async function resolveAuthorizedClassId(
     return defaultClassId;
   }
 
-  return ownedClasses[0]?.id || null;
+  return ownedClasses.length === 1
+    ? ownedClasses[0].id
+    : null;
 }
 
 async function resolveAuthorizedInstance(

--- a/tests/teacher-goal-progress-server-boundary.test.cjs
+++ b/tests/teacher-goal-progress-server-boundary.test.cjs
@@ -318,12 +318,14 @@ const {
   )
 );
 
+const teacherId =
+  '11111111-1111-4111-8111-111111111111';
+
 const teacherToken =
   sign(
     {
       role: 'teacher',
-      teacherId:
-        '11111111-1111-4111-8111-111111111111',
+      teacherId,
     },
     process.env.SESSION_SECRET
   );
@@ -453,6 +455,183 @@ async function run() {
     school_year: 2026,
   };
 
+  const assignmentInstanceId =
+    'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+  const assignmentId =
+    '42';
+
+  const foreignStudentId =
+    'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+  const foreignClassId =
+    '99999999-9999-4999-8999-999999999999';
+
+  const activeStudentRow = {
+    id: progressRow.student_id,
+    code: 'S001',
+    name: 'Student S001',
+    class_id: progressRow.class_id,
+    active: true,
+    archived_at: null,
+  };
+
+  const activeGoalRow = {
+    id: progressRow.goal_id,
+    code: 'READ.1',
+    student_id: progressRow.student_id,
+    status: 'Open',
+    active: true,
+  };
+
+  const ownedClassRow = {
+    id: progressRow.class_id,
+    code: 'LA1',
+    name: 'Language Arts 1 SC',
+    teacher_id: teacherId,
+  };
+
+  function makeWriteFetch({
+    studentRows = [activeStudentRow],
+    goalRows = [activeGoalRow],
+    enrollmentRows = [{
+      class_id: progressRow.class_id,
+    }],
+    classRows = [ownedClassRow],
+    instanceRows = [{
+      id: assignmentInstanceId,
+      student_id: progressRow.student_id,
+      assignment_id: assignmentId,
+    }],
+    assignmentRows = [{
+      id: assignmentId,
+      class_id: progressRow.class_id,
+    }],
+    allowWrite = true,
+    capturePayload = null,
+  } = {}) {
+    return async (url, init = {}) => {
+      const target = String(url);
+
+      calls.push({
+        url: target,
+        init,
+      });
+
+      if (
+        target.includes(
+          '/rest/v1/students?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          studentRows
+        );
+      }
+
+      if (
+        target.includes(
+          '/rest/v1/goals?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          goalRows
+        );
+      }
+
+      if (
+        target.includes(
+          '/rest/v1/class_enrollments?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          enrollmentRows
+        );
+      }
+
+      if (
+        target.includes(
+          '/rest/v1/assignment_instances?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          instanceRows
+        );
+      }
+
+      if (
+        target.includes(
+          '/rest/v1/assignments?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          assignmentRows
+        );
+      }
+
+      if (
+        target.includes(
+          '/rest/v1/classes?'
+        )
+      ) {
+        return mockResponse(
+          200,
+          classRows
+        );
+      }
+
+      if (
+        target.endsWith(
+          '/rest/v1/goal_progress'
+        ) &&
+        init.method === 'POST'
+      ) {
+        if (!allowWrite) {
+          throw new Error(
+            'Unauthorized canonical write attempted'
+          );
+        }
+
+        const payload =
+          JSON.parse(init.body);
+
+        if (capturePayload) {
+          capturePayload(payload);
+        }
+
+        return mockResponse(
+          201,
+          payload.map(
+            (row, index) => ({
+              id:
+                index === 0
+                  ? progressRow.id
+                  : undefined,
+              ...row,
+            })
+          )
+        );
+      }
+
+      throw new Error(
+        `Unexpected write URL: ${target}`
+      );
+    };
+  }
+
+  function hasCanonicalWrite() {
+    return calls.some(call =>
+      call.url.endsWith(
+        '/rest/v1/goal_progress'
+      ) &&
+      call.init.method === 'POST'
+    );
+  }
+
   global.fetch =
     async (url, init = {}) => {
       const target = String(url);
@@ -579,69 +758,11 @@ async function run() {
   let insertedPayload = null;
 
   global.fetch =
-    async (url, init = {}) => {
-      const target = String(url);
-
-      calls.push({
-        url: target,
-        init,
-      });
-
-      if (
-        target.includes(
-          '/rest/v1/students?'
-        )
-      ) {
-        return mockResponse(
-          200,
-          [{
-            id: progressRow.student_id,
-            code: 'S001',
-            name: 'Student S001',
-            class_id:
-              progressRow.class_id,
-          }]
-        );
-      }
-
-      if (
-        target.includes(
-          '/rest/v1/goals?'
-        )
-      ) {
-        return mockResponse(
-          200,
-          [{
-            id: progressRow.goal_id,
-            code: 'READ.1',
-            student_id:
-              progressRow.student_id,
-          }]
-        );
-      }
-
-      if (
-        target.endsWith(
-          '/rest/v1/goal_progress'
-        ) &&
-        init.method === 'POST'
-      ) {
-        insertedPayload =
-          JSON.parse(init.body);
-
-        return mockResponse(
-          201,
-          [{
-            id: progressRow.id,
-            ...insertedPayload[0],
-          }]
-        );
-      }
-
-      throw new Error(
-        `Unexpected insert URL: ${target}`
-      );
-    };
+    makeWriteFetch({
+      capturePayload(payload) {
+        insertedPayload = payload;
+      },
+    });
 
   const insertResponse =
     await handler(
@@ -680,6 +801,12 @@ async function run() {
   assert.strictEqual(
     insertedPayload[0].school_year,
     2026
+  );
+
+  assert.strictEqual(
+    insertedPayload[0].class_id,
+    progressRow.class_id,
+    'manual evidence must use an actively enrolled teacher-owned class'
   );
 
   assert.strictEqual(
@@ -748,78 +875,340 @@ async function run() {
 
   calls = [];
 
-  const assignmentInstanceId =
-    'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+  global.fetch =
+    makeWriteFetch({
+      studentRows: [],
+      allowWrite: false,
+    });
+
+  const inactiveStudentResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        date: '2026-08-01',
+        value: 70,
+      })
+    );
+
+  assert.strictEqual(
+    inactiveStudentResponse.statusCode,
+    404,
+    'inactive or archived student must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false,
+    'inactive or archived student must never reach canonical write'
+  );
+
+  assert(
+    calls.some(call =>
+      call.url.includes('/rest/v1/students?') &&
+      call.url.includes('active=eq.true') &&
+      call.url.includes('archived_at=is.null')
+    ),
+    'student write lookup must require active non-archived status'
+  );
+
+  console.log(
+    '✓ inactive or archived student cannot receive manual evidence'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      goalRows: [],
+      allowWrite: false,
+    });
+
+  const inactiveGoalResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        date: '2026-08-01',
+        value: 70,
+      })
+    );
+
+  assert.strictEqual(
+    inactiveGoalResponse.statusCode,
+    404,
+    'inactive or unavailable goal must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false,
+    'inactive goal must never reach canonical write'
+  );
+
+  assert(
+    calls.some(call =>
+      call.url.includes('/rest/v1/goals?') &&
+      call.url.includes('active=eq.true')
+    ),
+    'goal write lookup must require active goals'
+  );
+
+  console.log(
+    '✓ inactive or foreign goal cannot receive manual evidence'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      enrollmentRows: [],
+      allowWrite: false,
+    });
+
+  const noEnrollmentResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        date: '2026-08-01',
+        value: 70,
+      })
+    );
+
+  assert.strictEqual(
+    noEnrollmentResponse.statusCode,
+    403,
+    'manual evidence must require active teacher-owned enrollment'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false
+  );
+
+  console.log(
+    '✓ manual evidence requires active teacher-owned enrollment'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      allowWrite: false,
+    });
+
+  const foreignClassResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        class_code: 'FOREIGN-CLASS',
+        date: '2026-08-01',
+        value: 70,
+      })
+    );
+
+  assert.strictEqual(
+    foreignClassResponse.statusCode,
+    403,
+    'foreign requested class must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false
+  );
+
+  console.log(
+    '✓ foreign requested class cannot receive manual evidence'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      instanceRows: [{
+        id: assignmentInstanceId,
+        student_id: foreignStudentId,
+        assignment_id: assignmentId,
+      }],
+      allowWrite: false,
+    });
+
+  const mismatchedInstanceResponse =
+    await handler(
+      eventFor({
+        action: 'insert_batch',
+        student_id:
+          progressRow.student_id,
+        assignment_instance_id:
+          assignmentInstanceId,
+        goal_rollups: [{
+          goal_code: 'READ.1',
+          percent_correct: 80,
+        }],
+      })
+    );
+
+  assert.strictEqual(
+    mismatchedInstanceResponse.statusCode,
+    403,
+    'instance/student mismatch must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false
+  );
+
+  console.log(
+    '✓ assignment instance/student mismatch cannot write evidence'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      assignmentRows: [{
+        id: assignmentId,
+        class_id: foreignClassId,
+      }],
+      classRows: [],
+      allowWrite: false,
+    });
+
+  const foreignAssignmentResponse =
+    await handler(
+      eventFor({
+        action: 'insert_batch',
+        student_id:
+          progressRow.student_id,
+        assignment_instance_id:
+          assignmentInstanceId,
+        goal_rollups: [{
+          goal_code: 'READ.1',
+          percent_correct: 80,
+        }],
+      })
+    );
+
+  assert.strictEqual(
+    foreignAssignmentResponse.statusCode,
+    403,
+    'assignment class outside signed teacher ownership must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false
+  );
+
+  console.log(
+    '✓ assignment evidence must traverse a teacher-owned assignment class'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      enrollmentRows: [],
+      allowWrite: false,
+    });
+
+  const batchNoEnrollmentResponse =
+    await handler(
+      eventFor({
+        action: 'insert_batch',
+        student_id:
+          progressRow.student_id,
+        assignment_instance_id:
+          assignmentInstanceId,
+        goal_rollups: [{
+          goal_code: 'READ.1',
+          percent_correct: 80,
+        }],
+      })
+    );
+
+  assert.strictEqual(
+    batchNoEnrollmentResponse.statusCode,
+    403,
+    'assignment evidence must require active enrollment in assignment class'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false
+  );
+
+  console.log(
+    '✓ assignment evidence requires active enrolled teacher-owned class'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      goalRows: [],
+      allowWrite: false,
+    });
+
+  const batchInactiveGoalResponse =
+    await handler(
+      eventFor({
+        action: 'insert_batch',
+        student_id:
+          progressRow.student_id,
+        assignment_instance_id:
+          assignmentInstanceId,
+        goal_rollups: [{
+          goal_code: 'READ.1',
+          percent_correct: 80,
+        }],
+      })
+    );
+
+  assert.strictEqual(
+    batchInactiveGoalResponse.statusCode,
+    200,
+    'unavailable assignment goal may be safely skipped'
+  );
+
+  const batchInactiveGoalBody =
+    JSON.parse(
+      batchInactiveGoalResponse.body
+    );
+
+  assert.strictEqual(
+    batchInactiveGoalBody.inserted_count,
+    0
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false,
+    'inactive or foreign assignment goal must never be written'
+  );
+
+  console.log(
+    '✓ inactive or foreign assignment goal is safely skipped without write'
+  );
+
+  calls = [];
 
   let batchPayload = null;
 
   global.fetch =
-    async (url, init = {}) => {
-      const target = String(url);
-
-      calls.push({
-        url: target,
-        init,
-      });
-
-      if (
-        target.includes(
-          '/rest/v1/assignment_instances?'
-        )
-      ) {
-        return mockResponse(
-          200,
-          [{
-            id: assignmentInstanceId,
-            student_id:
-              progressRow.student_id,
-          }]
-        );
-      }
-
-      if (
-        target.includes(
-          '/rest/v1/goals?'
-        )
-      ) {
-        return mockResponse(
-          200,
-          [{
-            id: progressRow.goal_id,
-            code: 'READ.1',
-            student_id:
-              progressRow.student_id,
-          }]
-        );
-      }
-
-      if (
-        target.endsWith(
-          '/rest/v1/goal_progress'
-        ) &&
-        init.method === 'POST'
-      ) {
-        batchPayload =
-          JSON.parse(init.body);
-
-        return mockResponse(
-          201,
-          batchPayload.map(
-            (row, index) => ({
-              id:
-                index === 0
-                  ? progressRow.id
-                  : undefined,
-              ...row,
-            })
-          )
-        );
-      }
-
-      throw new Error(
-        `Unexpected batch URL: ${target}`
-      );
-    };
+    makeWriteFetch({
+      capturePayload(payload) {
+        batchPayload = payload;
+      },
+    });
 
   const batchResponse =
     await handler(
@@ -884,6 +1273,18 @@ async function run() {
   assert.strictEqual(
     batchPayload[0].value,
     88
+  );
+
+  assert.strictEqual(
+    batchPayload[0].class_id,
+    progressRow.class_id,
+    'assignment evidence must derive canonical teacher-owned class'
+  );
+
+  assert.strictEqual(
+    batchPayload[0].school_year,
+    2026,
+    'assignment evidence must preserve canonical school year'
   );
 
   console.log(

--- a/tests/teacher-goal-progress-server-boundary.test.cjs
+++ b/tests/teacher-goal-progress-server-boundary.test.cjs
@@ -467,6 +467,9 @@ async function run() {
   const foreignClassId =
     '99999999-9999-4999-8999-999999999999';
 
+  const secondOwnedClassId =
+    '88888888-8888-4888-8888-888888888888';
+
   const activeStudentRow = {
     id: progressRow.student_id,
     code: 'S001',
@@ -1026,6 +1029,102 @@ async function run() {
 
   console.log(
     '✓ foreign requested class cannot receive manual evidence'
+  );
+
+  calls = [];
+  insertedPayload = null;
+
+  global.fetch =
+    makeWriteFetch({
+      studentRows: [{
+        ...activeStudentRow,
+        class_id: foreignClassId,
+      }],
+      capturePayload(payload) {
+        insertedPayload = payload;
+      },
+    });
+
+  const soleClassFallbackResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        date: '2026-08-01',
+        value: 71,
+      })
+    );
+
+  assert.strictEqual(
+    soleClassFallbackResponse.statusCode,
+    200,
+    'exactly one authorized class may serve as the sole fallback'
+  );
+
+  assert.strictEqual(
+    insertedPayload[0].class_id,
+    progressRow.class_id,
+    'sole authorized class must become canonical class_id'
+  );
+
+  console.log(
+    '✓ sole authorized class remains a deterministic fallback'
+  );
+
+  calls = [];
+
+  global.fetch =
+    makeWriteFetch({
+      studentRows: [{
+        ...activeStudentRow,
+        class_id: foreignClassId,
+      }],
+      enrollmentRows: [
+        {
+          class_id: progressRow.class_id,
+        },
+        {
+          class_id: secondOwnedClassId,
+        },
+      ],
+      classRows: [
+        ownedClassRow,
+        {
+          id: secondOwnedClassId,
+          code: 'LA2',
+          name: 'Language Arts 2 SC',
+          teacher_id: teacherId,
+        },
+      ],
+      allowWrite: false,
+    });
+
+  const ambiguousClassResponse =
+    await handler(
+      eventFor({
+        action: 'insert',
+        student_code: 'S001',
+        goal_code: 'READ.1',
+        date: '2026-08-01',
+        value: 72,
+      })
+    );
+
+  assert.strictEqual(
+    ambiguousClassResponse.statusCode,
+    403,
+    'multiple authorized classes without an explicit/default match must fail closed'
+  );
+
+  assert.strictEqual(
+    hasCanonicalWrite(),
+    false,
+    'ambiguous class context must never reach canonical write'
+  );
+
+  console.log(
+    '✓ ambiguous multi-class context fails closed without guessing'
   );
 
   calls = [];


### PR DESCRIPTION
## RC-GOAL-04B — Canonical goal-progress write authorization

Hardens only the canonical `teacher-goal-progress` write paths so a valid
Teacher Center session can write goal evidence only within the signed
teacher's authorized classroom context.

### Write authorization

Manual writes now require:

- active, non-archived student
- active student-owned goal
- active class enrollment
- teacher-owned class
- requested class, when supplied, must match that authorized context

Assignment rollup writes now require:

- active, non-archived student
- assignment instance belongs to that student
- instance resolves to its canonical assignment
- assignment resolves to a class owned by the signed teacher
- student is actively enrolled in that class
- only active student-owned goals may receive evidence

### Preserved behavior

- canonical source provenance remains intact
- non-percent finite manual measurements remain valid
- canonical school-year stamping remains intact
- assignment evidence retains assignment-instance provenance
- existing `list` behavior is unchanged
- existing `quarter_averages` behavior is unchanged
- Observation Tray canonical writer behavior is unchanged

### Validation

- focused teacher goal-progress authorization boundary: PASS
- canonical Observation writer regression: PASS
- complete `TZ=UTC` unit suite: PASS
- Node/CommonJS syntax and focused lint: PASS
- read functions verified byte-identical to production base
- exact two-file scope

### Boundaries

- no schema change
- no RLS change
- no auth-setting change
- no database migration
- no historical-data rewrite
- no read-authorization changes in this slice
