### PR TITLE
Bust Newline compatibility asset cache

### DIFF
--- a/site/assets/js/viewer-display-compat.js
+++ b/site/assets/js/viewer-display-compat.js
@@ -63,7 +63,7 @@
 
       const link = doc.createElement('link');
       link.rel = 'stylesheet';
-      link.href = '/classroom-resources/display-compat.css?v=20260824';
+      link.href = '/classroom-resources/display-compat.css?v=20260824-2';
       link.setAttribute('data-rc-display-compat', 'safe');
       link.addEventListener('load', function () {
         requestAnimationFrame(function () {

--- a/site/viewer/index.html
+++ b/site/viewer/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/assets/css/rc-theme.css" />
   <link rel="stylesheet" href="/web/teacher-shell.css" />
   <link rel="stylesheet" href="/assets/css/viewer.css">
-  <link rel="stylesheet" href="/assets/css/viewer-display-compat.css?v=20260824">
+  <link rel="stylesheet" href="/assets/css/viewer-display-compat.css?v=20260824-2">
   <link rel="stylesheet" href="/assets/css/class-clock.css">
   <link rel="stylesheet" href="/assets/css/class-mode.css" />
 </head>
@@ -63,7 +63,7 @@
   <script defer src="/web/student-shell.js"></script>
   <script defer src="/assets/js/class-clock.js" type="module"></script>
   <script defer src="/web/class-mode.js"></script>
-  <script src="/assets/js/viewer-display-compat.js?v=20260824"></script>
+  <script src="/assets/js/viewer-display-compat.js?v=20260824-2"></script>
   <script src="/assets/js/viewer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Tiny follow-up to the Newline hard-visible fix.

The embedded Chrome display may retain the first compatibility assets because the cache-busting query string did not change between the first and second fixes. This bumps all Newline compatibility asset versions from `20260824` to `20260824-2` so the classroom display is guaranteed to request the new hard-visible CSS and flattened viewer-shell rules.

### Scope
- 2 files
- 4 changed lines in each file total
- No visual/content behavior changes beyond forcing fresh compatibility assets
- No presentation content, slide count, auth, database, portal, or Teacher Center changes