### PR TITLE
READER-01: restore Read Aloud to secure EPUB reader

### DIFF
--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6373,6 +6373,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=2026081104"></script>
+    <script defer src="/web/student-portal-init.js?v=2026081201"></script>
   </body>
 </html>

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -4915,9 +4915,33 @@
     }
 
     if (_epubTtsPaused) {
-      _epubTtsAudio
+      const audio =
+        _epubTtsAudio;
+
+      audio
         .play()
+        .then(function () {
+          if (
+            !_epubTtsActive ||
+            _epubTtsAudio !== audio
+          ) {
+            return;
+          }
+
+          _epubTtsPaused = false;
+          syncEpubTtsControls();
+        })
         .catch(function (err) {
+          if (
+            !_epubTtsActive ||
+            _epubTtsAudio !== audio
+          ) {
+            return;
+          }
+
+          _epubTtsPaused = true;
+          syncEpubTtsControls();
+
           console.warn(
             LOG_PREFIX,
             'EPUB Read Aloud resume failed:',
@@ -4925,12 +4949,11 @@
           );
         });
 
-      _epubTtsPaused = false;
-    } else {
-      _epubTtsAudio.pause();
-      _epubTtsPaused = true;
+      return;
     }
 
+    _epubTtsAudio.pause();
+    _epubTtsPaused = true;
     syncEpubTtsControls();
   }
 

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -4402,7 +4402,541 @@
   let _epubRendition = null;
   let _epubEscapeHandler = null;
 
+  // Secure EPUB Read Aloud is intentionally separate from the legacy
+  // pseudo-page reader TTS state. Both use the existing student-tts
+  // endpoint and saved voice/rate preferences.
+  let _epubTtsAudio = null;
+  let _epubTtsAudioUrl = null;
+  let _epubTtsAbortController = null;
+  let _epubTtsActive = false;
+  let _epubTtsPaused = false;
+  let _epubTtsRunId = 0;
+
+  function syncEpubTtsControls() {
+    const playBtn =
+      document.getElementById('epubTtsBtn');
+    const controls =
+      document.getElementById('epubTtsControls');
+    const pauseBtn =
+      document.getElementById('epubTtsPause');
+
+    if (playBtn) {
+      playBtn.classList.toggle(
+        'tts-active',
+        _epubTtsActive
+      );
+    }
+
+    if (controls) {
+      controls.style.display =
+        _epubTtsActive
+          ? 'flex'
+          : 'none';
+    }
+
+    if (pauseBtn) {
+      pauseBtn.textContent =
+        _epubTtsPaused
+          ? '▶ Resume'
+          : '⏸ Pause';
+
+      pauseBtn.disabled =
+        !_epubTtsAudio;
+    }
+  }
+
+  function clearEpubTtsAudio() {
+    if (_epubTtsAudio) {
+      _epubTtsAudio.pause();
+      _epubTtsAudio.onended = null;
+      _epubTtsAudio.onerror = null;
+      _epubTtsAudio = null;
+    }
+
+    if (_epubTtsAudioUrl) {
+      URL.revokeObjectURL(
+        _epubTtsAudioUrl
+      );
+      _epubTtsAudioUrl = null;
+    }
+  }
+
+  function stopEpubTts() {
+    _epubTtsRunId += 1;
+
+    if (_epubTtsAbortController) {
+      _epubTtsAbortController.abort();
+      _epubTtsAbortController = null;
+    }
+
+    clearEpubTtsAudio();
+
+    _epubTtsActive = false;
+    _epubTtsPaused = false;
+
+    syncEpubTtsControls();
+  }
+
+  function getEpubTtsSettings() {
+    const allowedVoices = [
+      'alloy',
+      'echo',
+      'fable',
+      'onyx',
+      'nova',
+      'shimmer'
+    ];
+
+    let voice =
+      localStorage.getItem(
+        'rc_book_tts_voice'
+      ) || 'nova';
+
+    if (!allowedVoices.includes(voice)) {
+      voice = 'nova';
+      localStorage.setItem(
+        'rc_book_tts_voice',
+        voice
+      );
+    }
+
+    let rate =
+      parseFloat(
+        localStorage.getItem(
+          'rc_book_tts_rate'
+        ) ||
+        String(DEFAULT_TTS_RATE)
+      );
+
+    if (
+      !Number.isFinite(rate) ||
+      rate < 0.25 ||
+      rate > 4
+    ) {
+      rate = DEFAULT_TTS_RATE;
+    }
+
+    return {
+      voice,
+      rate
+    };
+  }
+
+  function getVisibleEpubTtsChunks() {
+    if (
+      !_epubRendition ||
+      typeof _epubRendition.getContents !==
+        'function'
+    ) {
+      return [];
+    }
+
+    const paragraphs = [];
+
+    _epubRendition
+      .getContents()
+      .forEach(function (content) {
+        const doc =
+          content &&
+          content.document;
+
+        const body =
+          doc &&
+          doc.body;
+
+        if (!body) return;
+
+        const nodes =
+          Array.from(
+            body.querySelectorAll(
+              'h1,h2,h3,h4,h5,h6,p,blockquote,li'
+            )
+          );
+
+        const values =
+          nodes
+            .map(function (node) {
+              return (
+                node.innerText ||
+                node.textContent ||
+                ''
+              )
+                .replace(/\s+/g, ' ')
+                .trim();
+            })
+            .filter(Boolean);
+
+        if (values.length) {
+          paragraphs.push(...values);
+          return;
+        }
+
+        const fallback =
+          (
+            body.innerText ||
+            body.textContent ||
+            ''
+          )
+            .replace(/\s+/g, ' ')
+            .trim();
+
+        if (fallback) {
+          paragraphs.push(fallback);
+        }
+      });
+
+    const chunks = [];
+    const maxChars = 4000;
+    let current = '';
+
+    function flushCurrent() {
+      if (!current) return;
+      chunks.push(current);
+      current = '';
+    }
+
+    function appendText(value) {
+      let remaining =
+        String(value || '').trim();
+
+      while (remaining.length) {
+        if (
+          current &&
+          current.length +
+            2 +
+            remaining.length <=
+            maxChars
+        ) {
+          current +=
+            '\n\n' +
+            remaining;
+          return;
+        }
+
+        if (
+          !current &&
+          remaining.length <=
+            maxChars
+        ) {
+          current = remaining;
+          return;
+        }
+
+        if (current) {
+          flushCurrent();
+          continue;
+        }
+
+        let cut =
+          remaining.lastIndexOf(
+            ' ',
+            maxChars
+          );
+
+        if (cut < 1000) {
+          cut = maxChars;
+        }
+
+        chunks.push(
+          remaining
+            .slice(0, cut)
+            .trim()
+        );
+
+        remaining =
+          remaining
+            .slice(cut)
+            .trim();
+      }
+    }
+
+    paragraphs.forEach(appendText);
+    flushCurrent();
+
+    return chunks.filter(Boolean);
+  }
+
+  async function playEpubTtsChunk(
+    chunks,
+    index,
+    runId
+  ) {
+    if (
+      !_epubTtsActive ||
+      runId !== _epubTtsRunId
+    ) {
+      return;
+    }
+
+    if (index >= chunks.length) {
+      clearEpubTtsAudio();
+      _epubTtsActive = false;
+      _epubTtsPaused = false;
+      syncEpubTtsControls();
+      return;
+    }
+
+    const settings =
+      getEpubTtsSettings();
+
+    const controller =
+      new AbortController();
+
+    _epubTtsAbortController =
+      controller;
+
+    let data;
+
+    try {
+      const response =
+        await fetch(
+          '/.netlify/functions/student-tts',
+          {
+            method: 'POST',
+            credentials:
+              'same-origin',
+            headers: {
+              'Content-Type':
+                'application/json'
+            },
+            body: JSON.stringify({
+              text: chunks[index],
+              voice:
+                settings.voice,
+              speed:
+                settings.rate
+            }),
+            signal:
+              controller.signal
+          }
+        );
+
+      data =
+        await response.json();
+
+      if (
+        !response.ok ||
+        !data.ok ||
+        !data.audio
+      ) {
+        throw new Error(
+          data &&
+          data.error
+            ? data.error
+            : 'TTS request failed'
+        );
+      }
+    } catch (err) {
+      if (
+        err &&
+        err.name ===
+          'AbortError'
+      ) {
+        return;
+      }
+
+      console.warn(
+        LOG_PREFIX,
+        'EPUB Read Aloud request failed:',
+        err
+      );
+
+      showToast(
+        '⚠️ Could not load Read Aloud audio.',
+        'error'
+      );
+
+      stopEpubTts();
+      return;
+    } finally {
+      if (
+        _epubTtsAbortController ===
+        controller
+      ) {
+        _epubTtsAbortController =
+          null;
+      }
+    }
+
+    if (
+      !_epubTtsActive ||
+      runId !== _epubTtsRunId
+    ) {
+      return;
+    }
+
+    const binaryStr =
+      atob(data.audio);
+
+    const bytes =
+      new Uint8Array(
+        binaryStr.length
+      );
+
+    for (
+      let i = 0;
+      i < binaryStr.length;
+      i++
+    ) {
+      bytes[i] =
+        binaryStr.charCodeAt(i);
+    }
+
+    clearEpubTtsAudio();
+
+    const blob =
+      new Blob(
+        [bytes],
+        {
+          type: 'audio/mpeg'
+        }
+      );
+
+    _epubTtsAudioUrl =
+      URL.createObjectURL(blob);
+
+    const audio =
+      new Audio(
+        _epubTtsAudioUrl
+      );
+
+    _epubTtsAudio = audio;
+    _epubTtsPaused = false;
+
+    syncEpubTtsControls();
+
+    audio.onended =
+      function () {
+        if (
+          !_epubTtsActive ||
+          runId !== _epubTtsRunId
+        ) {
+          return;
+        }
+
+        clearEpubTtsAudio();
+
+        playEpubTtsChunk(
+          chunks,
+          index + 1,
+          runId
+        );
+      };
+
+    audio.onerror =
+      function () {
+        if (
+          !_epubTtsActive ||
+          runId !== _epubTtsRunId
+        ) {
+          return;
+        }
+
+        console.warn(
+          LOG_PREFIX,
+          'EPUB Read Aloud audio playback failed.'
+        );
+
+        showToast(
+          '⚠️ Audio unavailable. Please try again.',
+          'error'
+        );
+
+        stopEpubTts();
+      };
+
+    try {
+      await audio.play();
+    } catch (err) {
+      if (
+        !_epubTtsActive ||
+        runId !== _epubTtsRunId
+      ) {
+        return;
+      }
+
+      console.warn(
+        LOG_PREFIX,
+        'EPUB Read Aloud play() failed:',
+        err
+      );
+
+      showToast(
+        '⚠️ Audio unavailable. Please try again.',
+        'error'
+      );
+
+      stopEpubTts();
+    }
+  }
+
+  function startEpubTts() {
+    const chunks =
+      getVisibleEpubTtsChunks();
+
+    if (!chunks.length) {
+      showToast(
+        'No readable text is available on this page.'
+      );
+      return;
+    }
+
+    stopEpubTts();
+
+    const runId =
+      ++_epubTtsRunId;
+
+    _epubTtsActive = true;
+    _epubTtsPaused = false;
+
+    syncEpubTtsControls();
+
+    playEpubTtsChunk(
+      chunks,
+      0,
+      runId
+    );
+  }
+
+  function toggleEpubTts() {
+    if (_epubTtsActive) {
+      stopEpubTts();
+    } else {
+      startEpubTts();
+    }
+  }
+
+  function pauseResumeEpubTts() {
+    if (
+      !_epubTtsActive ||
+      !_epubTtsAudio
+    ) {
+      return;
+    }
+
+    if (_epubTtsPaused) {
+      _epubTtsAudio
+        .play()
+        .catch(function (err) {
+          console.warn(
+            LOG_PREFIX,
+            'EPUB Read Aloud resume failed:',
+            err
+          );
+        });
+
+      _epubTtsPaused = false;
+    } else {
+      _epubTtsAudio.pause();
+      _epubTtsPaused = true;
+    }
+
+    syncEpubTtsControls();
+  }
+
   function closeEpubReader() {
+    stopEpubTts();
+
     if (_epubEscapeHandler) {
       document.removeEventListener('keydown', _epubEscapeHandler);
       _epubEscapeHandler = null;
@@ -4558,6 +5092,14 @@
           <button class="st-book-nav-btn" id="epubFontDecBtn" title="Decrease font size" style="padding:8px 10px;font-weight:700;">A-</button>
           <button class="st-book-nav-btn" id="epubFontIncBtn" title="Increase font size" style="padding:8px 10px;font-weight:700;">A+</button>
         </div>
+
+        <div class="st-book-tts-wrapper" style="display:flex;align-items:center;gap:4px;">
+          <button class="st-book-nav-btn" id="epubTtsBtn">🔊 Read Aloud</button>
+          <div id="epubTtsControls" style="display:none;align-items:center;gap:4px;">
+            <button class="st-book-nav-btn" id="epubTtsPause" disabled>⏸ Pause</button>
+            <button class="st-book-nav-btn" id="epubTtsStop">⏹ Stop</button>
+          </div>
+        </div>
       </div>
     `;
 
@@ -4656,8 +5198,28 @@
         });
 
       panel
+        .querySelector('#epubTtsBtn')
+        .addEventListener('click', function () {
+          toggleEpubTts();
+        });
+
+      panel
+        .querySelector('#epubTtsPause')
+        .addEventListener('click', function () {
+          pauseResumeEpubTts();
+        });
+
+      panel
+        .querySelector('#epubTtsStop')
+        .addEventListener('click', function () {
+          stopEpubTts();
+        });
+
+      panel
         .querySelector('#epubPrevBtn')
         .addEventListener('click', function () {
+          stopEpubTts();
+
           if (_epubRendition) {
             _epubRendition.prev();
           }
@@ -4666,6 +5228,8 @@
       panel
         .querySelector('#epubNextBtn')
         .addEventListener('click', function () {
+          stopEpubTts();
+
           if (_epubRendition) {
             _epubRendition.next();
           }
@@ -4690,11 +5254,13 @@
           event.key === 'ArrowRight' &&
           _epubRendition
         ) {
+          stopEpubTts();
           _epubRendition.next();
         } else if (
           event.key === 'ArrowLeft' &&
           _epubRendition
         ) {
+          stopEpubTts();
           _epubRendition.prev();
         }
       };
@@ -4782,6 +5348,8 @@
             button.addEventListener(
               'click',
               function () {
+                stopEpubTts();
+
                 if (_epubRendition) {
                   _epubRendition.display(
                     chapter.href

--- a/tests/student-epub-real-smoke.spec.js
+++ b/tests/student-epub-real-smoke.spec.js
@@ -114,9 +114,40 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
       localStorage.removeItem(
         'rc_epub_font_size_lost-in-kragdon-ah'
       );
+
+      // Deterministic audio shim: the smoke verifies the Read Aloud
+      // request/lifecycle without relying on host audio hardware.
+      window.__rcEpubTtsAudio = {
+        created: 0,
+        playCount: 0,
+        pauseCount: 0,
+      };
+
+      window.Audio = class {
+        constructor(src) {
+          this.src = src;
+          this.paused = true;
+          this.onended = null;
+          this.onerror = null;
+          window.__rcEpubTtsAudio.created += 1;
+        }
+
+        play() {
+          this.paused = false;
+          window.__rcEpubTtsAudio.playCount += 1;
+          return Promise.resolve();
+        }
+
+        pause() {
+          this.paused = true;
+          window.__rcEpubTtsAudio.pauseCount += 1;
+        }
+      };
     }, SYNTHETIC_CODE);
 
     let secureBookRequests = 0;
+    let secureTtsRequests = 0;
+    let lastTtsRequest = null;
 
     await page.route('**/student/', async (route) => {
       const response = await route.fetch();
@@ -152,6 +183,57 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
               'inline; filename="Lost in Kragdon-ah.epub"',
           },
           body: epubBytes,
+        });
+
+        return;
+      }
+
+      if (url.pathname.endsWith('/student-tts')) {
+        const requestBody =
+          route.request().postDataJSON();
+
+        expect(
+          typeof requestBody.text
+        ).toBe('string');
+
+        expect(
+          requestBody.text.length
+        ).toBeGreaterThan(100);
+
+        expect(
+          requestBody.text.length
+        ).toBeLessThanOrEqual(5000);
+
+        expect([
+          'alloy',
+          'echo',
+          'fable',
+          'onyx',
+          'nova',
+          'shimmer',
+        ]).toContain(requestBody.voice);
+
+        expect(
+          Number(requestBody.speed)
+        ).toBeGreaterThanOrEqual(0.25);
+
+        expect(
+          Number(requestBody.speed)
+        ).toBeLessThanOrEqual(4);
+
+        secureTtsRequests += 1;
+        lastTtsRequest = requestBody;
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            audio: Buffer.from(
+              'reader-01-audio'
+            ).toString('base64'),
+            format: 'mp3',
+          }),
         });
 
         return;
@@ -475,6 +557,142 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
       )
       .toBeGreaterThan(1000);
 
+    // READER-01: Read Aloud must operate against the currently
+    // displayed secure EPUB content without using legacy pseudo-pages.
+    const epubTtsBtn =
+      page.locator('#epubTtsBtn');
+
+    const epubTtsControls =
+      page.locator('#epubTtsControls');
+
+    const epubTtsPause =
+      page.locator('#epubTtsPause');
+
+    const epubTtsStop =
+      page.locator('#epubTtsStop');
+
+    await expect(
+      epubTtsBtn
+    ).toBeVisible();
+
+    await expect(
+      epubTtsControls
+    ).toBeHidden();
+
+    await page.evaluate(() => {
+      window.__rcEpubTtsAudio.created = 0;
+      window.__rcEpubTtsAudio.playCount = 0;
+      window.__rcEpubTtsAudio.pauseCount = 0;
+    });
+
+    await epubTtsBtn.click();
+
+    await expect
+      .poll(
+        () => secureTtsRequests,
+        {
+          timeout: 5000,
+          message:
+            'Read Aloud should request student-tts audio',
+        }
+      )
+      .toBe(1);
+
+    expect(
+      lastTtsRequest.text.length
+    ).toBeGreaterThan(100);
+
+    await expect
+      .poll(
+        async () => {
+          return page.evaluate(() => {
+            return window
+              .__rcEpubTtsAudio
+              .playCount;
+          });
+        },
+        {
+          timeout: 5000,
+          message:
+            'Read Aloud should start audio playback',
+        }
+      )
+      .toBe(1);
+
+    await expect(
+      epubTtsControls
+    ).toBeVisible();
+
+    await expect(
+      epubTtsBtn
+    ).toHaveClass(/tts-active/);
+
+    await epubTtsPause.click();
+
+    await expect(
+      epubTtsPause
+    ).toHaveText('▶ Resume');
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          return window
+            .__rcEpubTtsAudio
+            .pauseCount;
+        });
+      })
+      .toBeGreaterThan(0);
+
+    await epubTtsPause.click();
+
+    await expect(
+      epubTtsPause
+    ).toHaveText('⏸ Pause');
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          return window
+            .__rcEpubTtsAudio
+            .playCount;
+        });
+      })
+      .toBe(2);
+
+    await epubTtsStop.click();
+
+    await expect(
+      epubTtsControls
+    ).toBeHidden();
+
+    await expect(
+      epubTtsBtn
+    ).not.toHaveClass(/tts-active/);
+
+    const pauseCountAfterStop =
+      await page.evaluate(() => {
+        return window
+          .__rcEpubTtsAudio
+          .pauseCount;
+      });
+
+    // Start once more so existing Next navigation proves it
+    // cancels stale spoken text before changing EPUB position.
+    await epubTtsBtn.click();
+
+    await expect
+      .poll(
+        () => secureTtsRequests,
+        {
+          timeout: 5000,
+        }
+      )
+      .toBe(2);
+
+    await expect(
+      epubTtsControls
+    ).toBeVisible();
+
     await expect(
       page.locator('#epubPrevBtn')
     ).toBeVisible();
@@ -524,6 +742,26 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
 
     await page.locator('#epubNextBtn').click();
 
+    await expect(
+      epubTtsControls
+    ).toBeHidden();
+
+    await expect(
+      epubTtsBtn
+    ).not.toHaveClass(/tts-active/);
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          return window
+            .__rcEpubTtsAudio
+            .pauseCount;
+        });
+      })
+      .toBeGreaterThan(
+        pauseCountAfterStop
+      );
+
     await expect
       .poll(
         async () => {
@@ -550,6 +788,58 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
     });
 
     expect(fontSetting).toBe('110');
+
+    // Reader close must also stop active EPUB audio and remove
+    // its panel without touching the authenticated Student shell.
+    await epubTtsBtn.click();
+
+    await expect
+      .poll(
+        () => secureTtsRequests,
+        {
+          timeout: 5000,
+        }
+      )
+      .toBe(3);
+
+    await expect(
+      epubTtsControls
+    ).toBeVisible();
+
+    const pauseCountBeforeClose =
+      await page.evaluate(() => {
+        return window
+          .__rcEpubTtsAudio
+          .pauseCount;
+      });
+
+    await page
+      .locator('#epubCloseBtn')
+      .click();
+
+    await expect(
+      page.locator('#epubBookPanel')
+    ).toHaveCount(
+      0,
+      {
+        timeout: 2000,
+      }
+    );
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          return window
+            .__rcEpubTtsAudio
+            .pauseCount;
+        });
+      })
+      .toBeGreaterThan(
+        pauseCountBeforeClose
+      );
+
+    expect(secureBookRequests).toBe(1);
+    expect(secureTtsRequests).toBe(3);
 
     expect(page.url()).toContain('/student/');
     expect(page.url()).not.toContain('/presentation-02/');

--- a/tests/student-epub-real-smoke.spec.js
+++ b/tests/student-epub-real-smoke.spec.js
@@ -121,6 +121,8 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
         created: 0,
         playCount: 0,
         pauseCount: 0,
+        rejectedPlayCount: 0,
+        rejectNextPlay: false,
       };
 
       window.Audio = class {
@@ -133,6 +135,25 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
         }
 
         play() {
+          if (
+            window.__rcEpubTtsAudio
+              .rejectNextPlay
+          ) {
+            window.__rcEpubTtsAudio
+              .rejectNextPlay = false;
+
+            window.__rcEpubTtsAudio
+              .rejectedPlayCount += 1;
+
+            this.paused = true;
+
+            return Promise.reject(
+              new Error(
+                'synthetic audio resume failure'
+              )
+            );
+          }
+
           this.paused = false;
           window.__rcEpubTtsAudio.playCount += 1;
           return Promise.resolve();
@@ -583,6 +604,8 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
       window.__rcEpubTtsAudio.created = 0;
       window.__rcEpubTtsAudio.playCount = 0;
       window.__rcEpubTtsAudio.pauseCount = 0;
+      window.__rcEpubTtsAudio.rejectedPlayCount = 0;
+      window.__rcEpubTtsAudio.rejectNextPlay = false;
     });
 
     await epubTtsBtn.click();
@@ -643,6 +666,29 @@ test.describe('RC-LIBRARY-02B real EPUB smoke', () => {
       })
       .toBeGreaterThan(0);
 
+    // A rejected browser resume must leave the reader visibly
+    // paused rather than claiming playback resumed.
+    await page.evaluate(() => {
+      window.__rcEpubTtsAudio.rejectNextPlay = true;
+    });
+
+    await epubTtsPause.click();
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          return window
+            .__rcEpubTtsAudio
+            .rejectedPlayCount;
+        });
+      })
+      .toBe(1);
+
+    await expect(
+      epubTtsPause
+    ).toHaveText('▶ Resume');
+
+    // A later successful Resume should clear the paused state.
     await epubTtsPause.click();
 
     await expect(


### PR DESCRIPTION
## Goal

Restore Read Aloud to the secure EPUB reader without changing the stabilized Library foundation.

## Scope

- adds Read Aloud to the secure EPUB reader
- adds Pause / Resume / Stop
- reads the currently displayed EPUB rendition
- uses existing saved TTS voice and rate preferences
- stops stale audio on EPUB navigation and reader close
- cache-busts the Student Portal script
- strengthens the certified real-EPUB regression smoke

## Explicitly unchanged

- student-tts endpoint
- student-book endpoint
- Student authentication
- Supabase
- Netlify configuration and CSP
- secure EPUB delivery boundary
- reader visual redesign
- 02C-B

## Local verification

- deterministic Library / EPUB tests: 27 of 27 passed
- Student Library browser regression: passed
- certified real EPUB Read Aloud smoke: passed
- ESLint: zero errors and no warnings added over baseline
- exact three-file footprint
