### PR TITLE
RC-MEDIA-01: add resumable large classroom media

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
       
       - name: Run unit tests
         run: npm run test:unit
+      - name: Run RC-MEDIA-01 large-media regression
+        run: node tests/rc-media-01-large-classroom-media.test.cjs
 
   smoke:
     runs-on: ubuntu-latest

--- a/netlify/functions/admin-media-upload-token.js
+++ b/netlify/functions/admin-media-upload-token.js
@@ -1,0 +1,216 @@
+'use strict';
+
+/**
+ * RC-MEDIA-01 — Large classroom media upload authorization.
+ *
+ * The existing Admin Uploader intentionally sends small presentation bundles
+ * through Netlify/GitHub. Large media must not use that transport.
+ *
+ * This endpoint:
+ * - requires the existing HttpOnly Teacher Center session
+ * - requires the real admin role
+ * - accepts only the dedicated public classroom-media bucket
+ * - accepts only MP4 and WebVTT objects
+ * - caps each object at 1 GiB
+ * - creates a short-lived Supabase signed upload token with the service role
+ * - returns the signed token and direct TUS endpoint, never the service role key
+ *
+ * POST /.netlify/functions/admin-media-upload-token
+ */
+
+const { requireTeacher } = require('./_lib/auth');
+const { getSupabaseConfig } = require('./_lib/supa');
+
+const { SESSION_SECRET } = process.env;
+
+const MEDIA_BUCKET = 'classroom-media';
+const MAX_FILE_BYTES = 1024 * 1024 * 1024;
+const CACHE_CONTROL_SECONDS = '86400';
+
+const ALLOWED_TYPES = Object.freeze({
+  'video/mp4': '.mp4',
+  'text/vtt': '.vtt',
+});
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function cleanObjectPath(value) {
+  const path = String(value || '').trim();
+
+  if (!path || path.length > 240) return '';
+  if (path.startsWith('/') || path.endsWith('/')) return '';
+  if (path.includes('..') || path.includes('\\')) return '';
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(path)) return '';
+
+  const segments = path.split('/');
+  if (segments.some((part) => !part || part === '.' || part === '..')) return '';
+
+  return path;
+}
+
+function encodedObjectPath(path) {
+  return path
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+}
+
+function projectRefFromUrl(url) {
+  try {
+    return new URL(url).hostname.split('.')[0] || '';
+  } catch {
+    return '';
+  }
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: {
+        Allow: 'POST, OPTIONS',
+        'Cache-Control': 'no-store',
+      },
+      body: '',
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return json(405, { ok: false, error: 'Method Not Allowed' });
+  }
+
+  if (!SESSION_SECRET) {
+    return json(503, { ok: false, error: 'Admin session unavailable' });
+  }
+
+  const auth = requireTeacher(event, SESSION_SECRET);
+
+  if (!auth.ok) {
+    return json(401, { ok: false, error: 'Unauthorized' });
+  }
+
+  if (!auth.user || auth.user.role !== 'admin') {
+    return json(403, { ok: false, error: 'Admin access required' });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return json(400, { ok: false, error: 'Invalid JSON body' });
+  }
+
+  const objectPath = cleanObjectPath(body.objectPath);
+  const contentType = String(body.contentType || '').trim().toLowerCase();
+  const size = Number(body.size);
+
+  if (!objectPath) {
+    return json(400, { ok: false, error: 'Invalid media object path' });
+  }
+
+  const requiredExtension = ALLOWED_TYPES[contentType];
+
+  if (!requiredExtension || !objectPath.toLowerCase().endsWith(requiredExtension)) {
+    return json(400, { ok: false, error: 'Unsupported media type or extension' });
+  }
+
+  if (!Number.isSafeInteger(size) || size <= 0 || size > MAX_FILE_BYTES) {
+    return json(400, {
+      ok: false,
+      error: 'Media file must be between 1 byte and 1 GiB',
+    });
+  }
+
+  const { url: supabaseUrl, key: serviceRoleKey } = getSupabaseConfig();
+  const projectRef = projectRefFromUrl(supabaseUrl);
+
+  if (!supabaseUrl || !serviceRoleKey || !projectRef) {
+    return json(503, { ok: false, error: 'Media storage unavailable' });
+  }
+
+  const encodedPath = encodedObjectPath(objectPath);
+  const signUrl =
+    `${supabaseUrl}/storage/v1/object/upload/sign/` +
+    `${encodeURIComponent(MEDIA_BUCKET)}/${encodedPath}`;
+
+  let response;
+
+  try {
+    response = await fetch(signUrl, {
+      method: 'POST',
+      headers: {
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+        'Content-Type': 'application/json',
+        'x-upsert': 'false',
+      },
+      body: '{}',
+    });
+  } catch (error) {
+    console.error('[admin-media-upload-token] Storage request failed:', error.message);
+    return json(502, { ok: false, error: 'Could not authorize media upload' });
+  }
+
+  const text = await response.text();
+  let data = null;
+
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok || !data || !data.url) {
+    console.error(
+      '[admin-media-upload-token] Storage signing failed:',
+      response.status,
+      text.slice(0, 300)
+    );
+
+    return json(response.status >= 400 && response.status < 500 ? 409 : 502, {
+      ok: false,
+      error: 'Could not create signed media upload URL',
+    });
+  }
+
+  let token = '';
+
+  try {
+    const signedUrl = new URL(`${supabaseUrl}/storage/v1${data.url}`);
+    token = signedUrl.searchParams.get('token') || '';
+  } catch {
+    token = '';
+  }
+
+  if (!token) {
+    return json(502, { ok: false, error: 'Storage did not return an upload token' });
+  }
+
+  const publicUrl =
+    `${supabaseUrl}/storage/v1/object/public/` +
+    `${encodeURIComponent(MEDIA_BUCKET)}/${encodedPath}`;
+
+  return json(200, {
+    ok: true,
+    bucket: MEDIA_BUCKET,
+    objectPath,
+    contentType,
+    size,
+    token,
+    cacheControl: CACHE_CONTROL_SECONDS,
+    uploadEndpoint:
+      `https://${projectRef}.storage.supabase.co/storage/v1/upload/resumable`,
+    publicUrl,
+    expiresInSeconds: 7200,
+  });
+};

--- a/site/assets/data/collection-featured-media.json
+++ b/site/assets/data/collection-featured-media.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "collections": {
+    "rfk-2026-27": [
+      {
+        "id": "kragdon-ah-catch-up-recap",
+        "title": "Kragdon-ah: The Story So Far — Books 1 & 2 Recap",
+        "url": "/presentations/rfk-2026-27/recap/",
+        "eyebrow": "START HERE",
+        "description": "11:37 cinematic catch-up before Return from Kragdon-ah."
+      }
+    ]
+  }
+}

--- a/site/assets/js/collection-featured-media.js
+++ b/site/assets/js/collection-featured-media.js
@@ -1,0 +1,112 @@
+(function () {
+  'use strict';
+
+  const REGISTRY_URL = '/assets/data/collection-featured-media.json';
+
+  function requestedCollectionId() {
+    try {
+      return String(new URLSearchParams(window.location.search).get('collection') || '').trim();
+    } catch {
+      return '';
+    }
+  }
+
+  function mediaIcon() {
+    return '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"></rect><polygon points="10 8 16 12 10 16 10 8"></polygon><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>';
+  }
+
+  function createCard(item) {
+    const card = document.createElement('a');
+    card.className = 'card featured-media-card';
+    card.href = item.url;
+    card.setAttribute('data-featured-media-id', item.id || item.url);
+    card.setAttribute('aria-label', `Open ${item.title}`);
+    card.style.borderColor = 'rgba(53,224,138,.42)';
+    card.style.boxShadow = '0 0 0 1px rgba(53,224,138,.10), 0 16px 34px rgba(0,0,0,.20)';
+
+    const icon = document.createElement('div');
+    icon.className = 'card-icon';
+    icon.innerHTML = mediaIcon();
+
+    const content = document.createElement('div');
+    content.style.minWidth = '0';
+
+    if (item.eyebrow) {
+      const eyebrow = document.createElement('div');
+      eyebrow.textContent = item.eyebrow;
+      eyebrow.style.cssText = 'font-size:.72rem;font-weight:800;letter-spacing:.13em;color:#35e08a;margin-bottom:4px;';
+      content.appendChild(eyebrow);
+    }
+
+    const title = document.createElement('div');
+    title.className = 't';
+    title.textContent = item.title || item.id || 'Featured Media';
+    content.appendChild(title);
+
+    if (item.description) {
+      const description = document.createElement('div');
+      description.textContent = item.description;
+      description.style.cssText = 'margin-top:5px;font-size:.86rem;opacity:.72;line-height:1.35;';
+      content.appendChild(description);
+    }
+
+    card.appendChild(icon);
+    card.appendChild(content);
+    return card;
+  }
+
+  function installFeaturedCards(grid, items) {
+    if (!grid || !Array.isArray(items) || !items.length) return;
+
+    function ensureCards() {
+      items
+        .slice()
+        .reverse()
+        .forEach((item) => {
+          const id = item.id || item.url;
+          if (!id) return;
+
+          const existing = Array.from(grid.querySelectorAll('[data-featured-media-id]'))
+            .find((node) => node.getAttribute('data-featured-media-id') === id);
+
+          if (!existing) grid.prepend(createCard(item));
+        });
+    }
+
+    const observer = new MutationObserver(() => ensureCards());
+    observer.observe(grid, { childList: true });
+
+    ensureCards();
+
+    window.setTimeout(() => {
+      ensureCards();
+      observer.disconnect();
+    }, 5000);
+  }
+
+  async function init() {
+    const collectionId = requestedCollectionId();
+    const grid = document.getElementById('grid');
+
+    if (!collectionId || !grid) return;
+
+    try {
+      const response = await fetch(`${REGISTRY_URL}?t=${Date.now()}`, { cache: 'no-store' });
+      if (!response.ok) return;
+
+      const data = await response.json();
+      const items = data && data.collections && data.collections[collectionId];
+
+      installFeaturedCards(grid, items);
+    } catch (_) {
+      // Featured media is additive. The ordinary collection grid must remain usable
+      // even if this registry cannot be loaded.
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/site/language-arts/collection/index.html
+++ b/site/language-arts/collection/index.html
@@ -19,6 +19,7 @@
   <script defer src="/web/class-mode.js"></script>
   <script src="/assets/js/open-in-viewer.js"></script>
   <script defer src="/assets/js/unit-grid.js"></script>
+  <script defer src="/assets/js/collection-featured-media.js"></script>
 </head>
 <body>
   <div class="tc-app" data-page-title="Curriculum Collection">

--- a/site/presentations/rfk-2026-27/recap/index.html
+++ b/site/presentations/rfk-2026-27/recap/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Kragdon-ah: The Story So Far — Reinisch Classroom</title>
+  <link rel="stylesheet" href="/assets/css/rc-theme.css" />
+  <style>
+    *{box-sizing:border-box}
+    body{margin:0;background:#090d0b;color:#edf5f1;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;min-height:100vh}
+    .page{max-width:1180px;margin:0 auto;padding:26px 24px 42px}
+    .top{display:flex;align-items:flex-start;justify-content:space-between;gap:18px;margin-bottom:20px}
+    .eyebrow{font-size:13px;letter-spacing:.15em;text-transform:uppercase;color:#63e59e;font-weight:800;margin-bottom:7px}
+    h1{font-size:clamp(28px,4vw,44px);line-height:1.08;margin:0 0 8px}
+    .sub{color:#aabbb2;font-size:17px;line-height:1.45}
+    .back{display:inline-flex;align-items:center;padding:9px 13px;border-radius:10px;border:1px solid rgba(255,255,255,.12);color:#e8f1ec;text-decoration:none;background:rgba(255,255,255,.05);white-space:nowrap}
+    .video-shell{background:#000;border:1px solid rgba(255,255,255,.10);border-radius:14px;overflow:hidden;box-shadow:0 24px 70px rgba(0,0,0,.42)}
+    video{display:block;width:100%;height:auto;background:#000;aspect-ratio:16/9}
+    .meta{display:flex;justify-content:space-between;gap:18px;flex-wrap:wrap;padding:14px 2px 0;color:#9fafA6;font-size:14px}
+    .note{margin-top:18px;padding:13px 15px;border-radius:11px;border:1px solid rgba(53,224,138,.15);background:rgba(53,224,138,.06);color:#cfe7da;line-height:1.45}
+    @media(max-width:720px){.top{flex-direction:column}.back{align-self:flex-start}.page{padding:18px 14px 34px}}
+  </style>
+</head>
+<body>
+  <main class="page">
+    <div class="top">
+      <div>
+        <div class="eyebrow">Start Here · Catch-Up Recap</div>
+        <h1>Kragdon-ah: The Story So Far</h1>
+        <div class="sub">A Door Into Time + Lost in Kragdon-ah · 11:37</div>
+      </div>
+      <a class="back" href="/language-arts/collection/?collection=rfk-2026-27">Back to Return from Kragdon-ah</a>
+    </div>
+
+    <div class="video-shell">
+      <video controls preload="metadata" playsinline crossorigin="anonymous">
+        <source
+          src="https://yrcvsotxnelnlcagblbe.supabase.co/storage/v1/object/public/classroom-media/kragdon-ah/kragdon-ah-catch-up-recap-final.mp4"
+          type="video/mp4"
+        />
+        <track
+          kind="captions"
+          srclang="en"
+          label="English"
+          src="https://yrcvsotxnelnlcagblbe.supabase.co/storage/v1/object/public/classroom-media/kragdon-ah/kragdon-ah-catch-up-recap-final.en.vtt"
+        />
+        Your browser does not support HTML5 video.
+      </video>
+    </div>
+
+    <div class="meta">
+      <span>1080p classroom master · narration by Marin</span>
+      <span>Optional English captions available with the CC control</span>
+    </div>
+
+    <div class="note">
+      This recap covers the major people, promises, losses, and story turns from Books 1 and 2 so students can begin <em>Return from Kragdon-ah</em> with the necessary context.
+    </div>
+  </main>
+</body>
+</html>

--- a/site/teacher/admin/media/app.js
+++ b/site/teacher/admin/media/app.js
@@ -1,0 +1,325 @@
+(function () {
+  'use strict';
+
+  const CHUNK_SIZE = 6 * 1024 * 1024;
+  const MAX_FILE_BYTES = 1024 * 1024 * 1024;
+  const RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
+
+  const objectPathEl = document.getElementById('objectPath');
+  const videoFileEl = document.getElementById('videoFile');
+  const captionFileEl = document.getElementById('captionFile');
+  const uploadBtn = document.getElementById('uploadBtn');
+  const progressWrap = document.getElementById('progressWrap');
+  const videoProgress = document.getElementById('videoProgress');
+  const videoPct = document.getElementById('videoPct');
+  const captionProgressRow = document.getElementById('captionProgressRow');
+  const captionProgress = document.getElementById('captionProgress');
+  const captionPct = document.getElementById('captionPct');
+  const resultEl = document.getElementById('result');
+  const logEl = document.getElementById('log');
+
+  function log(message) {
+    const stamp = new Date().toLocaleTimeString();
+    logEl.textContent += `\n[${stamp}] ${message}`;
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  function formatBytes(bytes) {
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let value = Number(bytes) || 0;
+    let index = 0;
+
+    while (value >= 1024 && index < units.length - 1) {
+      value /= 1024;
+      index += 1;
+    }
+
+    return `${value.toFixed(index ? 1 : 0)} ${units[index]}`;
+  }
+
+  function cleanObjectPath(value) {
+    const path = String(value || '').trim();
+
+    if (!path || path.length > 240) return '';
+    if (path.startsWith('/') || path.endsWith('/')) return '';
+    if (path.includes('..') || path.includes('\\')) return '';
+    if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(path)) return '';
+
+    const parts = path.split('/');
+    if (parts.some((part) => !part || part === '.' || part === '..')) return '';
+
+    return path;
+  }
+
+  function captionObjectPath(videoPath) {
+    return videoPath.toLowerCase().endsWith('.mp4')
+      ? `${videoPath.slice(0, -4)}.en.vtt`
+      : `${videoPath}.en.vtt`;
+  }
+
+  function encodeBase64(value) {
+    const bytes = new TextEncoder().encode(String(value));
+    let binary = '';
+
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+
+    return btoa(binary);
+  }
+
+  function uploadMetadata(values) {
+    return Object.entries(values)
+      .map(([key, value]) => `${key} ${encodeBase64(value)}`)
+      .join(',');
+  }
+
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function requestUploadAuthorization(objectPath, file, contentType) {
+    const response = await fetch('/.netlify/functions/admin-media-upload-token', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        objectPath,
+        contentType,
+        size: file.size,
+      }),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Admin session expired or is not authorized.');
+    }
+
+    if (!response.ok || !data || !data.ok) {
+      throw new Error((data && data.error) || `Upload authorization failed (${response.status})`);
+    }
+
+    return data;
+  }
+
+  async function createUpload(file, authorization, objectPath, contentType) {
+    const headers = {
+      'Tus-Resumable': '1.0.0',
+      'Upload-Length': String(file.size),
+      'Upload-Metadata': uploadMetadata({
+        bucketName: authorization.bucket,
+        objectName: objectPath,
+        contentType,
+        cacheControl: authorization.cacheControl || '86400',
+      }),
+      'x-signature': authorization.token,
+      'x-upsert': 'false',
+    };
+
+    const response = await fetch(authorization.uploadEndpoint, {
+      method: 'POST',
+      credentials: 'omit',
+      headers,
+    });
+
+    if (response.status !== 201) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Could not initialize resumable upload (${response.status}): ${body.slice(0, 240)}`);
+    }
+
+    const location = response.headers.get('location');
+
+    if (!location) {
+      throw new Error('Storage did not return a resumable upload location.');
+    }
+
+    return new URL(location, authorization.uploadEndpoint).toString();
+  }
+
+  async function currentOffset(uploadUrl, token) {
+    const response = await fetch(uploadUrl, {
+      method: 'HEAD',
+      credentials: 'omit',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+        'x-signature': token,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Could not recover upload offset (${response.status}).`);
+    }
+
+    const offset = Number(response.headers.get('upload-offset'));
+
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error('Storage returned an invalid upload offset.');
+    }
+
+    return offset;
+  }
+
+  async function patchChunk(uploadUrl, token, file, offset) {
+    const nextOffset = Math.min(offset + CHUNK_SIZE, file.size);
+    const body = file.slice(offset, nextOffset);
+
+    const response = await fetch(uploadUrl, {
+      method: 'PATCH',
+      credentials: 'omit',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': String(offset),
+        'Content-Type': 'application/offset+octet-stream',
+        'x-signature': token,
+      },
+      body,
+    });
+
+    if (response.status !== 204) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Chunk upload failed (${response.status}): ${text.slice(0, 180)}`);
+    }
+
+    const returnedOffset = Number(response.headers.get('upload-offset'));
+
+    return Number.isSafeInteger(returnedOffset) && returnedOffset >= nextOffset
+      ? returnedOffset
+      : nextOffset;
+  }
+
+  async function uploadFile(file, objectPath, contentType, onProgress) {
+    const authorization = await requestUploadAuthorization(objectPath, file, contentType);
+    const uploadUrl = await createUpload(file, authorization, objectPath, contentType);
+
+    let offset = 0;
+    onProgress(0, file.size);
+
+    while (offset < file.size) {
+      let completed = false;
+      let lastError = null;
+
+      for (const delay of RETRY_DELAYS) {
+        if (delay) await sleep(delay);
+
+        try {
+          offset = await patchChunk(uploadUrl, authorization.token, file, offset);
+          onProgress(offset, file.size);
+          completed = true;
+          break;
+        } catch (error) {
+          lastError = error;
+          log(`Chunk retry: ${error.message}`);
+
+          try {
+            offset = await currentOffset(uploadUrl, authorization.token);
+            onProgress(offset, file.size);
+          } catch (headError) {
+            log(`Offset recovery failed: ${headError.message}`);
+          }
+        }
+      }
+
+      if (!completed) {
+        throw lastError || new Error('Resumable upload failed after retries.');
+      }
+    }
+
+    return authorization.publicUrl;
+  }
+
+  function setProgress(progressEl, pctEl, uploaded, total) {
+    const percentage = total > 0 ? Math.min(100, (uploaded / total) * 100) : 0;
+    progressEl.value = percentage;
+    pctEl.textContent = `${percentage.toFixed(1)}%`;
+  }
+
+  uploadBtn.addEventListener('click', async () => {
+    const videoPath = cleanObjectPath(objectPathEl.value);
+    const video = videoFileEl.files && videoFileEl.files[0];
+    const captions = captionFileEl.files && captionFileEl.files[0];
+
+    resultEl.style.display = 'none';
+    resultEl.textContent = '';
+
+    if (!videoPath || !videoPath.toLowerCase().endsWith('.mp4')) {
+      window.alert('Enter a valid .mp4 Storage object path.');
+      return;
+    }
+
+    if (!video) {
+      window.alert('Choose an MP4 file.');
+      return;
+    }
+
+    if (video.size > MAX_FILE_BYTES) {
+      window.alert('The video exceeds the 1 GiB classroom-media limit.');
+      return;
+    }
+
+    if (captions && captions.size > MAX_FILE_BYTES) {
+      window.alert('The caption file exceeds the 1 GiB classroom-media limit.');
+      return;
+    }
+
+    uploadBtn.disabled = true;
+    progressWrap.style.display = 'block';
+    captionProgressRow.style.display = captions ? 'block' : 'none';
+    videoProgress.value = 0;
+    videoPct.textContent = '0%';
+    captionProgress.value = 0;
+    captionPct.textContent = '0%';
+
+    log(`Video: ${video.name} (${formatBytes(video.size)})`);
+    log(`Target: classroom-media/${videoPath}`);
+
+    try {
+      const videoUrl = await uploadFile(
+        video,
+        videoPath,
+        'video/mp4',
+        (uploaded, total) => setProgress(videoProgress, videoPct, uploaded, total)
+      );
+
+      log('Video upload complete.');
+
+      let captionUrl = '';
+
+      if (captions) {
+        const vttPath = captionObjectPath(videoPath);
+        log(`Captions: ${captions.name} (${formatBytes(captions.size)})`);
+        log(`Target: classroom-media/${vttPath}`);
+
+        captionUrl = await uploadFile(
+          captions,
+          vttPath,
+          'text/vtt',
+          (uploaded, total) => setProgress(captionProgress, captionPct, uploaded, total)
+        );
+
+        log('Caption upload complete.');
+      }
+
+      const lines = [
+        '<strong>Upload complete.</strong>',
+        `<div>Video: <a href="${videoUrl}" target="_blank" rel="noopener">${videoUrl}</a></div>`,
+      ];
+
+      if (captionUrl) {
+        lines.push(
+          `<div>Captions: <a href="${captionUrl}" target="_blank" rel="noopener">${captionUrl}</a></div>`
+        );
+      }
+
+      resultEl.innerHTML = lines.join('');
+      resultEl.style.display = 'block';
+    } catch (error) {
+      console.error('[large-media-upload]', error);
+      log(`ERROR: ${error.message || String(error)}`);
+      window.alert(error.message || String(error));
+    } finally {
+      uploadBtn.disabled = false;
+    }
+  });
+})();

--- a/site/teacher/admin/media/index.html
+++ b/site/teacher/admin/media/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Teacher Center — Large Media</title>
+  <link rel="stylesheet" href="/assets/css/rc-theme.css" />
+  <link rel="stylesheet" href="/web/teacher-shell.css" />
+  <script src="/assets/js/admin-guard.js"></script>
+  <script src="../gate.js" defer></script>
+  <style>
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--rc-bg,#0b0f0d);color:var(--rc-ink,#e8f1ec);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+    .wrap{max-width:980px;margin:32px auto;padding:24px;background:rgba(17,26,21,.78);border:1px solid rgba(255,255,255,.09);border-radius:16px}
+    .bar{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:22px}
+    .bar h1{margin:0;font-size:28px}
+    .btn-link{display:inline-flex;align-items:center;padding:9px 13px;border-radius:10px;border:1px solid rgba(255,255,255,.12);color:inherit;text-decoration:none;background:rgba(255,255,255,.05)}
+    .note{padding:14px 16px;border-radius:12px;background:rgba(53,224,138,.08);border:1px solid rgba(53,224,138,.18);color:#c9f8dc;margin-bottom:20px;line-height:1.45}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+    .field{margin-bottom:16px}
+    .field.full{grid-column:1/-1}
+    label{display:block;font-weight:700;margin-bottom:6px;color:#c9d7cf}
+    input,button{width:100%;padding:11px 12px;border-radius:11px;border:1px solid rgba(255,255,255,.12);background:rgba(0,0,0,.22);color:#edf7f1;font:inherit}
+    input:focus{outline:none;border-color:#35e08a;box-shadow:0 0 0 3px rgba(53,224,138,.13)}
+    button{cursor:pointer;font-weight:800;background:linear-gradient(180deg,#35e08a,#14b86a);color:#032313;border:0}
+    button:disabled{opacity:.45;cursor:not-allowed}
+    .hint{font-size:12px;color:#9fb0a7;margin-top:5px;line-height:1.35}
+    .filebox{padding:12px;border:1px dashed rgba(255,255,255,.18);border-radius:12px;background:rgba(0,0,0,.13)}
+    .progress-wrap{display:none;margin-top:18px}
+    .progress-row{margin-bottom:16px}
+    .progress-head{display:flex;justify-content:space-between;gap:12px;margin-bottom:6px;font-size:13px}
+    progress{width:100%;height:16px;accent-color:#35e08a}
+    .log{margin-top:18px;min-height:190px;max-height:320px;overflow:auto;white-space:pre-wrap;padding:12px;border-radius:12px;background:#07100c;border:1px solid rgba(255,255,255,.08);font:12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#d7e9df}
+    .result{display:none;margin-top:16px;padding:14px;border:1px solid rgba(53,224,138,.25);border-radius:12px;background:rgba(53,224,138,.07);word-break:break-all}
+    .result a{color:#74f3ad}
+    @media(max-width:760px){.grid{grid-template-columns:1fr}.field.full{grid-column:auto}}
+  </style>
+</head>
+<body>
+  <div id="gate" style="min-height:100vh;display:grid;place-items:center">Checking admin session…</div>
+
+  <div id="app" style="display:none">
+    <main class="wrap">
+      <div class="bar">
+        <div>
+          <h1>Large Classroom Media</h1>
+          <div class="hint">Resumable Supabase Storage uploads for video and caption assets.</div>
+        </div>
+        <a class="btn-link" href="/teacher/admin/">Back to Admin</a>
+      </div>
+
+      <div class="note">
+        Large files bypass the normal presentation uploader. They upload directly to the dedicated
+        <strong>classroom-media</strong> Storage bucket in 6 MB chunks. The browser never receives a service-role key.
+      </div>
+
+      <div class="grid">
+        <div class="field full">
+          <label for="objectPath">Video object path</label>
+          <input id="objectPath" value="kragdon-ah/kragdon-ah-catch-up-recap-final.mp4" autocomplete="off" />
+          <div class="hint">Letters, numbers, dots, dashes, underscores, and folders only. Existing objects are not overwritten.</div>
+        </div>
+
+        <div class="field">
+          <label for="videoFile">MP4 video</label>
+          <div class="filebox"><input id="videoFile" type="file" accept="video/mp4,.mp4" /></div>
+        </div>
+
+        <div class="field">
+          <label for="captionFile">WebVTT captions (optional)</label>
+          <div class="filebox"><input id="captionFile" type="file" accept="text/vtt,.vtt" /></div>
+          <div class="hint">If selected, captions use the same base path with <code>.en.vtt</code>.</div>
+        </div>
+
+        <div class="field full">
+          <button id="uploadBtn" type="button">Upload Large Media</button>
+        </div>
+      </div>
+
+      <div id="progressWrap" class="progress-wrap" aria-live="polite">
+        <div class="progress-row">
+          <div class="progress-head"><span>Video</span><span id="videoPct">0%</span></div>
+          <progress id="videoProgress" max="100" value="0"></progress>
+        </div>
+        <div class="progress-row" id="captionProgressRow" style="display:none">
+          <div class="progress-head"><span>Captions</span><span id="captionPct">0%</span></div>
+          <progress id="captionProgress" max="100" value="0"></progress>
+        </div>
+      </div>
+
+      <div id="result" class="result"></div>
+      <div id="log" class="log">Ready.</div>
+    </main>
+  </div>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/tests/rc-media-01-large-classroom-media.test.cjs
+++ b/tests/rc-media-01-large-classroom-media.test.cjs
@@ -1,0 +1,117 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+test('large media authorization stays admin-only and service-role mediated', () => {
+  const source = read('netlify/functions/admin-media-upload-token.js');
+
+  assert.match(source, /requireTeacher\(event, SESSION_SECRET\)/);
+  assert.match(source, /auth\.user\.role !== 'admin'/);
+  assert.match(source, /const MEDIA_BUCKET = 'classroom-media'/);
+  assert.match(source, /const MAX_FILE_BYTES = 1024 \* 1024 \* 1024/);
+  assert.match(source, /'video\/mp4': '\.mp4'/);
+  assert.match(source, /'text\/vtt': '\.vtt'/);
+  assert.match(source, /\/storage\/v1\/object\/upload\/sign\//);
+  assert.match(source, /serviceRoleKey/);
+  assert.match(source, /x-upsert': 'false'/);
+
+  assert.doesNotMatch(
+    source,
+    /return json\([^)]*serviceRoleKey/,
+    'service role credential must never be returned to the browser'
+  );
+});
+
+test('large media browser path uses direct resumable TUS chunks', () => {
+  const source = read('site/teacher/admin/media/app.js');
+
+  assert.match(source, /const CHUNK_SIZE = 6 \* 1024 \* 1024/);
+  assert.match(source, /'Tus-Resumable': '1\.0\.0'/);
+  assert.match(source, /'Upload-Length'/);
+  assert.match(source, /'Upload-Metadata'/);
+  assert.match(source, /'Upload-Offset'/);
+  assert.match(source, /'Content-Type': 'application\/offset\+octet-stream'/);
+  assert.match(source, /'x-signature': authorization\.token/);
+  assert.match(source, /credentials: 'omit'/);
+  assert.match(source, /RETRY_DELAYS/);
+
+  assert.doesNotMatch(source, /readAsDataURL|base64,/);
+  assert.doesNotMatch(source, /incremental-deploy/);
+});
+
+test('large media admin page is separate from the ordinary presentation uploader', () => {
+  const html = read('site/teacher/admin/media/index.html');
+
+  assert.match(html, /Large Classroom Media/);
+  assert.match(html, /6 MB chunks/);
+  assert.match(html, /id="videoFile"/);
+  assert.match(html, /id="captionFile"/);
+  assert.match(html, /\.\/app\.js/);
+});
+
+test('Kragdon recap viewer streams Storage video and keeps captions optional', () => {
+  const html = read('site/presentations/rfk-2026-27/recap/index.html');
+
+  assert.match(html, /<video controls preload="metadata" playsinline crossorigin="anonymous">/);
+  assert.match(html, /classroom-media\/kragdon-ah\/kragdon-ah-catch-up-recap-final\.mp4/);
+  assert.match(html, /classroom-media\/kragdon-ah\/kragdon-ah-catch-up-recap-final\.en\.vtt/);
+  assert.match(html, /kind="captions"/);
+  assert.doesNotMatch(html, /<track[^>]+default/);
+  assert.doesNotMatch(html, /autoplay/);
+});
+
+test('Return collection exposes recap as additive featured media', () => {
+  const registry = JSON.parse(
+    read('site/assets/data/collection-featured-media.json')
+  );
+
+  const items = registry.collections['rfk-2026-27'];
+
+  assert.ok(Array.isArray(items));
+  assert.equal(items.length, 1);
+  assert.equal(items[0].url, '/presentations/rfk-2026-27/recap/');
+  assert.match(items[0].title, /Books 1 & 2 Recap/);
+
+  const collectionHtml = read('site/language-arts/collection/index.html');
+  assert.match(collectionHtml, /collection-featured-media\.js/);
+
+  const featureSource = read('site/assets/js/collection-featured-media.js');
+  assert.match(featureSource, /grid\.prepend\(createCard\(item\)\)/);
+  assert.match(featureSource, /MutationObserver/);
+});
+
+test('existing Return weekly presentation topology remains 15 fixed slots', () => {
+  const units = JSON.parse(read('site/assets/data/units.json'));
+  const rfkUnit = units.units.find((unit) => unit.id === 'rfk-2026-27');
+
+  assert.ok(rfkUnit);
+  assert.equal(rfkUnit.slots, 15);
+  assert.equal(rfkUnit.baseOut, 'presentations/rfk-2026-27');
+
+  const state = JSON.parse(read('site/assets/data/site-state.json'));
+  const rfk = state.categories['rfk-2026-27'];
+
+  assert.ok(rfk);
+  assert.equal(rfk.slots, 15);
+  assert.equal(rfk.titles.length, 15);
+  assert.equal(rfk.links.length, 15);
+
+  for (let slot = 1; slot <= 15; slot += 1) {
+    const directory = path.join(
+      ROOT,
+      'site/presentations/rfk-2026-27',
+      `presentation-${String(slot).padStart(2, '0')}`
+    );
+
+    assert.ok(fs.existsSync(directory), `missing Return presentation slot ${slot}`);
+  }
+});


### PR DESCRIPTION
## RC-MEDIA-01 — Large Classroom Media

### Goal

Give ReinischClassroom a proper large-media lane without weakening or enlarging the existing presentation uploader.

### Architecture

- existing Admin presentation uploader remains unchanged and continues batching small HTML/presentation bundles through Netlify/GitHub
- new `/teacher/admin/media/` page uploads MP4/WebVTT directly to the dedicated Supabase `classroom-media` bucket
- browser upload uses TUS resumable transfer in 6 MB chunks with retry/offset recovery
- an authenticated Netlify function creates a 2-hour signed Supabase upload token
- only the real admin role may request upload authorization
- service-role credentials never reach the browser
- media objects are capped at 1 GiB and limited to `video/mp4` / `text/vtt`
- existing objects are not overwritten

### Kragdon-ah recap integration

- adds a clean video viewer at `/presentations/rfk-2026-27/recap/`
- optional WebVTT captions remain off by default
- adds an additive `START HERE` featured card before the ordinary Return weekly grid
- preserves all existing `presentation-01` through `presentation-15` paths and the 15-slot Return topology

### Footprint

- 9 changed files
- exactly one existing collection HTML file changed by one script include
- CI workflow adds one focused RC-MEDIA regression step
- no existing presentation uploader code changed
- no weekly presentation files changed
- no student data
- no auth/RLS schema changes
- no source books

### Supabase prerequisite

The production project global Storage file-size ceiling was explicitly raised to 1 GB. The existing `classroom-media` bucket is public, capped at 1 GiB, and restricted to MP4/WebVTT.

### Security

A temporary anonymous upload policy used during earlier troubleshooting was removed and verified absent before this PR.

### Regression coverage

`tests/rc-media-01-large-classroom-media.test.cjs` protects:

- admin-only signed upload authorization
- service-role boundary
- 1 GiB/type restrictions
- 6 MB TUS chunking and retry semantics
- no base64/Netlify transport for large media
- optional caption behavior
- additive featured media card
- unchanged 15-slot Return weekly topology

The focused RC-MEDIA regression runs as a named CI step after the existing unit suite.

No production media object is uploaded by this PR itself.