### PR TITLE
RC-LIBRARY: repair Student Library foundation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -101,7 +101,7 @@
 [[headers]]
   for = "/student/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
 
 # Redirects for presentation navigation script
 # Ensures /site/assets/js/presentation-nav.js resolves to canonical location

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6373,6 +6373,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=2026081103"></script>
+    <script defer src="/web/student-portal-init.js?v=2026081104"></script>
   </body>
 </html>

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6373,6 +6373,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=2026081102"></script>
+    <script defer src="/web/student-portal-init.js?v=2026081103"></script>
   </body>
 </html>

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -7715,7 +7715,24 @@
     for (const filename of candidates) {
       try {
         const response = await fetch(base + filename, { method: 'HEAD' });
-        if (response.ok) return filename;
+
+        if (!response.ok) continue;
+
+        /*
+         * Production rewrites unknown /student/* paths to the Student Portal
+         * shell with HTTP 200. Do not mistake that HTML fallback for book
+         * metadata. Only an actual JSON response may classify a legacy
+         * resource as a book.
+         */
+        const contentType =
+          (response.headers.get('content-type') || '').toLowerCase();
+
+        const isJson =
+          contentType.includes('application/json') ||
+          contentType.includes('text/json') ||
+          contentType.includes('+json');
+
+        if (isJson) return filename;
       } catch (err) {
         // A failed probe simply means this candidate is not usable here.
       }

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -7860,19 +7860,26 @@
           }
         });
 
-        const storageKey = 'rc_book_page_' + encodeURIComponent(link);
-        const savedPage = parseInt(localStorage.getItem(storageKey) || '0', 10);
-        const savedTotal = parseInt(localStorage.getItem(storageKey + '_total') || '0', 10);
+        /*
+         * Secure EPUBs use EPUB-native CFI/location progress. Never surface
+         * legacy pseudo-page state left behind by the retired inline reader.
+         * Legacy book resources keep their existing page-progress behavior.
+         */
+        if (!getSecureEpubBook(link)) {
+          const storageKey = 'rc_book_page_' + encodeURIComponent(link);
+          const savedPage = parseInt(localStorage.getItem(storageKey) || '0', 10);
+          const savedTotal = parseInt(localStorage.getItem(storageKey + '_total') || '0', 10);
 
-        if (savedPage > 0 && savedTotal > 0) {
-          const pct = Math.round(savedPage / Math.max(1, savedTotal) * 100);
-          const progressEl = card.querySelector('.st-resource-progress');
+          if (savedPage > 0 && savedTotal > 0) {
+            const pct = Math.round(savedPage / Math.max(1, savedTotal) * 100);
+            const progressEl = card.querySelector('.st-resource-progress');
 
-          if (progressEl) {
-            progressEl.innerHTML =
-              '<div class="st-resource-progress-text">Page ' + savedPage + ' of ' + savedTotal + ' · ' + pct + '% read</div>' +
-              '<div class="st-resource-progress-bar"><div class="st-resource-progress-fill" style="width:' + pct + '%"></div></div>';
-            progressEl.style.display = 'block';
+            if (progressEl) {
+              progressEl.innerHTML =
+                '<div class="st-resource-progress-text">Page ' + savedPage + ' of ' + savedTotal + ' · ' + pct + '% read</div>' +
+                '<div class="st-resource-progress-bar"><div class="st-resource-progress-fill" style="width:' + pct + '%"></div></div>';
+              progressEl.style.display = 'block';
+            }
           }
         }
 

--- a/tests/student-epub-real-smoke.spec.js
+++ b/tests/student-epub-real-smoke.spec.js
@@ -9,6 +9,48 @@ const EPUB_PATH = process.env.RC_LIBRARY_02B_EPUB_PATH;
 const EXPECTED_SHA =
   '7add3244f8835f80b0bf76f0ef605eb5fd78891e10c24cd206d8a42b2d497778';
 
+const NETLIFY_TOML_PATH = 'netlify.toml';
+
+function readStudentCsp() {
+  const text = fs.readFileSync(
+    NETLIFY_TOML_PATH,
+    'utf8'
+  );
+
+  const marker = 'for = "/student/*"';
+  const start = text.indexOf(marker);
+
+  if (start < 0) {
+    throw new Error(
+      'Student CSP header block not found'
+    );
+  }
+
+  const nextHeader = text.indexOf(
+    '[[headers]]',
+    start + marker.length
+  );
+
+  const block = text.slice(
+    start,
+    nextHeader >= 0
+      ? nextHeader
+      : text.length
+  );
+
+  const match = block.match(
+    /Content-Security-Policy\s*=\s*"([^"]+)"/
+  );
+
+  if (!match) {
+    throw new Error(
+      'Student Content-Security-Policy not found'
+    );
+  }
+
+  return match[1];
+}
+
 function sha256(buffer) {
   return crypto
     .createHash('sha256')
@@ -33,6 +75,16 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     expect(epubBytes.length).toBe(1018108);
     expect(sha256(epubBytes)).toBe(EXPECTED_SHA);
 
+    const studentCsp = readStudentCsp();
+
+    expect(studentCsp).toContain(
+      "style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"
+    );
+
+    expect(studentCsp).toContain(
+      "img-src 'self' data: blob: https:"
+    );
+
     await context.addInitScript((studentCode) => {
       sessionStorage.setItem('rc_user_role', 'student');
       sessionStorage.setItem('rc_user_code', studentCode);
@@ -47,6 +99,18 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     }, SYNTHETIC_CODE);
 
     let secureBookRequests = 0;
+
+    await page.route('**/student/', async (route) => {
+      const response = await route.fetch();
+
+      await route.fulfill({
+        response,
+        headers: {
+          ...response.headers(),
+          'content-security-policy': studentCsp,
+        },
+      });
+    });
 
     await page.route('**/.netlify/functions/**', async (route) => {
       const url = new URL(route.request().url());
@@ -111,9 +175,37 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     });
 
     const pageErrors = [];
+    const blobCspFailures = [];
+    const blobCspConsoleErrors = [];
 
     page.on('pageerror', (error) => {
       pageErrors.push(error.message);
+    });
+
+    page.on('requestfailed', (request) => {
+      const failure =
+        request.failure()?.errorText || '';
+
+      if (
+        request.url().startsWith('blob:') &&
+        failure.toLowerCase().includes('csp')
+      ) {
+        blobCspFailures.push({
+          url: request.url(),
+          failure,
+        });
+      }
+    });
+
+    page.on('console', (message) => {
+      const value = message.text();
+
+      if (
+        value.includes('blob:') &&
+        /Content Security Policy|Refused to load/i.test(value)
+      ) {
+        blobCspConsoleErrors.push(value);
+      }
     });
 
     await page.goto('/student/');
@@ -184,6 +276,115 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
         }
       )
       .toBe(true);
+
+    /*
+     * The audited Copyright Page contains an EPUB image. It must resolve
+     * through EPUB.js as a blob URL and actually decode. A broken <img>
+     * element with naturalWidth === 0 must never count as success.
+     */
+    const copyrightPage = page.locator(
+      '#epubTocList .st-book-toc-item',
+      { hasText: 'Copyright Page' }
+    ).first();
+
+    await expect(copyrightPage).toBeVisible({
+      timeout: 15000,
+    });
+
+    await copyrightPage.click();
+
+    await expect
+      .poll(
+        async () => {
+          return epubFrame
+            .locator('img')
+            .first()
+            .evaluate((img) => {
+              if (!img.complete) return 0;
+              return img.naturalWidth;
+            })
+            .catch(() => 0);
+        },
+        {
+          timeout: 15000,
+          message:
+            'Copyright Page EPUB image should load with nonzero width',
+        }
+      )
+      .toBeGreaterThan(0);
+
+    const copyrightImage =
+      await epubFrame
+        .locator('img')
+        .first()
+        .evaluate((img) => ({
+          src:
+            img.currentSrc ||
+            img.src ||
+            img.getAttribute('src') ||
+            '',
+          complete: img.complete,
+          naturalWidth: img.naturalWidth,
+          naturalHeight: img.naturalHeight,
+        }));
+
+    expect(copyrightImage.src).toMatch(
+      /^blob:/
+    );
+
+    expect(copyrightImage.complete).toBe(
+      true
+    );
+
+    expect(
+      copyrightImage.naturalWidth
+    ).toBeGreaterThan(0);
+
+    expect(
+      copyrightImage.naturalHeight
+    ).toBeGreaterThan(0);
+
+    /*
+     * EPUB.js may materialize publication styling without exposing a
+     * separate Playwright request event. Test the rendered document:
+     * at least one stylesheet must be attached with readable CSS rules.
+     */
+    const epubStylesheets =
+      await epubFrame
+        .locator('body')
+        .evaluate((body) => {
+          return [
+            ...body.ownerDocument.styleSheets,
+          ].map((sheet) => {
+            let ruleCount = null;
+
+            try {
+              ruleCount =
+                sheet.cssRules?.length ??
+                0;
+            } catch (error) {
+              ruleCount = null;
+            }
+
+            return {
+              href: sheet.href,
+              ruleCount,
+            };
+          });
+        });
+
+    expect(
+      epubStylesheets.length
+    ).toBeGreaterThan(0);
+
+    expect(
+      epubStylesheets.some(
+        (sheet) =>
+          typeof sheet.ruleCount ===
+            'number' &&
+          sheet.ruleCount > 0
+      )
+    ).toBe(true);
 
     // Lost uses split chapter sections:
     // the TOC target is a chapter opener, followed by prose
@@ -332,6 +533,8 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     expect(page.url()).toContain('/student/');
     expect(page.url()).not.toContain('/presentation-02/');
 
+    expect(blobCspFailures).toEqual([]);
+    expect(blobCspConsoleErrors).toEqual([]);
     expect(pageErrors).toEqual([]);
   });
 });

--- a/tests/student-library-shell.spec.js
+++ b/tests/student-library-shell.spec.js
@@ -57,6 +57,27 @@ test.describe('RC-LIBRARY-01 Student Portal Library shell', () => {
     await context.addInitScript((studentCode) => {
       sessionStorage.setItem('rc_user_role', 'student');
       sessionStorage.setItem('rc_user_code', studentCode);
+
+      /*
+       * Simulate stale pseudo-reader progress from the retired Lost reader.
+       * Secure EPUB Library cards must ignore this legacy state.
+       */
+      const secureLostLink =
+        '/student/resources/presentation-02/';
+
+      const legacyStorageKey =
+        'rc_book_page_' +
+        encodeURIComponent(secureLostLink);
+
+      localStorage.setItem(
+        legacyStorageKey,
+        '1'
+      );
+
+      localStorage.setItem(
+        legacyStorageKey + '_total',
+        '535'
+      );
     }, SYNTHETIC_CODE);
 
     await mockStudentFunctions(page);
@@ -129,6 +150,19 @@ test.describe('RC-LIBRARY-01 Student Portal Library shell', () => {
 
     await expect(lostCard).toHaveCount(1);
     await expect(lostCard).toBeVisible();
+
+    // Secure EPUB cards must not display stale pseudo-reader page progress.
+    await expect(lostCard).not.toContainText(
+      'Page 1 of 535'
+    );
+
+    await expect(lostCard).not.toContainText(
+      '0% read'
+    );
+
+    await expect(
+      lostCard.locator('.st-resource-progress')
+    ).toBeHidden();
 
     // Resources should contain Skill Builder and not the book.
     await page.locator('[data-tab="resources"]:visible').first().click();

--- a/tests/student-library-shell.spec.js
+++ b/tests/student-library-shell.spec.js
@@ -61,6 +61,33 @@ test.describe('RC-LIBRARY-01 Student Portal Library shell', () => {
 
     await mockStudentFunctions(page);
 
+    /*
+     * Production rewrites unknown /student/* paths to Student Portal HTML
+     * with HTTP 200. Simulate that exact behavior for Skill Builder's
+     * nonexistent legacy-book probes.
+     */
+    const falseBookProbeRequests = [];
+
+    for (const filename of ['book-index.json', 'book-pages.json']) {
+      await page.route(
+        `**/student/resources/presentation-01/${filename}`,
+        async (route) => {
+          falseBookProbeRequests.push({
+            filename,
+            method: route.request().method(),
+          });
+
+          await route.fulfill({
+            status: 200,
+            headers: {
+              'content-type': 'text/html; charset=UTF-8',
+            },
+            body: '',
+          });
+        }
+      );
+    }
+
     const bookIndexRequests = [];
 
     page.on('request', (request) => {
@@ -117,6 +144,17 @@ test.describe('RC-LIBRARY-01 Student Portal Library shell', () => {
     await expect(resources).not.toContainText(
       'Lost in Kragdon-ah'
     );
+
+    expect(falseBookProbeRequests).toEqual([
+      {
+        filename: 'book-index.json',
+        method: 'HEAD',
+      },
+      {
+        filename: 'book-pages.json',
+        method: 'HEAD',
+      },
+    ]);
 
     // Secure EPUB classification must not probe or load the retired
     // presentation-02 public book index. Actual reader opening is covered


### PR DESCRIPTION
## RC-LIBRARY foundation repair package

Repairs three authenticated-production defects found after the secure Lost EPUB foundation was deployed.

### Included repairs

**RC-LIBRARY-FOUNDATION-REPAIR-01**
- Prevents HTTP 200 Student Portal HTML fallback responses from being misclassified as legacy book metadata.
- Keeps Language Arts Skill Builder in Resources.
- Keeps secure Lost in Library.

**RC-LIBRARY-FOUNDATION-REPAIR-02**
- Secure EPUB Library cards no longer surface legacy pseudo-page state such as `Page 1 of 535`.
- Existing legacy reader progress behavior remains preserved for legacy resources.

**RC-LIBRARY-FOUNDATION-REPAIR-03**
- Allows EPUB.js-generated `blob:` publication images and styles only under the `/student/*` CSP.
- Strengthens the certified real-EPUB smoke so an image must actually decode with nonzero dimensions.
- Verifies rendered stylesheet rules and rejects blob CSP failures.

### Sealed commits

- `445852396968e1503c68493070ae6187b5dd5396` — REPAIR-01
- `9c2893386c42b6d77bab5aac8f13f43c945ba0b3` — REPAIR-02
- `d448021e6effe40ebaf4cc6e520c3bf0edf8623f` — REPAIR-03

### Local verification

- deterministic Student Library / EPUB tests: PASS
- Student Library / Resources Playwright regression: PASS
- certified Lost EPUB real-browser smoke: PASS
- known EPUB image decodes with nonzero dimensions: PASS
- rendered EPUB stylesheet rules present: PASS
- blob CSP failures: ZERO
- CSP console errors: ZERO
- cache-bust policy: PASS
- working tree clean before push: YES

### Scope guard

No Supabase schema, RLS, auth, or classroom-data changes.
No student data accessed.
No reader redesign.
No 02C-B work.
No deployment performed by this package step.
