### PR TITLE
RC-LIBRARY: align Student CSP report-only monitoring

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -102,6 +102,7 @@
   for = "/student/*"
   [headers.values]
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
 
 # Redirects for presentation navigation script
 # Ensures /site/assets/js/presentation-nav.js resolves to canonical location

--- a/netlify.toml
+++ b/netlify.toml
@@ -102,6 +102,7 @@
   for = "/student/*"
   [headers.values]
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
+    # Keep report-only byte-for-byte aligned with the enforced Student CSP above.
     Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://*.supabase.co; style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.supabase.io https://*.netlify.app; media-src 'self' blob: data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /.netlify/functions/csp-report"
 
 # Redirects for presentation navigation script

--- a/tests/student-epub-real-smoke.spec.js
+++ b/tests/student-epub-real-smoke.spec.js
@@ -11,7 +11,7 @@ const EXPECTED_SHA =
 
 const NETLIFY_TOML_PATH = 'netlify.toml';
 
-function readStudentCsp() {
+function readStudentCspHeaders() {
   const text = fs.readFileSync(
     NETLIFY_TOML_PATH,
     'utf8'
@@ -38,17 +38,30 @@ function readStudentCsp() {
       : text.length
   );
 
-  const match = block.match(
+  const enforcedMatch = block.match(
     /Content-Security-Policy\s*=\s*"([^"]+)"/
   );
 
-  if (!match) {
+  const reportOnlyMatch = block.match(
+    /Content-Security-Policy-Report-Only\s*=\s*"([^"]+)"/
+  );
+
+  if (!enforcedMatch) {
     throw new Error(
       'Student Content-Security-Policy not found'
     );
   }
 
-  return match[1];
+  if (!reportOnlyMatch) {
+    throw new Error(
+      'Student Content-Security-Policy-Report-Only not found'
+    );
+  }
+
+  return {
+    enforced: enforcedMatch[1],
+    reportOnly: reportOnlyMatch[1],
+  };
 }
 
 function sha256(buffer) {
@@ -75,13 +88,22 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     expect(epubBytes.length).toBe(1018108);
     expect(sha256(epubBytes)).toBe(EXPECTED_SHA);
 
-    const studentCsp = readStudentCsp();
+    const studentCsp =
+      readStudentCspHeaders();
 
-    expect(studentCsp).toContain(
+    expect(studentCsp.enforced).toContain(
       "style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"
     );
 
-    expect(studentCsp).toContain(
+    expect(studentCsp.enforced).toContain(
+      "img-src 'self' data: blob: https:"
+    );
+
+    expect(studentCsp.reportOnly).toContain(
+      "style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"
+    );
+
+    expect(studentCsp.reportOnly).toContain(
       "img-src 'self' data: blob: https:"
     );
 
@@ -107,7 +129,10 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
         response,
         headers: {
           ...response.headers(),
-          'content-security-policy': studentCsp,
+          'content-security-policy':
+            studentCsp.enforced,
+          'content-security-policy-report-only':
+            studentCsp.reportOnly,
         },
       });
     });

--- a/tests/student-epub-real-smoke.spec.js
+++ b/tests/student-epub-real-smoke.spec.js
@@ -91,19 +91,15 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     const studentCsp =
       readStudentCspHeaders();
 
+    expect(studentCsp.reportOnly).toBe(
+      studentCsp.enforced
+    );
+
     expect(studentCsp.enforced).toContain(
       "style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"
     );
 
     expect(studentCsp.enforced).toContain(
-      "img-src 'self' data: blob: https:"
-    );
-
-    expect(studentCsp.reportOnly).toContain(
-      "style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"
-    );
-
-    expect(studentCsp.reportOnly).toContain(
       "img-src 'self' data: blob: https:"
     );
 


### PR DESCRIPTION
## RC-LIBRARY-FOUNDATION-REPAIR-03B

Aligns Student Portal CSP monitoring with the already production-verified enforced Student CSP.

### Problem

Authenticated production QA confirmed the secure EPUB runtime is functioning correctly:

- Lost is correctly classified under Library
- Language Arts Skill Builder remains under Resources
- stale pseudo-page progress is suppressed
- secure `student-book` EPUB delivery succeeds
- EPUB image decodes successfully
- publication stylesheets render successfully

However, Chromium emitted `[Report Only]` warnings because the inherited global report-only CSP still described the pre-REPAIR-03 blob restrictions.

### Repair

- adds a route-specific `Content-Security-Policy-Report-Only` value under `/student/*`
- keeps the existing enforced Student CSP unchanged
- aligns Student report-only monitoring exactly with the enforced Student policy
- keeps the global report-only policy unchanged for unrelated routes
- strengthens the certified real-EPUB smoke to exercise both enforced and report-only Student CSP headers

### Sealed commit

- `e8ae23eec7557fb857fb3fac3f7cd4cd7d9fc874` — RC-LIBRARY-FOUNDATION-REPAIR-03B

Parent:

- `e758285227797839aa1dfa9e9f96cd71d18c1948` — verified production merge of PR #1380

### Verification

- TOML parse: PASS
- Student enforced/report-only CSP equality: PASS
- report-only style-src includes blob: PASS
- report-only img-src includes blob: PASS
- deterministic Library/EPUB tests: PASS
- Student Library Playwright regression: PASS
- certified real Lost EPUB smoke with both CSP policies: PASS
- targeted lint: PASS
- working tree clean before push: YES

### Scope guard

No Student enforced CSP expansion beyond production.
No global CSP change.
No Supabase schema, RLS, auth, or classroom-data change.
No reader redesign.
No 02C-B work.
No deployment performed by this package step.
