### PR TITLE
RC-LIBRARY-02A: authenticated private book delivery

### DIFF
--- a/netlify/functions/student-book.js
+++ b/netlify/functions/student-book.js
@@ -1,0 +1,245 @@
+'use strict';
+
+/**
+ * Authenticated classroom-book delivery endpoint.
+ *
+ * RC-LIBRARY-02A:
+ * - requires the existing signed HttpOnly student session
+ * - accepts only server-side allowlisted book IDs
+ * - retrieves private book bytes from Supabase Storage with the
+ *   server-side service role credential
+ * - never returns a public Storage URL
+ *
+ * GET /.netlify/functions/student-book?book=<book-id>
+ */
+
+const {
+  generateRequestId,
+  jsonResponse,
+  handleCorsPreFlight,
+  getSecurityHeaders,
+  getCorsHeaders,
+} = require('./_lib/http');
+
+const {
+  getSupabaseConfig,
+} = require('./_lib/supa');
+
+const {
+  requireStudent,
+} = require('./_lib/student-auth');
+
+const {
+  url: SUPABASE_URL,
+  key: SUPABASE_SERVICE_ROLE_KEY,
+} = getSupabaseConfig();
+
+const { SESSION_SECRET } = process.env;
+
+const BOOK_BUCKET = 'classroom-books';
+
+/**
+ * RC-LIBRARY-02A deliberately contains only a synthetic fixture ID.
+ * No copyrighted classroom book is added in this slice.
+ *
+ * Future real-book entries must remain server-side allowlist entries;
+ * client input must never become a Storage object path directly.
+ */
+const BOOK_CATALOG = Object.freeze({
+  'rc-library-02a-fixture': Object.freeze({
+    objectPath: 'fixtures/rc-library-02a-test.epub',
+    filename: 'rc-library-02a-test.epub',
+    contentType: 'application/epub+zip',
+  }),
+});
+
+function storageObjectUrl(objectPath) {
+  const encodedPath = String(objectPath)
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+
+  return (
+    `${SUPABASE_URL}/storage/v1/object/authenticated/` +
+    `${encodeURIComponent(BOOK_BUCKET)}/${encodedPath}`
+  );
+}
+
+function errorResponse(event, requestId, statusCode, error) {
+  return jsonResponse(
+    event,
+    statusCode,
+    {
+      ok: false,
+      error,
+    },
+    {
+      'Cache-Control': 'no-store',
+    },
+    requestId
+  );
+}
+
+exports.handler = async (event) => {
+  const requestId = generateRequestId();
+
+  if (event.httpMethod === 'OPTIONS') {
+    return handleCorsPreFlight(
+      event,
+      ['GET', 'OPTIONS'],
+      ['Content-Type']
+    );
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return errorResponse(
+      event,
+      requestId,
+      405,
+      'Method Not Allowed'
+    );
+  }
+
+  /*
+   * Authenticate BEFORE examining the requested book.
+   * Unauthenticated callers must not be able to enumerate valid IDs.
+   */
+  const studentAuth = requireStudent(
+    event,
+    SESSION_SECRET
+  );
+
+  if (!studentAuth.ok) {
+    return errorResponse(
+      event,
+      requestId,
+      studentAuth.statusCode,
+      studentAuth.error
+    );
+  }
+
+  const params = event.queryStringParameters || {};
+  const bookId =
+    typeof params.book === 'string'
+      ? params.book.trim()
+      : '';
+
+  const book = BOOK_CATALOG[bookId];
+
+  /*
+   * Client input is never interpolated into a filesystem or Storage path.
+   * Only an exact server-side catalog entry may resolve to an object.
+   */
+  if (!book) {
+    return errorResponse(
+      event,
+      requestId,
+      404,
+      'Book not found'
+    );
+  }
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return errorResponse(
+      event,
+      requestId,
+      503,
+      'Book storage unavailable'
+    );
+  }
+
+  let storageResponse;
+
+  try {
+    storageResponse = await fetch(
+      storageObjectUrl(book.objectPath),
+      {
+        method: 'GET',
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE_KEY,
+          Authorization:
+            `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        },
+      }
+    );
+  } catch (err) {
+    console.error(
+      `[student-book] [${requestId}] Storage request failed:`,
+      err.message
+    );
+
+    return errorResponse(
+      event,
+      requestId,
+      502,
+      'Book storage request failed'
+    );
+  }
+
+  if (storageResponse.status === 404) {
+    return errorResponse(
+      event,
+      requestId,
+      404,
+      'Book not found'
+    );
+  }
+
+  if (!storageResponse.ok) {
+    console.error(
+      `[student-book] [${requestId}] Storage returned status`,
+      storageResponse.status
+    );
+
+    return errorResponse(
+      event,
+      requestId,
+      502,
+      'Book storage request failed'
+    );
+  }
+
+  let bookBuffer;
+
+  try {
+    const arrayBuffer =
+      await storageResponse.arrayBuffer();
+
+    bookBuffer = Buffer.from(arrayBuffer);
+  } catch (err) {
+    console.error(
+      `[student-book] [${requestId}] Could not read book bytes:`,
+      err.message
+    );
+
+    return errorResponse(
+      event,
+      requestId,
+      502,
+      'Book storage response invalid'
+    );
+  }
+
+  return {
+    statusCode: 200,
+    headers: {
+      ...getSecurityHeaders(requestId),
+      ...getCorsHeaders(
+        event,
+        ['GET', 'OPTIONS'],
+        ['Content-Type']
+      ),
+      'Content-Type': book.contentType,
+      'Content-Length': String(bookBuffer.length),
+      'Content-Disposition':
+        `inline; filename="${book.filename}"`,
+      'Cache-Control': 'private, no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+    body: bookBuffer.toString('base64'),
+    isBase64Encoded: true,
+  };
+};
+
+exports.BOOK_BUCKET = BOOK_BUCKET;
+exports.BOOK_CATALOG = BOOK_CATALOG;

--- a/tests/student-book-auth-boundary.test.cjs
+++ b/tests/student-book-auth-boundary.test.cjs
@@ -1,0 +1,257 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+/*
+ * Synthetic test configuration only.
+ * No real Supabase credentials, student data, or copyrighted book bytes.
+ */
+process.env.SESSION_SECRET =
+  'rc-library-02a-test-session-secret';
+
+process.env.SUPABASE_URL =
+  'https://example-test.supabase.co';
+
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  'rc-library-02a-test-service-role-key';
+
+const {
+  createStudentSessionCookie,
+} = require('../netlify/functions/_lib/student-auth');
+
+const {
+  handler,
+  BOOK_BUCKET,
+  BOOK_CATALOG,
+} = require('../netlify/functions/student-book');
+
+const originalFetch = global.fetch;
+
+const FIXTURE_BYTES = Buffer.from([
+  0x50, 0x4b, 0x03, 0x04,
+  ...Buffer.from('RC-LIBRARY-02A-SYNTHETIC-EPUB'),
+]);
+
+function validCookie() {
+  const setCookie =
+    createStudentSessionCookie(
+      'S001',
+      process.env.SESSION_SECRET,
+      {
+        secure: false,
+      }
+    );
+
+  return setCookie.split(';', 1)[0];
+}
+
+function eventFor({
+  book = 'rc-library-02a-fixture',
+  cookie = '',
+  method = 'GET',
+} = {}) {
+  return {
+    httpMethod: method,
+    headers: cookie
+      ? {
+          cookie,
+          host: 'localhost:8888',
+        }
+      : {
+          host: 'localhost:8888',
+        },
+    queryStringParameters: {
+      book,
+    },
+  };
+}
+
+function jsonBody(response) {
+  return JSON.parse(response.body);
+}
+
+test.afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test('rejects missing student session before Storage access', async () => {
+  let fetchCalled = false;
+
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('Storage should not be called');
+  };
+
+  const response =
+    await handler(eventFor());
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(jsonBody(response).error, 'Unauthorized');
+  assert.equal(fetchCalled, false);
+});
+
+test('rejects malformed student session before Storage access', async () => {
+  let fetchCalled = false;
+
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('Storage should not be called');
+  };
+
+  const response =
+    await handler(
+      eventFor({
+        cookie: 'sc=definitely-not-a-valid-token',
+      })
+    );
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(jsonBody(response).error, 'Unauthorized');
+  assert.equal(fetchCalled, false);
+});
+
+test('rejects expired student session before Storage access', async () => {
+  let fetchCalled = false;
+
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('Storage should not be called');
+  };
+
+  const setCookie =
+    createStudentSessionCookie(
+      'S001',
+      process.env.SESSION_SECRET,
+      {
+        secure: false,
+        maxAge: -1,
+      }
+    );
+
+  const response =
+    await handler(
+      eventFor({
+        cookie: setCookie.split(';', 1)[0],
+      })
+    );
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(jsonBody(response).error, 'Unauthorized');
+  assert.equal(fetchCalled, false);
+});
+
+test('valid session cannot turn arbitrary input into a Storage path', async () => {
+  let fetchCalled = false;
+
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('Storage should not be called');
+  };
+
+  const response =
+    await handler(
+      eventFor({
+        cookie: validCookie(),
+        book: '../../secret-book.epub',
+      })
+    );
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(jsonBody(response).error, 'Book not found');
+  assert.equal(fetchCalled, false);
+});
+
+test('valid session receives exact synthetic binary bytes', async () => {
+  let capturedUrl = '';
+  let capturedOptions = null;
+
+  global.fetch = async (url, options) => {
+    capturedUrl = String(url);
+    capturedOptions = options;
+
+    const copy = Buffer.from(FIXTURE_BYTES);
+
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        copy.buffer.slice(
+          copy.byteOffset,
+          copy.byteOffset + copy.byteLength
+        ),
+    };
+  };
+
+  const response =
+    await handler(
+      eventFor({
+        cookie: validCookie(),
+      })
+    );
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.isBase64Encoded, true);
+
+  assert.deepEqual(
+    Buffer.from(response.body, 'base64'),
+    FIXTURE_BYTES
+  );
+
+  assert.equal(
+    response.headers['Content-Type'],
+    'application/epub+zip'
+  );
+
+  assert.match(
+    response.headers['Cache-Control'],
+    /no-store/
+  );
+
+  assert.equal(
+    capturedUrl,
+    'https://example-test.supabase.co/' +
+      'storage/v1/object/authenticated/' +
+      `${BOOK_BUCKET}/` +
+      BOOK_CATALOG['rc-library-02a-fixture'].objectPath
+  );
+
+  assert.equal(
+    capturedOptions.headers.Authorization,
+    'Bearer rc-library-02a-test-service-role-key'
+  );
+});
+
+test('private Storage 404 is normalized without exposing details', async () => {
+  global.fetch = async () => ({
+    ok: false,
+    status: 404,
+    arrayBuffer: async () =>
+      new ArrayBuffer(0),
+  });
+
+  const response =
+    await handler(
+      eventFor({
+        cookie: validCookie(),
+      })
+    );
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(jsonBody(response).error, 'Book not found');
+});
+
+test('unsupported HTTP methods are rejected', async () => {
+  const response =
+    await handler(
+      eventFor({
+        method: 'POST',
+      })
+    );
+
+  assert.equal(response.statusCode, 405);
+  assert.equal(
+    jsonBody(response).error,
+    'Method Not Allowed'
+  );
+});


### PR DESCRIPTION
## RC-LIBRARY-02A — authenticated private book delivery

### Goal
Establish a secure server-side delivery boundary for future classroom EPUBs without placing copyrighted book files in the public repository or public site tree.

### Code
- adds `student-book` Netlify Function
- reuses the existing signed HttpOnly student `sc` session via `requireStudent()`
- resolves only server-side allowlisted book IDs
- retrieves private Storage bytes server-side
- returns binary EPUB responses without exposing a public Storage URL
- adds focused security boundary tests

### Security verification
Focused tests prove:
- missing session → blocked before Storage access
- malformed session → blocked before Storage access
- expired session → blocked before Storage access
- arbitrary/path-traversal input → rejected before Storage access
- valid synthetic session → exact synthetic binary bytes
- missing private object → normalized response
- unsupported HTTP method → rejected

Existing student authentication and read-boundary regression tests also passed.

### Private Storage verification
A private `classroom-books` bucket was created separately in production Supabase Storage and tested only with a 52-byte synthetic fixture.

Verified:
- bucket is private
- anonymous authenticated-object request is blocked
- public-object endpoint is blocked
- service-role retrieval returns exact synthetic bytes
- actual `student-book` handler returns exact synthetic bytes

### Explicit non-scope
- no real classroom EPUB uploaded
- no copyrighted book file added to GitHub
- no Student Portal/frontend change
- no Supabase schema change
- no RLS policy change
- no authentication model change
- no Netlify configuration change
- no seven-book rollout
- no EPUB reader conversion

### Stopping point
Merge and production-verify this security boundary before beginning the Lost in Kragdon-ah EPUB pilot.
