### PR TITLE
Classroom Resources: add Guided Notes & Binder Guide

### DIFF
--- a/site/classroom-resources/guided-notes-binder-guide/guided-notes.css
+++ b/site/classroom-resources/guided-notes-binder-guide/guided-notes.css
@@ -1,0 +1,81 @@
+/* Guided Notes & Binder Guide — Classroom Resources accent layer */
+:root{
+  --gn-cyan:#55e7f3;
+  --gn-mint:#78e9c6;
+  --gn-amber:#efbd55;
+  --gn-violet:#a68bd6;
+}
+
+/* Keep the Playbook command-center language, but give this resource its own
+   notebook/reference identity. */
+.hero h1 span{
+  color:transparent!important;
+  background:linear-gradient(103deg,#55e7f3 0%,#78e9c6 44%,#a68bd6 100%)!important;
+  -webkit-background-clip:text!important;
+  background-clip:text!important;
+  filter:drop-shadow(0 0 13px rgba(85,231,243,.14))!important;
+}
+.hero-rule{
+  background:linear-gradient(90deg,var(--gn-cyan),var(--gn-mint) 40%,var(--gn-amber) 68%,var(--gn-violet))!important;
+}
+.hero-stamp{
+  color:#f0c865!important;
+  border-color:rgba(240,200,101,.48)!important;
+}
+
+/* A faint ruled-paper cue inside the glass without turning the screen into a
+   literal notebook page. */
+.deck::after{
+  background:
+    linear-gradient(112deg,rgba(255,255,255,.095),transparent 18% 72%,rgba(185,168,215,.06)),
+    repeating-linear-gradient(to bottom,transparent 0 31px,rgba(112,183,218,.025) 32px 33px),
+    radial-gradient(circle at 5% 0%,rgba(85,231,243,.09),transparent 25%),
+    radial-gradient(circle at 98% 100%,rgba(166,139,214,.07),transparent 29%)!important;
+  opacity:.48!important;
+}
+
+.four{
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+  gap:14px;
+  margin-top:22px;
+}
+.scenario-grid{
+  grid-template-columns:repeat(2,1fr)!important;
+}
+.four .topic.big{min-height:176px}
+
+/* Binder/routine cards get a slightly clearer "working tool" accent. */
+.rule .step,
+.topic .num{
+  background:rgba(85,231,243,.09)!important;
+  border:1px solid rgba(85,231,243,.18)!important;
+  color:#7cebf3!important;
+}
+.phrase{
+  border-left-color:var(--gn-cyan)!important;
+  background:rgba(85,231,243,.055)!important;
+}
+.callout{
+  border-color:rgba(239,189,85,.28)!important;
+  background:rgba(239,189,85,.055)!important;
+}
+
+/* Viewer alignment. */
+.slide{padding-top:30px;padding-bottom:72px}
+.deck{max-height:calc(100dvh - 96px)}
+.controls{right:14px!important;bottom:10px!important}
+.slide-counter{left:16px!important;bottom:18px!important}
+
+@media(max-width:980px){
+  .four{grid-template-columns:repeat(2,1fr)}
+}
+@media(max-width:720px){
+  .four,.scenario-grid{grid-template-columns:1fr!important}
+}
+@media(max-height:820px) and (min-width:721px){
+  .slide{padding-top:20px;padding-bottom:62px}
+  .deck{max-height:calc(100dvh - 76px)}
+  .four{gap:10px;margin-top:16px}
+  .four .topic.big{min-height:132px}
+}

--- a/site/classroom-resources/guided-notes-binder-guide/guided-notes.js
+++ b/site/classroom-resources/guided-notes-binder-guide/guided-notes.js
@@ -1,0 +1,111 @@
+(function(){
+  'use strict';
+
+  function init(){
+    const slides=[...document.querySelectorAll('.slide')];
+    const prev=document.getElementById('prevBtn');
+    const next=document.getElementById('nextBtn');
+    const current=document.getElementById('current');
+    const total=document.getElementById('total');
+    const progress=document.getElementById('progressBar');
+    const overlay=document.getElementById('overlay');
+    const close=document.getElementById('closeModal');
+    const modalTitle=document.getElementById('modalTitle');
+    const modalBody=document.getElementById('modalBody');
+    let index=0, lastFocus=null, touchStartX=null;
+
+    total.textContent=slides.length;
+
+    function animateSlide(slide){
+      if(!slide) return;
+      const items=[...slide.querySelectorAll('.kicker,h1,h2,.lead,.big-quote,.hero-rule,.hero-stamp,.chips,.card,.topic,.course-btn,.rule,.phrase,.callout')];
+      items.forEach((el,i)=>el.style.setProperty('--stagger',Math.min(i,12)*48+'ms'));
+      slide.classList.remove('motion-in');
+      void slide.offsetWidth;
+      slide.classList.add('motion-in');
+    }
+
+    function show(n){
+      n=Math.max(0,Math.min(slides.length-1,n));
+      slides.forEach((s,i)=>{
+        s.classList.toggle('active',i===n);
+        if(i!==n) s.classList.remove('motion-in');
+      });
+      index=n;
+      current.textContent=n+1;
+      progress.style.width=((n+1)/slides.length*100)+'%';
+      prev.disabled=n===0;
+      next.disabled=n===slides.length-1;
+      prev.setAttribute('aria-disabled',String(prev.disabled));
+      next.setAttribute('aria-disabled',String(next.disabled));
+      animateSlide(slides[n]);
+    }
+
+    function move(delta){
+      if(!overlay.classList.contains('open')) show(index+delta);
+    }
+
+    function openDetail(id,trigger){
+      const template=document.getElementById(id);
+      if(!template || !template.content) return;
+      const title=template.content.querySelector('[data-title]');
+      const body=template.content.querySelector('[data-body]');
+      lastFocus=trigger||document.activeElement;
+      modalTitle.textContent=title?title.textContent:'Example';
+      modalBody.innerHTML=body?body.innerHTML:'';
+      overlay.classList.add('open');
+      overlay.setAttribute('aria-hidden','false');
+      close.focus();
+    }
+
+    function closeDetail(){
+      overlay.classList.remove('open');
+      overlay.setAttribute('aria-hidden','true');
+      modalBody.innerHTML='';
+      if(lastFocus && typeof lastFocus.focus==='function') lastFocus.focus();
+    }
+
+    prev.addEventListener('click',()=>move(-1));
+    next.addEventListener('click',()=>move(1));
+    document.querySelectorAll('[data-detail]').forEach(btn=>btn.addEventListener('click',()=>openDetail(btn.dataset.detail,btn)));
+    close.addEventListener('click',closeDetail);
+    overlay.addEventListener('click',event=>{if(event.target===overlay) closeDetail();});
+
+    document.addEventListener('keydown',event=>{
+      if(overlay.classList.contains('open')){
+        if(event.key==='Escape') closeDetail();
+        return;
+      }
+      if(['ArrowRight','PageDown',' '].includes(event.key)){
+        event.preventDefault(); move(1);
+      }else if(['ArrowLeft','PageUp'].includes(event.key)){
+        event.preventDefault(); move(-1);
+      }else if(event.key==='Home'){
+        event.preventDefault(); show(0);
+      }else if(event.key==='End'){
+        event.preventDefault(); show(slides.length-1);
+      }
+    });
+
+    document.addEventListener('touchstart',event=>{
+      touchStartX=event.changedTouches[0].clientX;
+    },{passive:true});
+    document.addEventListener('touchend',event=>{
+      if(touchStartX===null || overlay.classList.contains('open')) return;
+      const dx=event.changedTouches[0].clientX-touchStartX;
+      touchStartX=null;
+      if(Math.abs(dx)>70) move(dx<0?1:-1);
+    },{passive:true});
+
+    show(0);
+    window.RC_GUIDED_NOTES_PRESENTATION={
+      showSlide:show,
+      next:()=>move(1),
+      previous:()=>move(-1),
+      version:'1.0-classroom-resources'
+    };
+  }
+
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',init);
+  else init();
+})();

--- a/site/classroom-resources/guided-notes-binder-guide/index.html
+++ b/site/classroom-resources/guided-notes-binder-guide/index.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
+<meta name="theme-color" content="#030715"/>
+<title>Guided Notes & Binder Guide | ReinischClassroom</title>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-1.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-2.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-3.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-v5.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-v6.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-v6-1.css"/>
+<link rel="stylesheet" href="/classroom-resources/classroom-playbook/playbook-v6-2.css"/>
+<link rel="stylesheet" href="/classroom-resources/guided-notes-binder-guide/guided-notes.css"/>
+</head>
+<body>
+<div class="bar" id="progressBar" aria-hidden="true"></div>
+<main class="presentation" id="presentation" aria-live="polite">
+<section class="slide active hero" aria-label="Slide 1: Guided Notes & Binder Guide">
+  <div class="deck">
+    <div class="hero-stamp">All Classes<br/>2026–27</div>
+    <p class="kicker">Classroom resources • daily routine</p>
+    <h1>Guided Notes<br/><span>&amp; Binder Guide.</span></h1>
+    <div class="hero-rule"></div>
+    <p class="lead">Your Guided Notes are not busywork. They are the record of what we learned, the place you participate during the lesson, and the reference you use later when your memory tries to ghost you.</p>
+    <div class="chips"><span class="chip">Routine</span><span class="chip">Retention</span><span class="chip">Participation</span><span class="chip">Reference</span><span class="chip">Catch-up</span></div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 2: Why we use guided notes">
+  <div class="deck">
+    <p class="kicker">Start with the point</p>
+    <h2>We build the notes <span>now</span> so Future You has something useful later.</h2>
+    <div class="compare">
+      <div class="card bad"><span class="label">What we are not doing</span><h3>Copying random stuff to look busy</h3><p>That wastes time, burns attention, and usually disappears from your brain five minutes later.</p></div>
+      <div class="vs">VS.</div>
+      <div class="card good"><span class="label">What we are doing</span><h3>Building a working reference</h3><p>The key information is already organized so you can listen, think, participate, fill in the important parts, and use the finished notes later.</p></div>
+    </div>
+    <button class="topic" data-detail="why-guided" style="margin-top:18px;width:100%"><span class="label">Tap this</span><h3>Why this helps your brain</h3><p>Information retention + participation + something useful when class is over.</p></button>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 3: Start of class routine">
+  <div class="deck">
+    <p class="kicker">The opening routine</p>
+    <h2>When you come in, the goal is simple: <span>ready fast.</span></h2>
+    <div class="flow">
+      <div class="card"><span class="label">1</span><h3>Come in</h3><p>Enter, settle, and do not treat the first minute like a free-for-all.</p></div>
+      <div class="card"><span class="label">2</span><h3>Grab your binder</h3><p>Pick up the Guided Notes binder for that class right away.</p></div>
+      <div class="card"><span class="label">3</span><h3>Sit down</h3><p>Get in your seat while I take attendance.</p></div>
+      <div class="card"><span class="label">4</span><h3>Open to today’s notes</h3><p>By the time the lesson begins, your binder is open and ready.</p></div>
+      <div class="card"><span class="label">5</span><h3>Be with us</h3><p>Eyes up, binder open, and ready to follow the lesson.</p></div>
+    </div>
+    <div class="callout"><strong>Fast truth:</strong> this routine helps the room start cleaner, faster, and with fewer nonsense detours. <strong>The Guided Notes pages stay in the binder</strong> unless I specifically tell you otherwise.</div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 4: During the lesson">
+  <div class="deck">
+    <p class="kicker">While we are teaching</p>
+    <h2>Use the notes to <span>follow, fill, think, and ask.</span></h2>
+    <div class="four">
+      <button class="topic big" data-detail="follow-along"><div class="num">1</div><h3>Follow along</h3><p>Track the lesson instead of trying to write every word I say.</p></button>
+      <button class="topic big" data-detail="fill-the-gaps"><div class="num">2</div><h3>Fill the missing information</h3><p>Complete the required parts as we move through the presentation.</p></button>
+      <button class="topic big" data-detail="add-examples"><div class="num">3</div><h3>Add useful examples</h3><p>Extra reminders, examples, and clarifying notes help later.</p></button>
+      <button class="topic big" data-detail="ask-specific"><div class="num">4</div><h3>Ask specific questions</h3><p>If something does not make sense, say what part is unclear.</p></button>
+    </div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 5: Make them useful later">
+  <div class="deck">
+    <p class="kicker">After the lesson</p>
+    <h2>Completed Guided Notes become your <span>reference library.</span></h2>
+    <div class="three">
+      <div class="card"><span class="label">Keep them in order</span><h3>Leave the pages in the binder</h3><p>The Guided Notes stay in your binder. Keep them in order and turn to the page we are using that day.</p></div>
+      <div class="card"><span class="label">Use them again</span><h3>Assignments, review, corrections</h3><p>When you need to remember a skill, idea, or process, the notes should be the first place you check.</p></div>
+      <div class="card"><span class="label">Think ahead</span><h3>Future You will appreciate this</h3><p>We are building something you can actually use during practice, make-up work, and review.</p></div>
+    </div>
+    <div class="phrase-grid">
+      <div class="phrase">If it helps you remember later, write it now.</div>
+      <div class="phrase">Organized notes are a tool. Disorganized notes are wallpaper.</div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 6: Participation and retention">
+  <div class="deck">
+    <p class="kicker">Why this helps</p>
+    <h2>Guided Notes help with <span>participation</span> and <span>information retention.</span></h2>
+    <div class="five">
+      <div class="card"><span class="label">Participation</span><h3>You are doing something real</h3><p>Listening, tracking, writing, and thinking count as engagement.</p></div>
+      <div class="card"><span class="label">Attention</span><h3>They keep your brain in the room</h3><p>Having something structured to do makes it easier to stay with the lesson.</p></div>
+      <div class="card"><span class="label">Processing</span><h3>You do more than hear it once</h3><p>Seeing it, hearing it, and writing it improves the odds that it sticks.</p></div>
+      <div class="card"><span class="label">Memory</span><h3>You leave with a record</h3><p>Even if you do not remember everything, you still have the notes.</p></div>
+      <div class="card"><span class="label">Confidence</span><h3>You have somewhere to look</h3><p>That makes assignments and review less intimidating.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 7: If you miss class">
+  <div class="deck">
+    <p class="kicker">Catch-up plan</p>
+    <h2>If you were absent or missed part of class, <span>start here.</span></h2>
+    <div class="rule-list">
+      <div class="rule"><div class="step">1</div><p>Turn to the Guided Notes for the lesson you missed.</p><div class="arrow">→</div></div>
+      <div class="rule"><div class="step">2</div><p>Check ReinischClassroom or the class materials for the lesson/presentation.</p><div class="arrow">→</div></div>
+      <div class="rule"><div class="step">3</div><p>Complete what you can first — do not wait for a rescue mission.</p><div class="arrow">→</div></div>
+      <div class="rule"><div class="step">4</div><p>Ask a specific question about the part you still do not understand.</p><div class="arrow">→</div></div>
+      <div class="rule"><div class="step">5</div><p>Keep the completed notes in the binder so they are there when you need them again.</p><div class="arrow">✓</div></div>
+    </div>
+    <button class="topic" data-detail="absence-help" style="margin-top:18px;width:100%"><span class="label">Tap this</span><h3>What if I was gone and feel lost?</h3><p>There is a plan. Panic is not the plan.</p></button>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 8: Scenario lab">
+  <div class="deck">
+    <p class="kicker">Scenario lab</p>
+    <h2>What do you do if one of these happens?</h2>
+    <div class="scenario-grid">
+      <button class="topic" data-detail="forgot-binder"><span class="label">Situation</span><h3>I forgot my binder</h3><p>What is the move instead of pretending this is the end of civilization?</p></button>
+      <button class="topic" data-detail="missed-part"><span class="label">Situation</span><h3>I missed part of the lesson</h3><p>How do I catch the missing piece without restarting the entire planet?</p></button>
+      <button class="topic" data-detail="notes-done-still-lost"><span class="label">Situation</span><h3>I finished the notes but still do not get it</h3><p>Notes help, but they are not magic. What comes next?</p></button>
+      <button class="topic" data-detail="absent-yesterday"><span class="label">Situation</span><h3>I was absent yesterday</h3><p>Where do I begin so I am not one day behind for the rest of my natural life?</p></button>
+    </div>
+  </div>
+</section>
+
+<section class="slide" aria-label="Slide 9: Closing">
+  <div class="deck">
+    <p class="kicker">Bottom line</p>
+    <h2>Bring the binder. Open the notes. Build the record. <span>Use it later.</span></h2>
+    <p class="big-quote">Guided Notes work best when you treat them like a <em>tool</em>, not a decoration.</p>
+    <div class="two">
+      <div class="card good"><span class="label">What I need from you</span><h3>Be ready and participate</h3><p>Grab the binder, open it on time, complete the notes as we go, and use them when you need them.</p></div>
+      <div class="card good"><span class="label">What you get back</span><h3>A cleaner path through class</h3><p>Less guessing, better retention, stronger participation, and a reference you can actually use.</p></div>
+    </div>
+    <div class="callout"><strong>One-line summary:</strong> We build the notes together now so Future You has something useful later.</div>
+  </div>
+</section>
+</main>
+<div class="slide-counter" aria-live="polite"><strong id="current">1</strong> / <span id="total">9</span></div>
+<nav class="controls" aria-label="Presentation controls">
+  <button class="nav-btn" id="prevBtn" type="button" aria-label="Previous slide">← Back</button>
+  <button class="nav-btn" id="nextBtn" type="button" aria-label="Next slide">Next →</button>
+</nav>
+<div aria-hidden="true" class="overlay" id="overlay"><div aria-modal="true" class="modal" role="dialog" aria-labelledby="modalTitle"><button aria-label="Close" class="close" id="closeModal" type="button">×</button><div class="modal-kicker">Guided Notes & Binder Guide</div><h3 id="modalTitle">Example</h3><div class="body" id="modalBody"></div></div></div>
+<div id="guidedNotesTemplates" hidden>
+<template id="why-guided"><div data-title>Why Guided Notes help</div><div data-body>
+  <p>Guided Notes reduce the amount of random copying and increase the amount of <strong>actual thinking</strong>. That matters because your brain learns better when it has a structure to follow.</p>
+  <div class="best"><strong>Best move:</strong> Use the notes to follow the lesson, fill the important pieces, and add quick reminders that help you later.</div>
+  <div class="watch"><strong>Watch out:</strong> If you just scribble something so the paper is not blank, you will still have a page full of nonsense when it is time to use it.</div>
+</div></template>
+
+<template id="follow-along"><div data-title>Follow along</div><div data-body>
+  <p>You do not need to win a speed-writing contest. You do need to keep your place in the notes and track the lesson as it moves.</p>
+  <ul><li>Watch the slide or example being taught.</li><li>Find the matching place in the notes.</li><li>Stay with the current step instead of jumping ahead and guessing.</li></ul>
+</div></template>
+
+<template id="fill-the-gaps"><div data-title>Fill the missing information</div><div data-body>
+  <p>The blanks and missing parts are there on purpose. They help you stay active during the lesson instead of turning into a spectator.</p>
+  <div class="best"><strong>Best move:</strong> Fill in the required answer while it is being taught, not ten minutes later from memory roulette.</div>
+</div></template>
+
+<template id="add-examples"><div data-title>Add useful examples</div><div data-body>
+  <p>If I say something that helps clarify the idea, write it down. A short example or reminder can be the thing that makes the notes actually useful later.</p>
+  <ul><li>Add an example word, phrase, or step.</li><li>Circle or star something you know you forget easily.</li><li>Keep it brief and readable.</li></ul>
+</div></template>
+
+<template id="ask-specific"><div data-title>Ask specific questions</div><div data-body>
+  <p>“I don’t get it” tells me you are stuck. “I do not understand number 3” tells me where to help.</p>
+  <div class="best"><strong>Try this language:</strong> “I missed part of that.” “What goes in this blank?” “I understand the example, but not why it works.”</div>
+</div></template>
+
+<template id="absence-help"><div data-title>I was absent. Now what?</div><div data-body>
+  <p>Start with the materials first. Do not wait passively and become more lost than necessary.</p>
+  <ul><li>Turn to the notes for the lesson you missed.</li><li>Open ReinischClassroom or the lesson materials.</li><li>Complete what you can.</li><li>Ask one specific question when you hit the part that still does not make sense.</li></ul>
+  <div class="watch"><strong>Watch out:</strong> “I was absent” explains the problem. It is not the full plan for solving it.</div>
+</div></template>
+
+<template id="forgot-binder"><div data-title>I forgot my binder</div><div data-body>
+  <p>Do not turn it into a dramatic production. Get what you need, get situated, and join the lesson.</p>
+  <div class="best"><strong>Best move:</strong> Let me know quickly, get a temporary copy or solution, and still complete the Guided Notes for the day.</div>
+</div></template>
+
+<template id="missed-part"><div data-title>I missed part of the lesson</div><div data-body>
+  <p>You do not need to restart the whole world. Catch the missing part specifically.</p>
+  <div class="best"><strong>Say:</strong> “I missed what goes here.” “Can you repeat that example?” “Which word goes in this blank?”</div>
+</div></template>
+
+<template id="notes-done-still-lost"><div data-title>I finished the notes but still do not get it</div><div data-body>
+  <p>That happens sometimes. The notes are a tool, not a miracle.</p>
+  <ul><li>Check the example you wrote.</li><li>Ask what part still does not make sense.</li><li>Use the notes again during practice.</li></ul>
+  <div class="best"><strong>Remember:</strong> Completed notes plus a specific question is a much stronger combo than blank paper and confusion.</div>
+</div></template>
+
+<template id="absent-yesterday"><div data-title>I was absent yesterday</div><div data-body>
+  <p>Start with yesterday’s Guided Notes and materials before you try to jump straight into today.</p>
+  <div class="best"><strong>Fast path:</strong> Turn to the notes → open the lesson → complete what you can → ask for the missing piece → keep the completed notes in the binder.</div>
+</div></template>
+</div>
+<script defer src="/classroom-resources/guided-notes-binder-guide/guided-notes.js"></script>
+</body>
+</html>

--- a/site/classroom-resources/index.html
+++ b/site/classroom-resources/index.html
@@ -154,6 +154,22 @@
                 <span class="resource-meta">Presentation · All Classes · Expectations, routines, technology, help, and resets</span>
               </span>
             </a>
+
+            <a
+              class="resource-card"
+              href="/viewer/?src=%2Fclassroom-resources%2Fguided-notes-binder-guide%2F&return=%2Fclassroom-resources%2F&title=Guided+Notes+%26+Binder+Guide"
+              data-viewer-src="/classroom-resources/guided-notes-binder-guide/"
+              data-viewer-title="Guided Notes &amp; Binder Guide"
+              aria-label="Open Guided Notes and Binder Guide presentation"
+            >
+              <span class="resource-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M5 4h13a1 1 0 0 1 1 1v15H6a2 2 0 0 1-2-2V5a1 1 0 0 1 1-1z"></path><path d="M8 2v4"></path><path d="M12 2v4"></path><path d="M16 2v4"></path><path d="M8 10h7"></path><path d="M8 14h7"></path><path d="M8 18h5"></path></svg>
+              </span>
+              <span>
+                <span class="resource-title">Guided Notes &amp; Binder Guide</span>
+                <span class="resource-meta">Presentation · All Classes · Daily routine, participation, retention, reference, and catch-up</span>
+              </span>
+            </a>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
Adds the Guided Notes & Binder Guide as the second real Classroom Resources item.

### Adds
- Public route: `/classroom-resources/guided-notes-binder-guide/`
- 9-slide interactive presentation
- External JS for CSP-safe navigation, keyboard/swipe support, and tap-open examples
- Small Guided Notes accent stylesheet layered on the current Playbook visual system
- Classroom Resources card that launches through the canonical ReinischClassroom viewer

### Student routine captured
- Grab the binder when entering class
- Sit down while attendance is taken
- Have the binder open to the day’s Guided Notes before the lesson begins
- Complete notes during the lesson for participation and retention
- Keep all Guided Notes pages in the binder as a permanent course reference
- Use completed notes for assignments, review, corrections, and absence catch-up

### Scope guardrails
- No Teacher Center/auth/database/student-data changes
- No Classroom Playbook content changes
- No public-navigation changes
- No filler resources added