### PR TITLE
Align Classroom Resources and Playbook with public shell

### DIFF
--- a/site/classroom-resources/classroom-playbook/index.html
+++ b/site/classroom-resources/classroom-playbook/index.html
@@ -10,12 +10,11 @@
 <link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-3.css"/>
 </head>
 <body>
-<div aria-hidden="true" class="topbar"><div class="brand">Mr. Reinisch • The Classroom Playbook</div><div class="progress"><span id="progressBar"></span></div><div class="count" id="topCount">01 / 18</div></div>
-<div class="tap-hint"><b>Interactive:</b> tap a card when you want the example</div>
+<div class="bar" id="progressBar" aria-hidden="true"></div>
 <main class="presentation" id="presentation" aria-live="polite"></main>
+<div class="slide-counter" aria-live="polite"><span id="current">1</span> / <span id="total">18</span></div>
 <nav aria-label="Presentation controls" class="controls">
-<button aria-label="Previous slide" class="nav-btn" id="prevBtn" type="button">← Previous</button>
-<div aria-live="polite" class="nav-mid"><span id="current">1</span> / <span id="total">18</span></div>
+<button aria-label="Previous slide" class="nav-btn" id="prevBtn" type="button">← Back</button>
 <button aria-label="Next slide" class="nav-btn" id="nextBtn" type="button">Next →</button>
 </nav>
 <div aria-hidden="true" aria-labelledby="modalTitle" aria-modal="true" class="overlay" id="overlay" role="dialog">

--- a/site/classroom-resources/classroom-playbook/playbook-3.css
+++ b/site/classroom-resources/classroom-playbook/playbook-3.css
@@ -75,3 +75,46 @@
   *,*::before,*::after{animation-duration:.001ms !important;animation-iteration-count:1 !important;scroll-behavior:auto !important;transition-duration:.001ms !important}
   .slide.active.motion-in .kicker,.slide.active.motion-in h1,.slide.active.motion-in h2,.slide.active.motion-in .lead,.slide.active.motion-in .big-quote,.slide.active.motion-in .hero-rule,.slide.active.motion-in .chips,.slide.active.motion-in .card,.slide.active.motion-in .topic,.slide.active.motion-in .course-btn,.slide.active.motion-in .rule,.slide.active.motion-in .phrase,.slide.active.motion-in .callout,.slide.active.motion-in .footer-line{opacity:1;transform:none}
 }
+
+/* ---------- ReinischClassroom presentation-shell alignment ---------- */
+.bar{
+  position:fixed;top:0;left:0;height:5px;width:0;z-index:60;
+  background:linear-gradient(90deg,var(--teal),var(--amber),var(--coral));
+  background-size:220% 100%;animation:progressShimmer 4.5s linear infinite;
+  transition:width .22s ease;
+}
+.slide{
+  padding:30px clamp(24px,4vw,58px) 72px;
+}
+.deck{
+  max-height:calc(100dvh - 96px);
+}
+.controls{
+  left:auto;right:14px;bottom:10px;transform:none;
+  gap:8px;padding:0;background:transparent;border:0;border-radius:0;
+  backdrop-filter:none;box-shadow:none;
+}
+.nav-btn{
+  min-width:auto;padding:10px 15px;border-radius:10px;
+  background:rgba(24,34,53,.88);border:1px solid rgba(255,255,255,.12);
+  box-shadow:0 8px 22px rgba(0,0,0,.18);
+}
+.nav-btn:hover:not(:disabled),.nav-btn:focus-visible:not(:disabled){
+  background:rgba(36,48,70,.96);border-color:rgba(255,255,255,.22);
+}
+.slide-counter{
+  position:fixed;left:16px;bottom:18px;z-index:40;
+  color:#9fb0c2;font-size:.84rem;font-weight:700;
+  font-variant-numeric:tabular-nums;
+}
+@media(max-height:820px) and (min-width:721px){
+  .slide{padding-top:20px;padding-bottom:62px}
+  .deck{max-height:calc(100dvh - 76px)}
+}
+@media(max-width:720px){
+  .slide{padding:18px 12px 66px}
+  .deck{width:96vw;max-height:calc(100dvh - 78px)}
+  .controls{right:8px;bottom:7px}
+  .slide-counter{left:10px;bottom:15px}
+  .nav-btn{padding:9px 12px}
+}

--- a/site/classroom-resources/classroom-playbook/playbook.js
+++ b/site/classroom-resources/classroom-playbook/playbook.js
@@ -33,7 +33,6 @@
     const next=document.getElementById('nextBtn');
     const current=document.getElementById('current');
     const total=document.getElementById('total');
-    const topCount=document.getElementById('topCount');
     const progress=document.getElementById('progressBar');
     const overlay=document.getElementById('overlay');
     const close=document.getElementById('closeModal');
@@ -60,7 +59,6 @@
       });
       index=n;
       current.textContent=n+1;
-      topCount.textContent=String(n+1).padStart(2,'0')+' / '+String(slides.length).padStart(2,'0');
       progress.style.width=((n+1)/slides.length*100)+'%';
       prev.disabled=n===0;
       next.disabled=n===slides.length-1;
@@ -135,7 +133,7 @@
       showSlide:show,
       next:()=>move(1),
       previous:()=>move(-1),
-      version:'3.1-public-resource'
+      version:'3.2-viewer-aligned'
     };
   }
 

--- a/site/classroom-resources/classroom-resources.js
+++ b/site/classroom-resources/classroom-resources.js
@@ -1,0 +1,25 @@
+(function(){
+  'use strict';
+
+  function wireViewerCards(){
+    document.querySelectorAll('[data-viewer-src]').forEach(function(card){
+      card.addEventListener('click', function(event){
+        if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || event.button === 1) return;
+
+        var src = card.getAttribute('data-viewer-src');
+        var title = card.getAttribute('data-viewer-title') || '';
+
+        if (src && typeof window.openInlineViewer === 'function') {
+          event.preventDefault();
+          window.openInlineViewer(src, { title: title });
+        }
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wireViewerCards);
+  } else {
+    wireViewerCards();
+  }
+})();

--- a/site/classroom-resources/index.html
+++ b/site/classroom-resources/index.html
@@ -11,173 +11,116 @@
   <link rel="stylesheet" href="/web/teacher-shell.css" />
   <link rel="stylesheet" href="/assets/css/class-clock.css" />
   <link rel="stylesheet" href="/assets/css/class-mode.css" />
+
   <script src="/web/public-nav.js"></script>
   <script src="/web/sidebar-init.js"></script>
   <script defer src="/assets/js/class-clock.js" type="module"></script>
   <script defer src="/web/class-mode.js"></script>
+  <script src="/assets/js/open-in-viewer.js"></script>
+  <script defer src="/classroom-resources/classroom-resources.js"></script>
 
   <style>
-    .cr-wrap {
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: 1rem 1.2rem 3rem;
-    }
-
-    .cr-hero {
-      position: relative;
-      overflow: hidden;
-      padding: clamp(1.6rem, 4vw, 2.5rem);
-      border-radius: 20px;
-      border: 1px solid rgba(255,255,255,0.10);
-      background:
-        radial-gradient(circle at 12% 18%, rgba(45, 212, 191, 0.13), transparent 30%),
-        radial-gradient(circle at 88% 20%, rgba(96, 165, 250, 0.10), transparent 28%),
-        rgba(255,255,255,0.035);
-      box-shadow: 0 18px 50px rgba(0,0,0,0.18);
-    }
-
-    .cr-kicker {
-      margin: 0 0 0.55rem;
-      color: rgba(94, 234, 212, 0.92);
-      font-size: 0.72rem;
-      font-weight: 800;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-    }
-
-    .cr-hero h1 {
-      margin: 0;
-      font-size: clamp(2rem, 5vw, 3.4rem);
-      letter-spacing: -0.035em;
-      line-height: 1.05;
-    }
-
-    .cr-hero p {
-      max-width: 720px;
-      margin: 0.8rem 0 0;
-      color: var(--rc-ink-dim);
-      font-size: 1rem;
-      line-height: 1.6;
-    }
-
-    .cr-section-title {
-      margin: 2rem 0 0.9rem;
-      font-size: 0.78rem;
-      font-weight: 800;
-      color: var(--rc-muted);
-      letter-spacing: 0.10em;
-      text-transform: uppercase;
-    }
-
-    .cr-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
-      gap: 1rem;
-    }
-
-    .cr-card {
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      min-height: 260px;
-      padding: 1.5rem;
-      border-radius: 18px;
-      border: 1px solid rgba(255,255,255,0.11);
-      background: linear-gradient(145deg, rgba(255,255,255,0.065), rgba(255,255,255,0.025));
-      color: inherit;
+    a.resource-card {
       text-decoration: none;
-      transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+      color: inherit;
     }
 
-    .cr-card:hover,
-    .cr-card:focus-visible {
-      transform: translateY(-3px);
-      border-color: rgba(45,212,191,0.48);
-      background: linear-gradient(145deg, rgba(45,212,191,0.10), rgba(255,255,255,0.03));
-      box-shadow: 0 16px 36px rgba(0,0,0,0.22);
+    .content-wrapper {
+      padding-top: 1rem;
+    }
+
+    .content-wrapper h1 {
+      font-size: 38px;
+      font-weight: 850;
+      margin: 0 0 12px;
+      letter-spacing: -0.02em;
+      color: var(--rc-ink);
+    }
+
+    .content-wrapper > p {
+      font-size: 1.05rem;
+      color: var(--rc-ink-dim);
+      margin: 0 0 1.5rem;
+      max-width: 72ch;
+    }
+
+    .resource-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 360px));
+      gap: 1.25rem;
+      margin-top: 2rem;
+    }
+
+    .resource-card {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      min-height: 118px;
+      padding: 20px;
+      background: linear-gradient(135deg, rgba(255,255,255,0.06), rgba(255,255,255,0.02));
+      backdrop-filter: blur(12px) saturate(130%);
+      -webkit-backdrop-filter: blur(12px) saturate(130%);
+      border: 1px solid rgba(255,255,255,0.10);
+      border-left: 3px solid rgba(45,212,191,0.58);
+      border-radius: 18px;
+      transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08);
+    }
+
+    .resource-card:hover,
+    .resource-card:focus-visible {
+      transform: translateY(-4px);
+      border-color: rgba(45,212,191,0.38);
+      border-left-color: rgba(45,212,191,0.9);
+      box-shadow: 0 16px 48px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.12);
       outline: none;
     }
 
-    .cr-card-icon {
+    .resource-icon {
+      flex-shrink: 0;
       display: grid;
       place-items: center;
       width: 48px;
       height: 48px;
-      margin-bottom: 1rem;
-      border-radius: 13px;
-      background: rgba(45,212,191,0.10);
-      border: 1px solid rgba(45,212,191,0.22);
+      border-radius: 12px;
       color: #5eead4;
+      background: rgba(45,212,191,0.08);
+      border: 1px solid rgba(45,212,191,0.18);
     }
 
-    .cr-card-icon svg {
-      width: 27px;
-      height: 27px;
+    .resource-icon svg {
+      width: 28px;
+      height: 28px;
       fill: none;
       stroke: currentColor;
-      stroke-width: 1.6;
+      stroke-width: 1.5;
       stroke-linecap: round;
       stroke-linejoin: round;
     }
 
-    .cr-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.45rem;
-      margin-bottom: 0.85rem;
+    .resource-title {
+      display: block;
+      font-size: 1.1rem;
+      font-weight: 800;
+      line-height: 1.2;
+      color: var(--rc-ink);
     }
 
-    .cr-tag {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.28rem 0.55rem;
-      border-radius: 999px;
-      background: rgba(255,255,255,0.055);
-      border: 1px solid rgba(255,255,255,0.08);
-      color: var(--rc-muted);
-      font-size: 0.68rem;
-      font-weight: 750;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .cr-card h2 {
-      margin: 0;
-      font-size: 1.45rem;
-      letter-spacing: -0.02em;
-    }
-
-    .cr-card p {
-      margin: 0.65rem 0 1.2rem;
-      color: var(--rc-ink-dim);
-      line-height: 1.55;
-      font-size: 0.94rem;
-    }
-
-    .cr-launch {
-      margin-top: auto;
-      color: rgba(147,197,253,0.95);
-      font-size: 0.9rem;
-      font-weight: 750;
-    }
-
-    .cr-note {
-      margin-top: 1rem;
-      padding: 1rem 1.1rem;
-      border-radius: 14px;
-      border: 1px dashed rgba(255,255,255,0.11);
-      background: rgba(255,255,255,0.02);
-      color: var(--rc-muted);
+    .resource-meta {
+      display: block;
+      margin-top: 5px;
       font-size: 0.86rem;
-      line-height: 1.5;
+      line-height: 1.4;
+      color: var(--rc-ink-dim);
     }
 
     @media (min-width: 1920px) {
-      .cr-wrap { max-width: 1400px; }
-      .cr-card { min-height: 320px; padding: 2rem; }
-      .cr-card h2 { font-size: 1.8rem; }
-      .cr-card p { font-size: 1.1rem; }
-      .cr-launch { font-size: 1.05rem; }
+      .content-wrapper h1 { font-size: 48px; }
+      .content-wrapper > p { font-size: 1.2rem; }
+      .resource-grid { grid-template-columns: repeat(auto-fill, minmax(340px, 440px)); gap: 1.5rem; }
+      .resource-card { min-height: 148px; padding: 26px; }
+      .resource-title { font-size: 1.35rem; }
+      .resource-meta { font-size: 1rem; }
     }
   </style>
 </head>
@@ -185,31 +128,33 @@
   <div class="tc-app" data-page-title="Classroom Resources">
     <div class="tc-shell">
       <main class="tc-main">
-        <div class="cr-wrap">
-          <section class="cr-hero">
-            <p class="cr-kicker">Reusable • Classroom-facing • Public access</p>
-            <h1>Classroom Resources</h1>
-            <p>Presentations, routines, reference tools, and other things we use across classes — without burying them inside a weekly Language Arts or Transitional Skills lesson.</p>
-          </section>
-
-          <div class="cr-section-title">Featured Resource</div>
-          <section class="cr-grid" aria-label="Classroom resources">
-            <a class="cr-card" href="/classroom-resources/classroom-playbook/">
-              <div class="cr-card-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v17H6.5A2.5 2.5 0 0 0 4 22z"></path><path d="M4 5.5v14"></path><path d="M8 7h8"></path><path d="M8 11h6"></path></svg>
-              </div>
-              <div class="cr-tags">
-                <span class="cr-tag">Presentation</span>
-                <span class="cr-tag">All Classes</span>
-                <span class="cr-tag">2026–27</span>
-              </div>
-              <h2>The Classroom Playbook</h2>
-              <p>Expectations, routines, technology, help, resets, and what to do when a day gets sideways. Built for the first day — useful whenever we need a reset.</p>
-              <div class="cr-launch">Launch presentation →</div>
+        <div class="content-wrapper">
+          <nav class="tc-context-nav" aria-label="Contextual navigation">
+            <a class="tc-context-back" href="/" aria-label="Back to Home">
+              <span aria-hidden="true">←</span><span>Back to Home</span>
             </a>
-          </section>
+          </nav>
 
-          <div class="cr-note">This section is intentionally small right now. We’ll add resources here as they become useful — not because an empty category demanded decorative filler.</div>
+          <h1>Classroom Resources</h1>
+          <p>Presentations, routines, reference tools, and other reusable materials we use across classes.</p>
+
+          <div class="resource-grid" aria-label="Classroom resources">
+            <a
+              class="resource-card"
+              href="/viewer/?src=%2Fclassroom-resources%2Fclassroom-playbook%2F&return=%2Fclassroom-resources%2F&title=The+Classroom+Playbook"
+              data-viewer-src="/classroom-resources/classroom-playbook/"
+              data-viewer-title="The Classroom Playbook"
+              aria-label="Open The Classroom Playbook presentation"
+            >
+              <span class="resource-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v17H6.5A2.5 2.5 0 0 0 4 22z"></path><path d="M4 5.5v14"></path><path d="M8 7h8"></path><path d="M8 11h6"></path></svg>
+              </span>
+              <span>
+                <span class="resource-title">The Classroom Playbook</span>
+                <span class="resource-meta">Presentation · All Classes · Expectations, routines, technology, help, and resets</span>
+              </span>
+            </a>
+          </div>
         </div>
       </main>
     </div>

--- a/site/web/public-nav.js
+++ b/site/web/public-nav.js
@@ -25,22 +25,24 @@
 
   // ── Nav configs ────────────────────────────────────────────────────────────
   var MAIN_NAV = [
-    { href: '/',                    label: 'Home',                icon: I.home      },
-    { href: '/language-arts/',      label: 'Language Arts',       icon: I.book      },
-    { href: '/life-skills/',        label: 'Transitional Skills', icon: I.life      },
-    { href: '/classroom-resources/',label: 'Classroom Resources', icon: I.resources },
-    { href: '/toolkits/',           label: 'Toolkits',            icon: I.wrench    },
-    { href: '/teacher/',            label: 'Teacher',             icon: I.teacher   },
-    { href: '/substitute/',         label: 'Substitute',          icon: I.clip      },
-    { href: '/student/',            label: 'Student',             icon: I.student   },
+    { href: '/',                     label: 'Home',                icon: I.home      },
+    { href: '/language-arts/',       label: 'Language Arts',       icon: I.book      },
+    { href: '/life-skills/',         label: 'Transitional Skills', icon: I.life      },
+    { href: '/classroom-resources/', label: 'Classroom Resources', icon: I.resources },
+    { href: '/toolkits/',            label: 'Toolkits',            icon: I.wrench    },
+    { href: '/teacher/',             label: 'Teacher',             icon: I.teacher   },
+    { href: '/substitute/',          label: 'Substitute',          icon: I.clip      },
+    { href: '/student/',             label: 'Student',             icon: I.student   },
   ];
 
+  // Language Arts uses a focused sub-navigation just like before.
+  // Top-level sections such as Transitional Skills and Classroom Resources
+  // remain in MAIN_NAV rather than being mixed into the LA collection list.
   var LA_NAV = [
-    { href: '/',                       label: 'Home',                icon: I.home      },
-    { href: '/language-arts/',         label: 'Language Arts',       icon: I.book      },
-    { href: '/classroom-resources/',   label: 'Classroom Resources', icon: I.resources },
-    { href: '/language-arts/toolkit/', label: 'Toolkit',             icon: I.wrench    },
-    { href: '/toolkits/',              label: 'All Toolkits',        icon: I.wrench    },
+    { href: '/',                       label: 'Home',          icon: I.home   },
+    { href: '/language-arts/',         label: 'Language Arts', icon: I.book   },
+    { href: '/language-arts/toolkit/', label: 'Toolkit',       icon: I.wrench },
+    { href: '/toolkits/',              label: 'All Toolkits',  icon: I.wrench },
   ];
 
   function activeLanguageArtsCollections(units){
@@ -122,9 +124,9 @@
         '.home-classroom-resource{display:grid;grid-template-columns:auto 1fr auto;gap:16px;align-items:center;margin:18px 0 8px;padding:16px 18px;border-radius:15px;border:1px solid rgba(45,212,191,.22);border-left:3px solid rgba(45,212,191,.72);background:linear-gradient(100deg,rgba(45,212,191,.075),rgba(96,165,250,.035));color:inherit;text-decoration:none;transition:transform .18s ease,border-color .18s ease,background .18s ease;}' +
         '.home-classroom-resource:hover,.home-classroom-resource:focus-visible{transform:translateY(-2px);border-color:rgba(45,212,191,.48);background:linear-gradient(100deg,rgba(45,212,191,.12),rgba(96,165,250,.06));outline:none;}' +
         '.home-classroom-resource-icon{display:grid;place-items:center;width:42px;height:42px;border-radius:12px;background:rgba(45,212,191,.10);color:#5eead4;}' +
-        '.home-classroom-resource-kicker{font-size:.66rem;font-weight:800;letter-spacing:.09em;text-transform:uppercase;color:rgba(94,234,212,.9);margin-bottom:3px;}' +
-        '.home-classroom-resource-title{font-size:1rem;font-weight:800;color:var(--rc-ink);}' +
-        '.home-classroom-resource-desc{font-size:.82rem;color:var(--rc-ink-dim);margin-top:2px;}' +
+        '.home-classroom-resource-kicker{font-size:.66rem;font-weight:800;letter-spacing:.09em;text-transform:uppercase;color:rgba(94,234,212,.9);margin-bottom:3px;display:block;}' +
+        '.home-classroom-resource-title{font-size:1rem;font-weight:800;color:var(--rc-ink);display:block;}' +
+        '.home-classroom-resource-desc{font-size:.82rem;color:var(--rc-ink-dim);margin-top:2px;display:block;}' +
         '.home-classroom-resource-action{white-space:nowrap;font-size:.84rem;font-weight:750;color:rgba(147,197,253,.95);}' +
         '@media(max-width:700px){.home-classroom-resource{grid-template-columns:auto 1fr}.home-classroom-resource-action{grid-column:2;white-space:normal}.home-classroom-resource-desc{display:none}}';
       document.head.appendChild(style);
@@ -133,7 +135,7 @@
     var feature = document.createElement('a');
     feature.id = 'home-classroom-resources-feature';
     feature.className = 'home-classroom-resource';
-    feature.href = '/classroom-resources/classroom-playbook/';
+    feature.href = '/viewer/?src=%2Fclassroom-resources%2Fclassroom-playbook%2F&return=%2F&title=The+Classroom+Playbook';
     feature.innerHTML =
       '<span class="home-classroom-resource-icon" aria-hidden="true">' + I.resources + '</span>' +
       '<span><span class="home-classroom-resource-kicker">Featured Classroom Resource</span>' +


### PR DESCRIPTION
## What this fixes
- Aligns `/classroom-resources/` with the same public-section layout used by Language Arts and Transitional Skills
- Uses the standard contextual Back-to-Home treatment instead of a custom hero/microsite layout
- Keeps Classroom Resources in top-level navigation, but removes it from Language Arts' focused sub-navigation
- Launches the Classroom Playbook through ReinischClassroom's canonical presentation viewer from Classroom Resources
- Keeps the homepage spotlight launch inside the canonical viewer as well

## Classroom Playbook alignment
- Removes duplicate Playbook-specific top chrome so the viewer owns the frame/title/clock/fullscreen controls
- Moves slide count to bottom-left and Back/Next to bottom-right to match the established presentation convention
- Keeps the approved Playbook theme, wording, animations, 18 slides, and 53 interactive examples unchanged

## Scope / safety
- No Teacher Center auth changes
- No student data or database changes
- No curriculum-registry or weekly presentation inventory changes
- No changes to Playbook lesson content

## QA targets
- Classroom Resources layout and top-level nav behavior
- Language Arts focused nav no longer includes Classroom Resources
- Inline viewer launch from Classroom Resources
- Homepage featured launch uses canonical viewer
- Playbook slide navigation, examples/modals, animations, reduced motion, and sizing inside viewer