### PR TITLE
Remove iframe from Newline Classroom Display source path

### DIFF
--- a/site/classroom-resources/tv-player/index.html
+++ b/site/classroom-resources/tv-player/index.html
@@ -25,7 +25,6 @@
     <div></div>
   </footer>
 </div>
-<iframe class="tv-source-frame" id="sourceFrame" title="Presentation source" sandbox="allow-scripts allow-same-origin"></iframe>
 <div class="tv-overlay" id="tvOverlay" hidden>
   <div class="tv-modal" role="dialog" aria-modal="true" aria-labelledby="tvModalTitle">
     <button class="tv-modal-close" id="tvModalClose" type="button" aria-label="Close example">×</button>
@@ -34,6 +33,6 @@
     <div id="tvModalBody"></div>
   </div>
 </div>
-<script src="/classroom-resources/tv-player/tv-player.js?v=20260824-1"></script>
+<script src="/classroom-resources/tv-player/tv-player.js?v=20260824-2"></script>
 </body>
 </html>

--- a/site/classroom-resources/tv-player/tv-player.js
+++ b/site/classroom-resources/tv-player/tv-player.js
@@ -9,7 +9,6 @@
     !src.startsWith('/classroom-resources/tv-player');
 
   const app = document.getElementById('tvApp');
-  const sourceFrame = document.getElementById('sourceFrame');
   const slideHost = document.getElementById('slideHost');
   const titleEl = document.getElementById('tvTitle');
   const countEl = document.getElementById('tvCount');
@@ -28,7 +27,6 @@
   let sourceDoc = null;
   let slides = [];
   let index = 0;
-  let loadTimer = null;
 
   function closePlayer() {
     window.location.href = '/classroom-resources/';
@@ -56,9 +54,42 @@
     statusEl.hidden = !message;
   }
 
+  async function fetchText(url) {
+    const response = await fetch(url, { cache: 'no-store', credentials: 'same-origin' });
+    if (!response.ok) throw new Error(url + ' returned ' + response.status);
+    return response.text();
+  }
+
+  function parseDocument(html) {
+    return new DOMParser().parseFromString(html, 'text/html');
+  }
+
+  async function loadPlaybookDocument() {
+    const base = '/classroom-resources/classroom-playbook/';
+    const slideParts = ['slides-1.html', 'slides-2.html', 'slides-3.html'];
+    const exampleParts = ['examples-1.html', 'examples-2.html', 'examples-3.html'];
+    const [slideHtml, exampleHtml] = await Promise.all([
+      Promise.all(slideParts.map(function (name) { return fetchText(base + name); })),
+      Promise.all(exampleParts.map(function (name) { return fetchText(base + name); }))
+    ]);
+
+    const doc = document.implementation.createHTMLDocument('The Classroom Playbook');
+    doc.body.innerHTML = '<main id="tvSourceSlides">' + slideHtml.join('\n') + '</main>' +
+      '<div id="tvSourceTemplates">' + exampleHtml.join('\n') + '</div>';
+    return doc;
+  }
+
+  async function loadSourceDocument() {
+    if (src.startsWith('/classroom-resources/classroom-playbook/')) {
+      return loadPlaybookDocument();
+    }
+    const html = await fetchText(src);
+    return parseDocument(html);
+  }
+
   function cleanClone(node) {
     const clone = node.cloneNode(true);
-    const all = [clone, ...clone.querySelectorAll('*')];
+    const all = [clone].concat(Array.from(clone.querySelectorAll('*')));
     all.forEach(function (el) {
       el.removeAttribute('style');
       el.removeAttribute('id');
@@ -67,7 +98,7 @@
       el.removeAttribute('tabindex');
       if (el.classList) el.classList.remove('active', 'motion-in');
     });
-    clone.querySelectorAll('script,style,link,iframe').forEach(function (el) { el.remove(); });
+    clone.querySelectorAll('script,style,link,iframe,video,audio,canvas').forEach(function (el) { el.remove(); });
     return clone;
   }
 
@@ -78,7 +109,7 @@
     const clone = cleanClone(deck);
 
     slideHost.replaceChildren(clone);
-    titleEl.textContent = requestedTitle || sourceDoc.title || 'Classroom Resource';
+    titleEl.textContent = requestedTitle || (sourceDoc && sourceDoc.title) || 'Classroom Resource';
     countEl.textContent = (index + 1) + ' / ' + slides.length;
     prevBtn.disabled = index === 0;
     nextBtn.disabled = index === slides.length - 1;
@@ -121,45 +152,29 @@
     modalBody.innerHTML = '';
   }
 
-  function findSlides() {
-    try {
-      sourceDoc = sourceFrame.contentDocument;
-      if (!sourceDoc) return false;
-      slides = Array.from(sourceDoc.querySelectorAll('section.slide'));
-      if (!slides.length) slides = Array.from(sourceDoc.querySelectorAll('.slide'));
-      return slides.length > 0;
-    } catch (error) {
-      return false;
-    }
-  }
-
-  function finishLoad() {
-    if (!findSlides()) return false;
-    window.clearTimeout(loadTimer);
-    sourceFrame.setAttribute('aria-hidden', 'true');
-    setStatus('');
-    app.classList.add('ready');
-    renderSlide();
-    return true;
-  }
-
-  function pollForSlides(attempt) {
-    if (finishLoad()) return;
-    if (attempt >= 30) {
-      setStatus('This presentation could not be prepared for Classroom Display mode.', true);
+  async function init() {
+    if (!allowed) {
+      setStatus('Classroom Display mode received an invalid presentation source.', true);
       return;
     }
-    loadTimer = window.setTimeout(function () { pollForSlides(attempt + 1); }, 100);
-  }
 
-  if (!allowed) {
-    setStatus('Classroom Display mode received an invalid presentation source.', true);
-    return;
-  }
+    titleEl.textContent = requestedTitle;
+    setStatus('Preparing presentation…');
 
-  titleEl.textContent = requestedTitle;
-  sourceFrame.addEventListener('load', function () { pollForSlides(0); }, { once: true });
-  sourceFrame.src = src;
+    try {
+      sourceDoc = await loadSourceDocument();
+      slides = Array.from(sourceDoc.querySelectorAll('section.slide'));
+      if (!slides.length) slides = Array.from(sourceDoc.querySelectorAll('.slide'));
+      if (!slides.length) throw new Error('No slides found in source');
+
+      setStatus('');
+      app.classList.add('ready');
+      renderSlide();
+    } catch (error) {
+      console.error('[Classroom Display] Could not prepare presentation:', error);
+      setStatus('This presentation could not be prepared for Classroom Display mode. Refresh Classroom Resources and try again.', true);
+    }
+  }
 
   prevBtn.addEventListener('click', function () { move(-1); });
   nextBtn.addEventListener('click', function () { move(1); });
@@ -198,4 +213,6 @@
     touchX = null;
     if (Math.abs(dx) > 90) move(dx < 0 ? 1 : -1);
   }, { passive: true });
+
+  init();
 })();


### PR DESCRIPTION
## Summary
Hardens the new Classroom Display renderer one step further based on the Newline's prior repaint failures.

### Change
- Removes the hidden 1x1 source iframe from the Classroom Display player entirely.
- Guided Notes, Student Quick Start, and Missed Class are fetched as same-origin HTML text and parsed with DOMParser.
- The Classroom Playbook loads the same three canonical slide fragments and three canonical example fragments its desktop presentation uses.
- The TV renderer therefore runs **no original presentation page, CSS, or JavaScript at all**.
- Slide text/cards/examples remain sourced from the current canonical presentation files; there is no duplicated instructional content.

### Why
The Newline has already shown unreliable repaint behavior even when a complex iframe is hidden/offscreen. This removes the iframe/compositor dependency from the Classroom Display path completely.

### Scope
- 2 TV-player files only
- No changes to the four presentation source files
- No slide-count/content changes
- No Student Portal, Teacher Center, auth, database, or assignment changes
- Desktop/full presentation path unchanged