### PR TITLE
RC-LIBRARY-01: Add Student Portal Library shell

### DIFF
--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6031,6 +6031,7 @@
           <nav class="tc-nav">
             <a href="#" data-tab="dashboard" class="active"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg></span><span class="tc-label">Dashboard</span></a>
             <a href="#" data-tab="assignments"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg></span><span class="tc-label">Assignments</span></a>
+            <a href="#" data-tab="library"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path></svg></span><span class="tc-label">Library</span></a>
             <a href="#" data-tab="resources"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></span><span class="tc-label">Resources</span></a>
             <a href="#" data-tab="grades"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg></span><span class="tc-label">Grades</span></a>
             <a href="#" data-tab="goals"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="6"></circle><circle cx="12" cy="12" r="2"></circle></svg></span><span class="tc-label">Goals</span></a>
@@ -6136,6 +6137,7 @@
             <nav class="st-tab-nav" id="studentTabNav">
               <button class="st-tab-link active" data-tab="dashboard"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg> Dashboard</button>
               <button class="st-tab-link" data-tab="assignments"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Assignments</button>
+              <button class="st-tab-link" data-tab="library"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path></svg> Library</button>
               <button class="st-tab-link" data-tab="resources"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg> Resources</button>
               <button class="st-tab-link" data-tab="grades"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg> Grades</button>
               <button class="st-tab-link" data-tab="goals"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="6"></circle><circle cx="12" cy="12" r="2"></circle></svg> Goals</button>
@@ -6279,6 +6281,21 @@
               </div>
             </div>
 
+            <!-- Tab: Library -->
+            <div id="tabLibrary" class="st-tab-panel">
+              <div class="st-dashboard-content">
+                <h1 style="margin-top:0;">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="display:inline-block;vertical-align:middle;margin-right:10px;">
+                    <path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path>
+                    <path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path>
+                  </svg>
+                  Library
+                </h1>
+                <p style="opacity:0.8; margin-bottom:24px;">Classroom books and reading</p>
+                <div id="libraryContent"><p style="opacity:0.7;">Loading your library...</p></div>
+              </div>
+            </div>
+
             <!-- Tab: Resources -->
             <div id="tabResources" class="st-tab-panel">
               <div class="st-dashboard-content">
@@ -6289,7 +6306,7 @@
                   </svg>
                   Resources
                 </h1>
-                <p style="opacity:0.8; margin-bottom:24px;">Reading materials and reference documents</p>
+                <p style="opacity:0.8; margin-bottom:24px;">Learning tools, presentations, guided notes, and reference materials</p>
                 <div id="resourcesContent"><p style="opacity:0.7;">Loading resources...</p></div>
               </div>
             </div>

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6371,6 +6371,6 @@
     <!-- CACHE-BUST: Update the ?v= parameter below whenever JS files change. Use format: YYYYMMDD or PR number. -->
     <script defer src="/web/student-shell.js?v=20260418-catalog"></script>
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
-    <script defer src="/web/student-portal-init.js?v=2026072001"></script>
+    <script defer src="/web/student-portal-init.js?v=2026081101"></script>
   </body>
 </html>

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -4086,6 +4086,7 @@
       'dashboard': 'tabDashboard',
       'goals': 'tabGoals',
       'assignments': 'tabAssignments',
+      'library': 'tabLibrary',
       'resources': 'tabResources',
       'grades': 'tabGrades',
       'settings': 'tabSettings'
@@ -7216,98 +7217,202 @@
   /**
    * Load and render student resources from site-state.json
    */
-  async function loadStudentResources() {
-    const el = document.getElementById('resourcesContent');
-    if (!el) return;
+  /**
+   * Detect whether a Student Portal resource contains inline book data.
+   * Chunked book-index.json is preferred; book-pages.json remains the
+   * legacy fallback.
+   */
+  async function detectStudentBookResource(link) {
+    const base = link.endsWith('/') ? link : link + '/';
+    const candidates = ['book-index.json', 'book-pages.json'];
+
+    for (const filename of candidates) {
+      try {
+        const response = await fetch(base + filename, { method: 'HEAD' });
+        if (response.ok) return filename;
+      } catch (err) {
+        // A failed probe simply means this candidate is not usable here.
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Load book metadata for Reading Helper deep-links.
+   * Mirrors openBookReader(): prefer the chunked index and preserve
+   * book-pages.json as the legacy fallback.
+   */
+  async function loadStudentBookMetadata(link) {
+    const base = link.endsWith('/') ? link : link + '/';
 
     try {
-      const res = await fetch('/assets/data/site-state.json');
-      if (!res.ok) throw new Error('Failed to load');
-      const state = await res.json();
+      let response = await fetch(base + 'book-index.json');
+      if (response.ok) return await response.json();
 
-      const cat = state.categories && state.categories.student_resources;
-      if (!cat) {
-        el.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-icon"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></div><div class="st-resources-empty-msg">No resources available yet.</div><div style="font-size:14px;opacity:0.6;">Your teacher hasn\'t uploaded any reading materials.</div></div>';
-        return;
-      }
+      response = await fetch(base + 'book-pages.json');
+      if (response.ok) return await response.json();
+    } catch (err) {
+      // Metadata is an enhancement; book opening remains authoritative.
+    }
 
-      const titles = cat.titles || [];
-      const links = cat.links || [];
+    return null;
+  }
 
-      // Collect non-empty slots
-      const resources = [];
-      for (let i = 0; i < titles.length; i++) {
-        const title = (titles[i] || '').trim();
-        const link = (links[i] || '').trim();
-        if (title && link) {
-          resources.push({ title, link, index: i });
-        }
-      }
+  /**
+   * Load and separate Student Portal Library books from general Resources.
+   */
+  async function loadStudentResources() {
+    const resourcesEl = document.getElementById('resourcesContent');
+    const libraryEl = document.getElementById('libraryContent');
+    if (!resourcesEl || !libraryEl) return;
 
+    const escapeHtml = function (value) {
+      return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    };
+
+    const bookSvg = '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path></svg>';
+    const resourceSvg = '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line></svg>';
+
+    const renderResources = function (resources) {
       if (!resources.length) {
-        el.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-icon"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></div><div class="st-resources-empty-msg">No resources available yet.</div><div style="font-size:14px;opacity:0.6;">Your teacher hasn\'t uploaded any reading materials.</div></div>';
+        resourcesEl.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-msg">No learning resources available yet.</div><div style="font-size:14px;opacity:0.6;">Your teacher hasn\'t added any additional materials.</div></div>';
         return;
       }
 
-      // Build card grid
       let html = '<div class="st-resources-grid">';
-      for (const r of resources) {
-        const svg = '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>';
-        const safeTitle = r.title.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-        html += '<a class="st-resource-card" href="' + r.link + '" target="_blank" rel="noopener" data-resource-link="' + r.link + '" data-resource-title="' + safeTitle + '">' + svg + '<div class="st-resource-card-title">' + safeTitle + '</div><div class="st-resource-card-badge" style="display:none;font-size:12px;margin-top:6px;opacity:0.75;">📖 Read inline</div><div class="st-resource-progress" style="display:none;margin-top:8px;"></div></a>';
+      for (const resource of resources) {
+        const safeTitle = escapeHtml(resource.title);
+        const safeLink = escapeHtml(resource.link);
+        html += '<a class="st-resource-card" href="' + safeLink + '" target="_blank" rel="noopener">' +
+          resourceSvg +
+          '<div class="st-resource-card-title">' + safeTitle + '</div>' +
+          '</a>';
       }
       html += '</div>';
-      el.innerHTML = html;
+      resourcesEl.innerHTML = html;
+    };
 
-      // After rendering, check each card for book-pages.json (async, non-blocking)
-      const cards = el.querySelectorAll('.st-resource-card[data-resource-link]');
+    const renderLibrary = function (books) {
+      if (!books.length) {
+        libraryEl.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-msg">No classroom books available yet.</div><div style="font-size:14px;opacity:0.6;">Your teacher hasn\'t added a book to your library.</div></div>';
+        return;
+      }
+
+      let html = '<div class="st-resources-grid">';
+      for (const book of books) {
+        const safeTitle = escapeHtml(book.title);
+        const safeLink = escapeHtml(book.link);
+
+        html += '<a class="st-resource-card" href="' + safeLink + '" data-library-book="true" data-resource-link="' + safeLink + '" data-resource-title="' + safeTitle + '">' +
+          bookSvg +
+          '<div class="st-resource-card-title">' + safeTitle + '</div>' +
+          '<div class="st-resource-card-badge" style="font-size:12px;margin-top:6px;opacity:0.75;">📖 Read inline</div>' +
+          '<div class="st-resource-progress" style="display:none;margin-top:8px;"></div>' +
+          '</a>';
+      }
+      html += '</div>';
+      libraryEl.innerHTML = html;
+
+      const cards = libraryEl.querySelectorAll('.st-resource-card[data-library-book="true"]');
       cards.forEach(function (card) {
         const link = card.getAttribute('data-resource-link');
         const title = card.getAttribute('data-resource-title');
-        const base = link.endsWith('/') ? link : link + '/';
-        // Attempt HEAD request first to avoid downloading the full file
-        fetch(base + 'book-pages.json', { method: 'HEAD' }).then(function (r) {
-          if (r.ok) {
-            // Has book-pages.json — switch card to inline reader
-            card.removeAttribute('href');
-            card.removeAttribute('target');
-            card.removeAttribute('rel');
-            card.style.cursor = 'pointer';
-            const badge = card.querySelector('.st-resource-card-badge');
-            if (badge) badge.style.display = 'block';
-            card.addEventListener('click', function (e) {
-              e.preventDefault();
-              openBookReader(link, title);
-            });
-            // Show reading progress if available
-            const storageKey = 'rc_book_page_' + encodeURIComponent(link);
-            const savedPage = parseInt(localStorage.getItem(storageKey) || '0', 10);
-            const savedTotal = parseInt(localStorage.getItem(storageKey + '_total') || '0', 10);
-            if (savedPage > 0 && savedTotal > 0) {
-              const pct = Math.round(savedPage / Math.max(1, savedTotal) * 100);
-              const progressEl = card.querySelector('.st-resource-progress');
-              if (progressEl) {
-                progressEl.innerHTML = `<div class="st-resource-progress-text">Page ${savedPage} of ${savedTotal} \u00b7 ${pct}% read</div><div class="st-resource-progress-bar"><div class="st-resource-progress-fill" style="width:${pct}%"></div></div>`;
-                progressEl.style.display = 'block';
-              }
-            }
-            // Populate _knownBookResources for hint deep-links (fetch full JSON)
-            if (!_knownBookResources.find(function (x) { return x.link === link; })) {
-              fetch(base + 'book-pages.json').then(function (r2) {
-                return r2.ok ? r2.json() : null;
-              }).then(function (bd) {
-                if (bd && bd.chapters && !_knownBookResources.find(function (x) { return x.link === link; })) {
-                  _knownBookResources.push({ link: link, title: title, chapters: bd.chapters, totalPages: bd.totalPages || 0 });
-                }
-              }).catch(function () {});
-            }
+
+        card.removeAttribute('target');
+        card.removeAttribute('rel');
+        card.style.cursor = 'pointer';
+
+        card.addEventListener('click', function (event) {
+          event.preventDefault();
+          openBookReader(link, title);
+        });
+
+        const storageKey = 'rc_book_page_' + encodeURIComponent(link);
+        const savedPage = parseInt(localStorage.getItem(storageKey) || '0', 10);
+        const savedTotal = parseInt(localStorage.getItem(storageKey + '_total') || '0', 10);
+
+        if (savedPage > 0 && savedTotal > 0) {
+          const pct = Math.round(savedPage / Math.max(1, savedTotal) * 100);
+          const progressEl = card.querySelector('.st-resource-progress');
+
+          if (progressEl) {
+            progressEl.innerHTML =
+              '<div class="st-resource-progress-text">Page ' + savedPage + ' of ' + savedTotal + ' · ' + pct + '% read</div>' +
+              '<div class="st-resource-progress-bar"><div class="st-resource-progress-fill" style="width:' + pct + '%"></div></div>';
+            progressEl.style.display = 'block';
           }
-        }).catch(function () { /* no book-pages.json, leave as external link */ });
+        }
+
+        if (!_knownBookResources.find(function (item) { return item.link === link; })) {
+          loadStudentBookMetadata(link).then(function (bookData) {
+            if (
+              bookData &&
+              bookData.chapters &&
+              !_knownBookResources.find(function (item) { return item.link === link; })
+            ) {
+              _knownBookResources.push({
+                link: link,
+                title: title,
+                chapters: bookData.chapters,
+                totalPages: bookData.totalPages || 0
+              });
+            }
+          }).catch(function () {});
+        }
+      });
+    };
+
+    try {
+      const response = await fetch('/assets/data/site-state.json');
+      if (!response.ok) throw new Error('Failed to load site state');
+
+      const state = await response.json();
+      const category = state.categories && state.categories.student_resources;
+
+      if (!category) {
+        renderLibrary([]);
+        renderResources([]);
+        return;
+      }
+
+      const titles = category.titles || [];
+      const links = category.links || [];
+      const entries = [];
+
+      for (let i = 0; i < titles.length; i++) {
+        const title = (titles[i] || '').trim();
+        const link = (links[i] || '').trim();
+
+        if (title && link) {
+          entries.push({ title: title, link: link, index: i });
+        }
+      }
+
+      const classified = await Promise.all(entries.map(async function (entry) {
+        const bookDataFile = await detectStudentBookResource(entry.link);
+        return Object.assign({}, entry, { bookDataFile: bookDataFile });
+      }));
+
+      const books = classified.filter(function (entry) {
+        return Boolean(entry.bookDataFile);
       });
 
+      const resources = classified.filter(function (entry) {
+        return !entry.bookDataFile;
+      });
+
+      renderLibrary(books);
+      renderResources(resources);
     } catch (err) {
-      console.error(LOG_PREFIX, 'Failed to load resources:', err);
-      el.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-icon"><svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg></div><div class="st-resources-empty-msg">Unable to load resources</div><div style="font-size:14px;opacity:0.6;">Please try again later.</div></div>';
+      console.error(LOG_PREFIX, 'Failed to load student Library/Resources:', err);
+
+      libraryEl.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-msg">Unable to load your library</div><div style="font-size:14px;opacity:0.6;">Please try again later.</div></div>';
+      resourcesEl.innerHTML = '<div class="st-resources-empty"><div class="st-resources-empty-msg">Unable to load resources</div><div style="font-size:14px;opacity:0.6;">Please try again later.</div></div>';
     }
   }
 

--- a/tests/student-library-shell.spec.js
+++ b/tests/student-library-shell.spec.js
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test';
+
+const SYNTHETIC_CODE = 'S001';
+
+async function mockStudentFunctions(page) {
+  await page.route('**/.netlify/functions/**', async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    // Browser Supabase configuration is intentionally unavailable in this
+    // synthetic test. Student Portal behavior is exercised through mocked
+    // server endpoints only.
+    if (pathname.endsWith('/browser-supabase-config')) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: false,
+          error: 'Not used by synthetic Library smoke test',
+        }),
+      });
+      return;
+    }
+
+    const syntheticStudent = {
+      code: SYNTHETIC_CODE,
+      name: 'Synthetic Student',
+      active: true,
+      class_id: null,
+    };
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        code: SYNTHETIC_CODE,
+        name: 'Synthetic Student',
+        student: syntheticStudent,
+        students: [syntheticStudent],
+        assignments: [],
+        instances: [],
+        submissions: [],
+        goals: [],
+        progress: [],
+        data_points: [],
+      }),
+    });
+  });
+}
+
+test.describe('RC-LIBRARY-01 Student Portal Library shell', () => {
+  test('separates books from Resources and opens Lost inline', async ({
+    context,
+    page,
+  }) => {
+    await context.addInitScript((studentCode) => {
+      sessionStorage.setItem('rc_user_role', 'student');
+      sessionStorage.setItem('rc_user_code', studentCode);
+    }, SYNTHETIC_CODE);
+
+    await mockStudentFunctions(page);
+
+    const bookIndexRequests = [];
+
+    page.on('request', (request) => {
+      if (
+        request.url().includes(
+          '/student/resources/presentation-02/book-index.json'
+        )
+      ) {
+        bookIndexRequests.push(request.method());
+      }
+    });
+
+    await page.goto('/student/');
+
+    await expect(
+      page.locator('#studentDashboardView')
+    ).toBeVisible({ timeout: 10000 });
+
+    // Library should contain the book and not the instructional resource.
+    await page.locator('[data-tab="library"]:visible').first().click();
+
+    await expect(page.locator('#tabLibrary')).toHaveClass(/active/);
+
+    const library = page.locator('#libraryContent');
+
+    await expect(library).toContainText(
+      '"Lost in Kragdon-ah" by Shawn Inmon',
+      { timeout: 10000 }
+    );
+
+    await expect(library).not.toContainText(
+      'Language Arts Skill Builder'
+    );
+
+    const lostCard = library.locator(
+      '.st-resource-card[data-library-book="true"]',
+      { hasText: 'Lost in Kragdon-ah' }
+    );
+
+    await expect(lostCard).toHaveCount(1);
+    await expect(lostCard).toBeVisible();
+
+    // Resources should contain Skill Builder and not the book.
+    await page.locator('[data-tab="resources"]:visible').first().click();
+
+    await expect(page.locator('#tabResources')).toHaveClass(/active/);
+
+    const resources = page.locator('#resourcesContent');
+
+    await expect(resources).toContainText(
+      'Language Arts Skill Builder'
+    );
+
+    await expect(resources).not.toContainText(
+      'Lost in Kragdon-ah'
+    );
+
+    // Return to Library and prove the existing inline reader opens.
+    await page.locator('[data-tab="library"]:visible').first().click();
+
+    const requestsBeforeOpen = bookIndexRequests.length;
+
+    await lostCard.click();
+
+    await expect(page.locator('#bookTtsBtn')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(
+      page.locator('#bookReadingHelperBtn')
+    ).toBeVisible();
+
+    // Inline means we remain in Student Portal rather than navigating
+    // to the generated resource landing page.
+    expect(page.url()).toContain('/student/');
+    expect(page.url()).not.toContain('/presentation-02/');
+
+    // Detection uses HEAD; opening the reader should add a GET for
+    // the actual chunked book index.
+    await expect
+      .poll(() => bookIndexRequests.length)
+      .toBeGreaterThan(requestsBeforeOpen);
+
+    expect(bookIndexRequests).toContain('GET');
+  });
+});

--- a/tests/student-library-shell.test.cjs
+++ b/tests/student-library-shell.test.cjs
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const studentHtml = fs.readFileSync(
+  path.join(ROOT, 'site/student/index.html'),
+  'utf8'
+);
+const portalJs = fs.readFileSync(
+  path.join(ROOT, 'site/web/student-portal-init.js'),
+  'utf8'
+);
+
+test('Student Portal exposes Library in both navigation surfaces', () => {
+  const libraryLinks = studentHtml.match(/data-tab="library"/g) || [];
+  assert.equal(libraryLinks.length, 2);
+  assert.match(studentHtml, /id="tabLibrary"/);
+  assert.match(studentHtml, /id="libraryContent"/);
+});
+
+test('Resources remains a separate Student Portal destination', () => {
+  const resourceLinks = studentHtml.match(/data-tab="resources"/g) || [];
+  assert.equal(resourceLinks.length, 2);
+  assert.match(studentHtml, /id="tabResources"/);
+  assert.match(studentHtml, /id="resourcesContent"/);
+});
+
+test('tab router maps Library independently from Resources', () => {
+  assert.match(portalJs, /'library':\s*'tabLibrary'/);
+  assert.match(portalJs, /'resources':\s*'tabResources'/);
+});
+
+test('book classification prefers chunked index and preserves legacy fallback', () => {
+  const detectorStart = portalJs.indexOf(
+    'async function detectStudentBookResource'
+  );
+  assert.notEqual(detectorStart, -1);
+
+  const detectorEnd = portalJs.indexOf(
+    'async function loadStudentBookMetadata',
+    detectorStart
+  );
+  assert.notEqual(detectorEnd, -1);
+
+  const detector = portalJs.slice(detectorStart, detectorEnd);
+
+  const indexPos = detector.indexOf('book-index.json');
+  const pagesPos = detector.indexOf('book-pages.json');
+
+  assert.ok(indexPos >= 0);
+  assert.ok(pagesPos >= 0);
+  assert.ok(indexPos < pagesPos);
+});
+
+test('Library and Resources are rendered into separate containers', () => {
+  assert.match(
+    portalJs,
+    /document\.getElementById\('libraryContent'\)/
+  );
+  assert.match(
+    portalJs,
+    /document\.getElementById\('resourcesContent'\)/
+  );
+  assert.match(
+    portalJs,
+    /const books = classified\.filter/
+  );
+  assert.match(
+    portalJs,
+    /const resources = classified\.filter/
+  );
+});
+
+test('existing reader still prefers book-index with book-pages fallback', () => {
+  const readerStart = portalJs.indexOf('async function openBookReader');
+  assert.notEqual(readerStart, -1);
+
+  const readerEnd = portalJs.indexOf(
+    '// Remove loading backdrop',
+    readerStart
+  );
+  assert.notEqual(readerEnd, -1);
+
+  const reader = portalJs.slice(readerStart, readerEnd);
+
+  const indexPos = reader.indexOf(
+    "fetch(base + 'book-index.json')"
+  );
+  const pagesPos = reader.indexOf(
+    "fetch(base + 'book-pages.json')"
+  );
+
+  assert.ok(indexPos >= 0);
+  assert.ok(pagesPos >= 0);
+  assert.ok(indexPos < pagesPos);
+});


### PR DESCRIPTION
## RC-LIBRARY-01 — Student Portal Library shell

### Goal

Add a dedicated Student Portal **Library** destination and separate classroom books from general instructional resources without changing the existing book reader.

### Changes

- adds **Library** to both Student Portal navigation surfaces
- adds a dedicated Library panel
- classifies resources containing `book-index.json` or legacy `book-pages.json` as books
- moves the existing Lost in Kragdon-ah reader entry into Library
- keeps Language Arts Skill Builder in Resources
- preserves the existing `openBookReader()` implementation
- preserves reading progress and Reading Helper metadata support
- adds focused structural and Playwright regression coverage

### Verification

- RC-LIBRARY-01 structural tests: **6/6 PASS**
- synthetic Student Portal browser smoke test: **1/1 PASS**
- complete unit suite: **PASS**
- full repository lint: **0 errors**
- `git diff --check`: **PASS**

Browser smoke coverage proves:

- synthetic student reaches Student Portal
- Library is navigable
- Lost in Kragdon-ah appears in Library
- Language Arts Skill Builder remains in Resources
- Lost does not remain in Resources
- Lost opens in the existing inline reader

### Explicitly out of scope

- EPUB conversion
- reader-engine replacement
- authentication changes
- Supabase changes
- schema/RLS changes
- deployment configuration

No real student data was used.
