### PR TITLE
RC Goals: align objective item mapping with bigint IDs

### DIFF
--- a/supabase/migrations/20260823020500_assignment_item_objectives.sql
+++ b/supabase/migrations/20260823020500_assignment_item_objectives.sql
@@ -13,7 +13,7 @@ BEGIN;
 CREATE TABLE IF NOT EXISTS public.assignment_item_objectives (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  item_id uuid NOT NULL
+  item_id bigint NOT NULL
     REFERENCES public.assignment_items(id)
     ON DELETE CASCADE,
 
@@ -83,7 +83,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE
 -- If any insert fails, PostgreSQL rolls back the preceding DELETE from the
 -- same RPC call, preserving the previously valid mapping set.
 CREATE OR REPLACE FUNCTION public.replace_assignment_item_objectives(
-  p_item_id uuid,
+  p_item_id bigint,
   p_mappings jsonb DEFAULT '[]'::jsonb
 )
 RETURNS integer
@@ -136,19 +136,19 @@ END;
 $$;
 
 REVOKE ALL PRIVILEGES
-  ON FUNCTION public.replace_assignment_item_objectives(uuid, jsonb)
+  ON FUNCTION public.replace_assignment_item_objectives(bigint, jsonb)
   FROM PUBLIC;
 
 REVOKE ALL PRIVILEGES
-  ON FUNCTION public.replace_assignment_item_objectives(uuid, jsonb)
+  ON FUNCTION public.replace_assignment_item_objectives(bigint, jsonb)
   FROM anon;
 
 REVOKE ALL PRIVILEGES
-  ON FUNCTION public.replace_assignment_item_objectives(uuid, jsonb)
+  ON FUNCTION public.replace_assignment_item_objectives(bigint, jsonb)
   FROM authenticated;
 
 GRANT EXECUTE
-  ON FUNCTION public.replace_assignment_item_objectives(uuid, jsonb)
+  ON FUNCTION public.replace_assignment_item_objectives(bigint, jsonb)
   TO service_role;
 
 COMMIT;

--- a/tests/objective-item-mapping-contract.test.cjs
+++ b/tests/objective-item-mapping-contract.test.cjs
@@ -92,7 +92,7 @@ for (const column of REQUIRED_COLUMNS) {
 
 assert.match(
   migration,
-  /item_id[\s\S]*REFERENCES public\.assignment_items\s*\(\s*id\s*\)[\s\S]*ON DELETE CASCADE/i,
+  /item_id\s+bigint\s+NOT NULL[\s\S]*REFERENCES public\.assignment_items\s*\(\s*id\s*\)[\s\S]*ON DELETE CASCADE/i,
   'item objective mappings must cascade when their assignment item is deleted'
 );
 
@@ -124,6 +124,12 @@ assert.match(
   migration,
   /component_order\s+integer\s+NOT NULL/i,
   'component ordering must be deterministic'
+);
+
+assert.doesNotMatch(
+  migration,
+  /\bitem_id\s+uuid\b|\bp_item_id\s+uuid\b/i,
+  'assignment-item objective identity must never regress to UUID; production assignment_items.id is bigint'
 );
 
 /* -------------------------------------------------------------------------- */
@@ -166,7 +172,7 @@ assert.match(
 
 assert.match(
   migration,
-  /CREATE OR REPLACE FUNCTION public\.replace_assignment_item_objectives\s*\(\s*p_item_id\s+uuid\s*,\s*p_mappings\s+jsonb/i,
+  /CREATE OR REPLACE FUNCTION public\.replace_assignment_item_objectives\s*\(\s*p_item_id\s+bigint\s*,\s*p_mappings\s+jsonb/i,
   'atomic replacement RPC must exist'
 );
 
@@ -178,13 +184,13 @@ assert.match(
 
 assert.match(
   migration,
-  /ON FUNCTION public\.replace_assignment_item_objectives\s*\(\s*uuid\s*,\s*jsonb\s*\)[\s\S]*TO service_role/i,
+  /ON FUNCTION public\.replace_assignment_item_objectives\s*\(\s*bigint\s*,\s*jsonb\s*\)[\s\S]*TO service_role/i,
   'atomic replacement RPC must be executable by service_role'
 );
 
 assert.match(
   migration,
-  /ON FUNCTION public\.replace_assignment_item_objectives\s*\(\s*uuid\s*,\s*jsonb\s*\)[\s\S]*FROM authenticated/i,
+  /ON FUNCTION public\.replace_assignment_item_objectives\s*\(\s*bigint\s*,\s*jsonb\s*\)[\s\S]*FROM authenticated/i,
   'authenticated browser role must not execute the objective replacement RPC'
 );
 


### PR DESCRIPTION
## Slice 2.1 — production schema compatibility correction

### Goal

Align the dormant objective-item mapping migration with Reinisch Classroom's canonical production assignment-item identity.

Production and repository baseline use:

- `assignment_items.id bigint`
- `submission_answers.assignment_item_id bigint`
- `goal_data_points.item_id bigint`

Slice 2 originally declared the new objective mapping `item_id` and replacement RPC `p_item_id` as UUID. This PR corrects those unapplied definitions to `bigint`.

### Changes

- `assignment_item_objectives.item_id`: `uuid` → `bigint`
- `replace_assignment_item_objectives(p_item_id ...)`: `uuid` → `bigint`
- matching RPC privilege signatures: `uuid` → `bigint`
- contract tests now require bigint item identity and explicitly block regression to UUID

### Preserved behavior

- `[IG:]` remains the controlling parent/legal IEP goal mapping.
- `[IO:]` remains optional additive child-objective metadata.
- Existing parent-goal / DESE mappings are unchanged.
- No parser behavior changed.
- No assignment scoring changed.
- No progress/evidence tables changed.
- No objective scoring or roll-up was added.

### Local verification

Passed:

- goal-objective registry contract
- objective item-mapping contract
- objective mapping helper
- objective assignment identity
- objective TXT parser
- assignment/parser regressions
- teacher issuance regressions
- parent goal-progress provenance regressions
- `git diff --check`

### Activation status

This PR does **not** apply any Supabase migration.

The objective registry and item mapping foundation remain intentionally dormant until separately approved.
