### PR TITLE
Viewer: add Newline-safe Classroom Resources rendering

### DIFF
--- a/site/assets/css/viewer-display-compat.css
+++ b/site/assets/css/viewer-display-compat.css
@@ -1,0 +1,46 @@
+/* Classroom-display compatibility profile for embedded/touch browsers. */
+html.rc-display-safe .pv-bar {
+  background: linear-gradient(180deg, #172033 0%, #101827 100%) !important;
+  border-bottom: 1px solid rgba(255,255,255,.13) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  box-shadow: 0 1px 0 rgba(0,0,0,.45) !important;
+  isolation: isolate;
+}
+
+html.rc-display-safe .pv-traffic-lights,
+html.rc-display-safe .pv-title,
+html.rc-display-safe .pv-clock,
+html.rc-display-safe .viewer-btn-sidebar {
+  position: relative;
+  z-index: 2;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+html.rc-display-safe .pv-dot {
+  opacity: 1 !important;
+  visibility: visible !important;
+  filter: none !important;
+  transform: none !important;
+  transition: none !important;
+}
+
+html.rc-display-safe .pv-dot-red { background: #ff5f57 !important; }
+html.rc-display-safe .pv-dot-yellow { background: #ffbd2e !important; }
+html.rc-display-safe .pv-dot-green { background: #28c840 !important; }
+
+html.rc-display-safe .viewer-btn-sidebar {
+  background: #172033 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  transition: none !important;
+}
+
+html.rc-display-safe .viewer-frame {
+  background: #020611 !important;
+}
+
+html.rc-display-safe .viewer-iframe {
+  transition: none !important;
+}

--- a/site/assets/js/viewer-display-compat.js
+++ b/site/assets/js/viewer-display-compat.js
@@ -3,6 +3,8 @@
 
   const params = new URLSearchParams(window.location.search);
   const override = (params.get('render') || '').toLowerCase();
+  const requestedSrc = params.get('src') || '';
+  const classroomResource = requestedSrc.startsWith('/classroom-resources/');
   const ua = navigator.userAgent || '';
   const coarsePointer = window.matchMedia && (
     window.matchMedia('(pointer: coarse)').matches ||
@@ -21,6 +23,13 @@
 
   document.documentElement.classList.add('rc-display-safe');
   if (document.body) document.body.classList.add('rc-display-safe');
+
+  // Keep the viewer chrome reliable on classroom displays, but only inject the
+  // low-GPU presentation profile into Classroom Resources presentations.
+  if (!classroomResource) {
+    console.info('[viewer] Classroom display compatibility enabled for viewer chrome only');
+    return;
+  }
 
   const iframe = document.getElementById('contentIframe');
   if (!iframe) return;
@@ -77,6 +86,7 @@
     override: override || 'auto',
     android: embeddedAndroid,
     coarsePointer: Boolean(coarsePointer),
-    noHover: Boolean(noHover)
+    noHover: Boolean(noHover),
+    classroomResource: classroomResource
   });
 })();

--- a/site/assets/js/viewer-display-compat.js
+++ b/site/assets/js/viewer-display-compat.js
@@ -1,0 +1,82 @@
+(function () {
+  'use strict';
+
+  const params = new URLSearchParams(window.location.search);
+  const override = (params.get('render') || '').toLowerCase();
+  const ua = navigator.userAgent || '';
+  const coarsePointer = window.matchMedia && (
+    window.matchMedia('(pointer: coarse)').matches ||
+    window.matchMedia('(any-pointer: coarse)').matches
+  );
+  const noHover = window.matchMedia && window.matchMedia('(hover: none)').matches;
+  const embeddedAndroid = /Android/i.test(ua);
+
+  const safeMode = override === 'safe' ||
+    (override !== 'full' && (embeddedAndroid || (coarsePointer && noHover)));
+
+  if (!safeMode) {
+    document.documentElement.classList.add('rc-display-full');
+    return;
+  }
+
+  document.documentElement.classList.add('rc-display-safe');
+  if (document.body) document.body.classList.add('rc-display-safe');
+
+  const iframe = document.getElementById('contentIframe');
+  if (!iframe) return;
+
+  iframe.style.visibility = 'hidden';
+  iframe.style.opacity = '0';
+
+  let revealed = false;
+  function reveal() {
+    if (revealed) return;
+    revealed = true;
+    iframe.style.visibility = 'visible';
+    iframe.style.opacity = '1';
+  }
+
+  function applySafePresentationProfile() {
+    try {
+      const doc = iframe.contentDocument;
+      if (!doc || !doc.documentElement || !doc.head) {
+        reveal();
+        return;
+      }
+
+      doc.documentElement.classList.add('rc-display-safe');
+      if (doc.body) doc.body.classList.add('rc-display-safe');
+
+      if (doc.querySelector('link[data-rc-display-compat]')) {
+        reveal();
+        return;
+      }
+
+      const link = doc.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = '/classroom-resources/display-compat.css?v=20260824';
+      link.setAttribute('data-rc-display-compat', 'safe');
+      link.addEventListener('load', function () {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(reveal);
+        });
+      }, { once: true });
+      link.addEventListener('error', reveal, { once: true });
+      doc.head.appendChild(link);
+
+      window.setTimeout(reveal, 1800);
+    } catch (error) {
+      console.warn('[viewer] Display compatibility profile could not be injected:', error);
+      reveal();
+    }
+  }
+
+  iframe.addEventListener('load', applySafePresentationProfile, true);
+
+  console.info('[viewer] Classroom display compatibility mode enabled', {
+    override: override || 'auto',
+    android: embeddedAndroid,
+    coarsePointer: Boolean(coarsePointer),
+    noHover: Boolean(noHover)
+  });
+})();

--- a/site/classroom-resources/display-compat.css
+++ b/site/classroom-resources/display-compat.css
@@ -1,0 +1,142 @@
+/* ======================================================================
+   REINISCHCLASSROOM — CLASSROOM DISPLAY COMPATIBILITY PROFILE
+   Applied by the canonical viewer on embedded Android / touch displays.
+   Keeps the visual language while avoiding fragile GPU compositor effects.
+   ====================================================================== */
+
+html.rc-display-safe,
+html.rc-display-safe body {
+  background:
+    radial-gradient(ellipse at 4% 18%, rgba(45,196,205,.18), transparent 31%),
+    radial-gradient(ellipse at 96% 20%, rgba(149,101,221,.16), transparent 34%),
+    radial-gradient(ellipse at 52% 112%, rgba(55,104,177,.13), transparent 44%),
+    linear-gradient(132deg,#020611 0%,#06101f 43%,#081020 70%,#0b0918 100%) !important;
+}
+
+html.rc-display-safe *,
+html.rc-display-safe *::before,
+html.rc-display-safe *::after {
+  animation: none !important;
+  transition: none !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  mix-blend-mode: normal !important;
+}
+
+html.rc-display-safe body::before {
+  filter: none !important;
+  opacity: .10 !important;
+  background-image: radial-gradient(rgba(220,246,255,.42) .55px, transparent .75px) !important;
+  background-size: 24px 24px !important;
+}
+
+html.rc-display-safe body::after {
+  display: none !important;
+}
+
+html.rc-display-safe .v6-atmosphere,
+html.rc-display-safe .v6-progress-track {
+  display: none !important;
+}
+
+html.rc-display-safe .slide,
+html.rc-display-safe .slide.active,
+html.rc-display-safe .slide.motion-in {
+  animation: none !important;
+}
+
+html.rc-display-safe .deck {
+  border: 1px solid rgba(111,207,226,.34) !important;
+  background:
+    radial-gradient(circle at 2% 2%, rgba(53,183,193,.08), transparent 28%),
+    radial-gradient(circle at 98% 98%, rgba(137,104,203,.07), transparent 30%),
+    linear-gradient(151deg, rgba(10,28,51,.98), rgba(5,16,32,.985)) !important;
+  box-shadow:
+    0 26px 68px rgba(0,0,0,.52),
+    inset 0 1px 0 rgba(255,255,255,.12) !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .deck::after {
+  opacity: .28 !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .hero .deck {
+  box-shadow:
+    0 28px 74px rgba(0,0,0,.56),
+    inset 0 1px 0 rgba(255,255,255,.13) !important;
+}
+
+html.rc-display-safe .card,
+html.rc-display-safe .topic,
+html.rc-display-safe .course-btn,
+html.rc-display-safe .rule,
+html.rc-display-safe .phrase,
+html.rc-display-safe .chip,
+html.rc-display-safe .hero-stamp {
+  border-color: rgba(125,199,220,.24) !important;
+  background: linear-gradient(151deg, rgba(18,43,68,.94), rgba(7,24,45,.95)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.09),
+    0 10px 24px rgba(0,0,0,.22) !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .topic:hover,
+html.rc-display-safe .topic:focus-visible,
+html.rc-display-safe .course-btn:hover,
+html.rc-display-safe .course-btn:focus-visible {
+  transform: none !important;
+  border-color: rgba(92,218,222,.42) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.10), 0 10px 24px rgba(0,0,0,.24) !important;
+}
+
+html.rc-display-safe .overlay {
+  background: rgba(2,6,13,.94) !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .modal {
+  background: linear-gradient(151deg, rgba(12,29,51,.99), rgba(7,18,34,.995)) !important;
+  border: 1px solid rgba(126,204,222,.28) !important;
+  box-shadow: 0 28px 70px rgba(0,0,0,.60), inset 0 1px 0 rgba(255,255,255,.10) !important;
+  filter: none !important;
+}
+
+html.rc-display-safe h1,
+html.rc-display-safe h2,
+html.rc-display-safe h3,
+html.rc-display-safe .hero h1 span {
+  filter: none !important;
+  text-shadow: 0 2px 4px rgba(0,0,0,.30) !important;
+}
+
+html.rc-display-safe .bar {
+  box-shadow: none !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .controls,
+html.rc-display-safe .slide-counter {
+  filter: none !important;
+}
+
+html.rc-display-safe .nav-btn {
+  background: linear-gradient(180deg, #16233a, #0f1b30) !important;
+  box-shadow: 0 8px 18px rgba(0,0,0,.28) !important;
+  filter: none !important;
+}
+
+html.rc-display-safe .nav-btn:last-child {
+  background: linear-gradient(100deg, #238a9d 0%, #3473b7 52%, #7555a8 100%) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.rc-display-safe *,
+  html.rc-display-safe *::before,
+  html.rc-display-safe *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/site/viewer/index.html
+++ b/site/viewer/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/assets/css/rc-theme.css" />
   <link rel="stylesheet" href="/web/teacher-shell.css" />
   <link rel="stylesheet" href="/assets/css/viewer.css">
+  <link rel="stylesheet" href="/assets/css/viewer-display-compat.css?v=20260824">
   <link rel="stylesheet" href="/assets/css/class-clock.css">
   <link rel="stylesheet" href="/assets/css/class-mode.css" />
 </head>
@@ -62,6 +63,7 @@
   <script defer src="/web/student-shell.js"></script>
   <script defer src="/assets/js/class-clock.js" type="module"></script>
   <script defer src="/web/class-mode.js"></script>
+  <script src="/assets/js/viewer-display-compat.js?v=20260824"></script>
   <script src="/assets/js/viewer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds an automatic low-GPU compatibility path for Classroom Resources when the canonical viewer is running on embedded Android / touch-display environments such as the classroom Newline display.

### What changes
- Adds a viewer compatibility bootstrap that detects Android or coarse/no-hover classroom-display environments.
- Keeps the viewer chrome (including red/yellow/green traffic-light controls) on a simple non-blurred rendering path in safe mode.
- Keeps the Classroom Resources iframe hidden until the compatibility stylesheet is injected and loaded, avoiding a heavy first paint before fallback styling is active.
- Injects the low-GPU profile only for `/classroom-resources/` presentations so unrelated viewer content is not restyled.
- Adds URL overrides for QA: `render=safe` forces compatibility mode and `render=full` forces the normal rendering path.

### Safe presentation profile
The compatibility stylesheet preserves the dark navy / cyan / violet design language but disables or simplifies the compositor-heavy features most likely to cause intermittent paint loss on the Newline:
- no backdrop-filter layers
- no mix-blend-mode
- no ambient animation stack
- no animated panel sheen
- static localized gradients instead of large blurred moving auroras
- denser opaque glass panels/cards
- simpler shadows and controls

### Scope guardrails
- No Classroom Resources content changes
- No slide-count changes
- No Student Portal / Teacher Center / auth / database changes
- No changes to the four presentation source files themselves
- Desktop/full rendering path remains available