### PR TITLE
Fix Newline hidden-slide and viewer-shell races

### DIFF
--- a/site/assets/css/viewer-display-compat.css
+++ b/site/assets/css/viewer-display-compat.css
@@ -5,7 +5,7 @@ html.rc-display-safe .pv-bar {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   box-shadow: 0 1px 0 rgba(0,0,0,.45) !important;
-  isolation: isolate;
+  isolation: auto !important;
 }
 
 html.rc-display-safe .pv-traffic-lights,
@@ -43,4 +43,112 @@ html.rc-display-safe .viewer-frame {
 
 html.rc-display-safe .viewer-iframe {
   transition: none !important;
+}
+
+/* ----------------------------------------------------------------------
+   V2 FLAT VIEWER SHELL
+   Remove the collapsible sidebar from the classroom-display path entirely.
+   This prevents the viewer bar from being translated/clipped by shell state
+   changes while the Newline is opening and closing iframe content.
+   ---------------------------------------------------------------------- */
+html.rc-display-safe,
+html.rc-display-safe body,
+html.rc-display-safe .tc-app,
+html.rc-display-safe .tc-shell {
+  width: 100% !important;
+  height: 100% !important;
+  min-height: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+}
+
+html.rc-display-safe .tc-shell {
+  display: block !important;
+  position: relative !important;
+  transform: none !important;
+}
+
+html.rc-display-safe .tc-sidebar {
+  display: none !important;
+  width: 0 !important;
+  min-width: 0 !important;
+}
+
+html.rc-display-safe .tc-shell > div {
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  height: 100vh !important;
+  min-height: 100vh !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  transform: none !important;
+}
+
+html.rc-display-safe #viewerControls,
+html.rc-display-safe .pv-bar {
+  position: relative !important;
+  left: 0 !important;
+  right: 0 !important;
+  width: 100% !important;
+  min-width: 100% !important;
+  max-width: 100% !important;
+  margin: 0 !important;
+  transform: none !important;
+  overflow: visible !important;
+  contain: none !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  z-index: 20 !important;
+}
+
+html.rc-display-safe .pv-traffic-lights {
+  display: flex !important;
+  flex: 0 0 53px !important;
+  min-width: 53px !important;
+  width: 53px !important;
+  gap: 7px !important;
+  margin: 0 !important;
+  transform: none !important;
+  overflow: visible !important;
+}
+
+html.rc-display-safe .pv-dot {
+  display: block !important;
+  position: relative !important;
+  flex: 0 0 13px !important;
+  width: 13px !important;
+  height: 13px !important;
+  min-width: 13px !important;
+  min-height: 13px !important;
+  margin: 0 !important;
+  transform: none !important;
+  contain: none !important;
+  will-change: auto !important;
+}
+
+html.rc-display-safe .viewer-btn-sidebar {
+  display: none !important;
+}
+
+html.rc-display-safe .viewer-frame {
+  width: 100% !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  left: 0 !important;
+  transform: none !important;
+  contain: none !important;
+}
+
+html.rc-display-safe .viewer-iframe {
+  display: block !important;
+  width: 100% !important;
+  height: 100% !important;
+  margin: 0 !important;
+  transform: none !important;
+  contain: none !important;
+  will-change: auto !important;
 }

--- a/site/classroom-resources/display-compat.css
+++ b/site/classroom-resources/display-compat.css
@@ -132,6 +132,68 @@ html.rc-display-safe .nav-btn:last-child {
   background: linear-gradient(100deg, #238a9d 0%, #3473b7 52%, #7555a8 100%) !important;
 }
 
+/* ----------------------------------------------------------------------
+   V2 HARD-VISIBLE STATE
+   The base presentation system starts staggered entrance targets at opacity:0.
+   Disabling animation alone can strand those elements invisibly on embedded
+   Chromium. In classroom-display mode, active-slide content is fully painted
+   from the first frame and never depends on an animation completing.
+   ---------------------------------------------------------------------- */
+html.rc-display-safe .slide:not(.active) {
+  display: none !important;
+}
+
+html.rc-display-safe .slide.active {
+  display: flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  will-change: auto !important;
+}
+
+html.rc-display-safe .slide.active .deck,
+html.rc-display-safe .slide.active .deck * {
+  animation: none !important;
+  transition: none !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  filter: none !important;
+  will-change: auto !important;
+}
+
+html.rc-display-safe .slide.active .chips,
+html.rc-display-safe .slide.active .chip,
+html.rc-display-safe .slide.active .kicker,
+html.rc-display-safe .slide.active h1,
+html.rc-display-safe .slide.active h2,
+html.rc-display-safe .slide.active .lead,
+html.rc-display-safe .slide.active .big-quote,
+html.rc-display-safe .slide.active .hero-rule,
+html.rc-display-safe .slide.active .hero-stamp,
+html.rc-display-safe .slide.active .card,
+html.rc-display-safe .slide.active .topic,
+html.rc-display-safe .slide.active .course-btn,
+html.rc-display-safe .slide.active .rule,
+html.rc-display-safe .slide.active .phrase,
+html.rc-display-safe .slide.active .callout,
+html.rc-display-safe .slide.active .footer-line {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  animation: none !important;
+}
+
+html.rc-display-safe .overlay.open,
+html.rc-display-safe .overlay.open .modal,
+html.rc-display-safe .overlay.open .modal * {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  animation: none !important;
+  will-change: auto !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html.rc-display-safe *,
   html.rc-display-safe *::before,


### PR DESCRIPTION
## Summary
Second-pass Newline fix based directly on classroom photos from the embedded display.

The photos exposed two state/layout bugs that the first low-GPU pass did not fully neutralize:

1. Presentation entrance targets can begin at `opacity: 0` and depend on CSS animation completion to become visible. Disabling animation alone can strand random titles, chips, kickers, rules, and other content invisibly on embedded Chromium.
2. The canonical viewer bar can still be shifted/clipped by the collapsible Teacher Shell state, which explains why the red/yellow/green traffic-light controls sometimes all appear, sometimes partly appear, and sometimes vanish.

### Fix
- In display-safe mode, the active slide and all content inside its deck are forced to a fully painted state from frame one: `opacity:1`, `visibility:visible`, `transform:none`, no animation/transition/filter/will-change dependency.
- Modal content receives the same hard-visible treatment while open.
- Non-active slides remain hidden normally.
- The display-safe viewer shell is flattened: the sidebar is removed from layout, the content column is forced to full-screen width, and the viewer control bar is pinned to a stable 100% layout.
- Traffic-light controls receive fixed dimensions/flex behavior and cannot be clipped by sidebar-collapse transitions.
- The sidebar-toggle control is hidden in display-safe mode because the sidebar itself is intentionally absent there.

### Scope
- 2 CSS files only
- No presentation content changes
- No slide-count changes
- No JS changes
- No Student Portal, Teacher Center, auth, database, or assignment behavior changes
- Desktop/full rendering path unchanged