### PR TITLE
RC-LIBRARY-04: add A Door Into Time to secure Student Library

### DIFF
--- a/netlify/functions/student-book.js
+++ b/netlify/functions/student-book.js
@@ -55,6 +55,11 @@ const BOOK_CATALOG = Object.freeze({
     filename: 'Lost in Kragdon-ah.epub',
     contentType: 'application/epub+zip',
   }),
+  'a-door-into-time': Object.freeze({
+    objectPath: 'books/a-door-into-time.epub',
+    filename: 'A Door Into Time.epub',
+    contentType: 'application/epub+zip',
+  }),
 });
 
 function storageObjectUrl(objectPath) {

--- a/site/assets/data/site-state.json
+++ b/site/assets/data/site-state.json
@@ -1147,7 +1147,7 @@
       "titles": [
         "Language Arts Skill Builder",
         "\"Lost in Kragdon-ah\" by Shawn Inmon",
-        "",
+        "\"A Door Into Time\" by Shawn Inmon",
         "",
         "",
         "",
@@ -1189,7 +1189,7 @@
       "links": [
         "/student/resources/presentation-01/",
         "/student/resources/presentation-02/",
-        "",
+        "/student/resources/presentation-03/",
         "",
         "",
         "",

--- a/site/assets/data/student-book-support/a-door-into-time.json
+++ b/site/assets/data/student-book-support/a-door-into-time.json
@@ -1,0 +1,6 @@
+{
+  "bookId": "a-door-into-time",
+  "title": "A Door Into Time",
+  "author": "Shawn Inmon",
+  "glossary": []
+}

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6373,6 +6373,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=2026081201"></script>
+    <script defer src="/web/student-portal-init.js?v=2026081401"></script>
   </body>
 </html>

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -4377,6 +4377,11 @@
       id: 'lost-in-kragdon-ah',
       title: 'Lost in Kragdon-ah',
       supportPath: '/assets/data/student-book-support/lost-in-kragdon-ah.json'
+    }),
+    '/student/resources/presentation-03/': Object.freeze({
+      id: 'a-door-into-time',
+      title: 'A Door Into Time',
+      supportPath: '/assets/data/student-book-support/a-door-into-time.json'
     })
   });
 

--- a/tests/rc-library-04-adit.test.cjs
+++ b/tests/rc-library-04-adit.test.cjs
@@ -1,0 +1,111 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(
+    path.join(ROOT, relativePath),
+    'utf8'
+  );
+}
+
+test(
+  'ADIT is allowlisted only to its fixed private Storage object',
+  () => {
+    const source = read(
+      'netlify/functions/student-book.js'
+    );
+
+    assert.match(
+      source,
+      /'a-door-into-time': Object\.freeze\(\{[\s\S]*?objectPath:\s*'books\/a-door-into-time\.epub'[\s\S]*?filename:\s*'A Door Into Time\.epub'[\s\S]*?contentType:\s*'application\/epub\+zip'/
+    );
+  }
+);
+
+test(
+  'Student Resource slot 3 maps ADIT into the secure EPUB reader',
+  () => {
+    const source = read(
+      'site/web/student-portal-init.js'
+    );
+
+    assert.match(
+      source,
+      /['"]\/student\/resources\/presentation-03\/['"][\s\S]*?id:\s*['"]a-door-into-time['"][\s\S]*?title:\s*['"]A Door Into Time['"]/
+    );
+
+    assert.match(
+      source,
+      /supportPath:\s*['"]\/assets\/data\/student-book-support\/a-door-into-time\.json['"]/
+    );
+  }
+);
+
+test(
+  'Student Resources publishes ADIT as slot 3 without disturbing slots 1 or 2',
+  () => {
+    const state = JSON.parse(
+      read('site/assets/data/site-state.json')
+    );
+
+    const category =
+      state.categories.student_resources;
+
+    assert.equal(
+      category.titles[0],
+      'Language Arts Skill Builder'
+    );
+
+    assert.equal(
+      category.links[0],
+      '/student/resources/presentation-01/'
+    );
+
+    assert.equal(
+      category.titles[1],
+      '"Lost in Kragdon-ah" by Shawn Inmon'
+    );
+
+    assert.equal(
+      category.links[1],
+      '/student/resources/presentation-02/'
+    );
+
+    assert.equal(
+      category.titles[2],
+      '"A Door Into Time" by Shawn Inmon'
+    );
+
+    assert.equal(
+      category.links[2],
+      '/student/resources/presentation-03/'
+    );
+  }
+);
+
+test(
+  'ADIT support metadata is minimal and contains no book prose',
+  () => {
+    const support = JSON.parse(
+      read(
+        'site/assets/data/student-book-support/a-door-into-time.json'
+      )
+    );
+
+    assert.deepEqual(
+      support,
+      {
+        bookId: 'a-door-into-time',
+        title: 'A Door Into Time',
+        author: 'Shawn Inmon',
+        glossary: []
+      }
+    );
+  }
+);


### PR DESCRIPTION
## RC-LIBRARY-04 — A Door Into Time Student Library onboarding

### Goal

Add **A Door Into Time** by Shawn Inmon to the existing secure Student Library architecture without redesigning the reader or changing authentication, TTS architecture, Supabase schema/RLS, or Netlify settings.

### Source authority

The EPUB source was verified against the Google Drive classroom-books folder before onboarding.

Certified SHA256:

`3f5e174bd8ff5380c12dfc2a15cfe321028054a4bfd0d3172d567bdc30b04d37`

The EPUB itself is **not committed to Git**. The exact certified bytes were uploaded as one new private Storage object:

`classroom-books/books/a-door-into-time.epub`

The stored object was downloaded again and verified byte-for-byte against the certified Google Drive source.

### Application changes

- allowlist `a-door-into-time` in `student-book`
- map Student Resource slot 3 into the existing secure EPUB reader
- add minimal prose-free support metadata
- preserve existing Lost in Kragdon-ah Library behavior
- add focused RC-LIBRARY-04 regression coverage

### Verified behavior

- focused RC-LIBRARY-04 tests: 4/4 passed
- existing secure-Library regression tests: 22/22 passed
- existing Student Library browser regression: 1/1 passed
- integrated ADIT Student Portal smoke: 1/1 passed
- actual `student-book` handler read the actual private ADIT Storage object
- exact stored size: 902,732 bytes
- exact stored SHA verified
- EPUB.js reader opened successfully
- TOC populated
- publisher-rendered Chapter One opener displayed correctly
- substantive Chapter One prose rendered on the following EPUB page
- Previous / Next navigation passed
- CFI persistence passed
- Read Aloud / Pause / Resume / Stop passed with synthetic TTS
- reader Close passed
- existing Lost card remained present

### Guardrails preserved

- no real student data used
- no OpenAI call during integrated smoke
- no reader redesign
- no Hub changes
- no TTS architecture changes
- no Supabase schema/RLS/auth changes
- no Netlify settings changes
- no manual deployment

### Commit

`2efc8df6752072e950761b68f29de15d112a7751`
