### PR TITLE
Add student Word Search activities access

### DIFF
--- a/site/assets/css/viewer-display-compat.css
+++ b/site/assets/css/viewer-display-compat.css
@@ -9,6 +9,7 @@ html.rc-display-safe .pv-bar {
 }
 
 html.rc-display-safe .pv-traffic-lights,
+html.rc-display-safe .viewer-exit-activity,
 html.rc-display-safe .pv-title,
 html.rc-display-safe .pv-clock,
 html.rc-display-safe .viewer-btn-sidebar {
@@ -29,6 +30,12 @@ html.rc-display-safe .pv-dot {
 html.rc-display-safe .pv-dot-red { background: #ff5f57 !important; }
 html.rc-display-safe .pv-dot-yellow { background: #ffbd2e !important; }
 html.rc-display-safe .pv-dot-green { background: #28c840 !important; }
+
+html.rc-display-safe .viewer-exit-activity {
+  background: #172033 !important;
+  border-color: rgba(255,255,255,.22) !important;
+  transition: none !important;
+}
 
 html.rc-display-safe .viewer-btn-sidebar {
   background: #172033 !important;

--- a/site/assets/css/viewer.css
+++ b/site/assets/css/viewer.css
@@ -79,6 +79,28 @@ body {
 .pv-dot-yellow { background: #ffbd2e; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3); }
 .pv-dot-green  { background: #28c840; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.3); }
 
+.viewer-exit-activity {
+  min-height: 44px;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--rc-border-strong, rgba(255, 255, 255, 0.14));
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--rc-ink, #e8f1ec);
+  font: 700 14px/1 var(--rc-font, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif);
+  white-space: nowrap;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.viewer-exit-activity:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.viewer-exit-activity:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.5);
+  outline-offset: 2px;
+}
+
 .pv-title {
   font-size: 12px;
   color: var(--rc-ink-dim, #a9bbb1);

--- a/site/assets/js/viewer.js
+++ b/site/assets/js/viewer.js
@@ -9,6 +9,7 @@
   // Elements
   const iframe = document.getElementById('contentIframe');
   const closeBtn = document.getElementById('closeBtn');
+  const exitActivityBtn = document.getElementById('exitActivityBtn');
   const presentationModeBtn = document.getElementById('presentationModeBtn');
   const fullscreenBtn = document.getElementById('fullscreenBtn');
   const sidebarToggleBtn = document.getElementById('sidebarToggleBtn');
@@ -57,6 +58,23 @@
     const params = new URLSearchParams(window.location.search);
     let src = params.get('src');
     returnUrl = params.get('return');
+
+    // Activities and Word Search get a large touch-friendly exit.
+    // Word Search receives it even when opened from the teacher/toolkit
+    // route so classroom displays are never trapped in the activity.
+    const isActivity =
+      params.get('activity') === '1';
+
+    const isWordSearch =
+      src &&
+      src.startsWith(
+        '/presentations/language-arts-toolkit/presentation-03/'
+      );
+
+    if (exitActivityBtn) {
+      exitActivityBtn.hidden =
+        !(isActivity || isWordSearch);
+    }
 
     if (!src) {
       showError('No content source provided', 'Please provide a src parameter in the URL.');
@@ -170,6 +188,11 @@
 
     // Close button
     closeBtn.addEventListener('click', handleClose);
+
+    // Large touch-friendly activity exit control
+    if (exitActivityBtn) {
+      exitActivityBtn.addEventListener('click', handleClose);
+    }
 
     // Presentation mode button
     presentationModeBtn.addEventListener('click', togglePresentationMode);

--- a/site/presentations/language-arts-toolkit/presentation-03/index.html
+++ b/site/presentations/language-arts-toolkit/presentation-03/index.html
@@ -5,7 +5,7 @@
   <title>Word Search</title>
   <link rel="stylesheet" href="/assets/css/rc-theme.css"/>
   <script src="/assets/js/section-nav.js" defer></script>
-    <meta http-equiv="refresh" content="0; url=wordsearch_optimized_classroom (1).html"/>
+    <meta http-equiv="refresh" content="0; url=/presentations/language-arts-toolkit/presentation-03/wordsearch_optimized_classroom%20(1).html"/>
   </head>
   <body>
     

--- a/site/presentations/language-arts-toolkit/presentation-03/wordsearch_optimized_classroom (1).html
+++ b/site/presentations/language-arts-toolkit/presentation-03/wordsearch_optimized_classroom (1).html
@@ -585,7 +585,7 @@ body {
     <div class="puzzle-hero window">
       <div class="compact-top">
         <div class="nav-group">
-          <button id="homeBtn" class="btn secondary" type="button">← Back</button>
+          <button id="homeBtn" class="btn secondary" type="button">← All Themes</button>
           <button id="prevBtn" class="btn secondary" type="button">← Previous</button>
           <button id="nextBtn" class="btn secondary" type="button">Next →</button>
         </div>

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6808,6 +6808,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=202608251228"></script>
+    <script defer src="/web/student-portal-init.js?v=20260826"></script>
   </body>
 </html>

--- a/site/student/index.html
+++ b/site/student/index.html
@@ -4304,6 +4304,64 @@
         color: #93c5fd;
       }
 
+      /* Activities */
+      .st-activity-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 360px));
+        gap: 18px;
+      }
+
+      .st-activity-card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        min-height: 190px;
+        padding: 22px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.045);
+        color: inherit;
+        text-decoration: none;
+        transition:
+          transform 0.15s ease,
+          border-color 0.15s ease,
+          background 0.15s ease;
+      }
+
+      .st-activity-card:hover,
+      .st-activity-card:focus-visible {
+        transform: translateY(-2px);
+        border-color: rgba(96, 165, 250, 0.55);
+        background: rgba(96, 165, 250, 0.09);
+      }
+
+      .st-activity-card:focus-visible {
+        outline: 3px solid rgba(96, 165, 250, 0.38);
+        outline-offset: 3px;
+      }
+
+      .st-activity-card__icon {
+        font-size: 38px;
+        line-height: 1;
+      }
+
+      .st-activity-card__title {
+        margin: 0;
+        font-size: 22px;
+      }
+
+      .st-activity-card__description {
+        margin: 0;
+        opacity: 0.78;
+        line-height: 1.5;
+      }
+
+      .st-activity-card__open {
+        margin-top: auto;
+        font-weight: 700;
+        color: #93c5fd;
+      }
+
       /* Tab System */
       .st-tab-nav {
         display: flex;
@@ -6377,6 +6435,7 @@
             <a href="#" data-tab="assignments"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg></span><span class="tc-label">Assignments</span></a>
             <a href="#" data-tab="library"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path></svg></span><span class="tc-label">Library</span></a>
             <a href="#" data-tab="resources"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg></span><span class="tc-label">Resources</span></a>
+            <a href="#" data-tab="activities"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><polygon points="10 8 16 12 10 16 10 8"></polygon></svg></span><span class="tc-label">Activities</span></a>
             <a href="#" data-tab="grades"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg></span><span class="tc-label">Grades</span></a>
             <a href="#" data-tab="goals"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="6"></circle><circle cx="12" cy="12" r="2"></circle></svg></span><span class="tc-label">Goals</span></a>
             <a href="#" data-tab="settings"><span class="tc-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg></span><span class="tc-label">Settings</span></a>
@@ -6483,6 +6542,7 @@
               <button class="st-tab-link" data-tab="assignments"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg> Assignments</button>
               <button class="st-tab-link" data-tab="library"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"></path><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"></path></svg> Library</button>
               <button class="st-tab-link" data-tab="resources"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg> Resources</button>
+              <button class="st-tab-link" data-tab="activities"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><polygon points="10 8 16 12 10 16 10 8"></polygon></svg> Activities</button>
               <button class="st-tab-link" data-tab="grades"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"></line><line x1="12" y1="20" x2="12" y2="4"></line><line x1="6" y1="20" x2="6" y2="14"></line></svg> Grades</button>
               <button class="st-tab-link" data-tab="goals"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="6"></circle><circle cx="12" cy="12" r="2"></circle></svg> Goals</button>
               <button class="st-tab-link" data-tab="settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg> Settings</button>
@@ -6652,6 +6712,37 @@
                 </h1>
                 <p style="opacity:0.8; margin-bottom:24px;">Learning tools, presentations, guided notes, and reference materials</p>
                 <div id="resourcesContent"><p style="opacity:0.7;">Loading resources...</p></div>
+              </div>
+            </div>
+
+            <!-- Tab: Activities -->
+            <div id="tabActivities" class="st-tab-panel">
+              <div class="st-dashboard-content">
+                <h1 style="margin-top:0;">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="display:inline-block;vertical-align:middle;margin-right:10px;">
+                    <circle cx="12" cy="12" r="9"></circle>
+                    <polygon points="10 8 16 12 10 16 10 8"></polygon>
+                  </svg>
+                  Activities
+                </h1>
+
+                <p style="opacity:0.8; margin-bottom:24px;">
+                  Optional classroom activities for practice, focus, and a little fun.
+                </p>
+
+                <div class="st-activity-grid">
+                  <a
+                    class="st-activity-card"
+                    href="/viewer/?src=%2Fpresentations%2Flanguage-arts-toolkit%2Fpresentation-03%2F&amp;return=%2Fstudent%2F%3Ftab%3Dactivities&amp;title=Word%20Search&amp;activity=1"
+                  >
+                    <div class="st-activity-card__icon" aria-hidden="true">🔎</div>
+                    <h2 class="st-activity-card__title">Word Search</h2>
+                    <p class="st-activity-card__description">
+                      Choose from 30 themes and hunt for hidden words. Works with a mouse, touchscreen, or Chromebook.
+                    </p>
+                    <span class="st-activity-card__open">Open Word Search →</span>
+                  </a>
+                </div>
               </div>
             </div>
 

--- a/site/viewer/index.html
+++ b/site/viewer/index.html
@@ -37,6 +37,12 @@
             <button class="pv-dot pv-dot-yellow" id="presentationModeBtn" title="Presentation Mode" aria-label="Toggle presentation mode"></button>
             <button class="pv-dot pv-dot-green"  id="fullscreenBtn"       title="Full Screen"       aria-label="Toggle fullscreen"></button>
           </div>
+          <button
+            class="viewer-exit-activity"
+            id="exitActivityBtn"
+            type="button"
+            hidden
+          >← Exit Activity</button>
           <div class="pv-title" id="viewerTitle"></div>
           <div class="pv-clock" id="viewerClock"></div>
           <button class="viewer-btn-sidebar" id="sidebarToggleBtn" aria-label="Toggle sidebar">

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -5643,6 +5643,15 @@
       // Setup tab switching
       setupTabSwitching();
 
+      // Honor an explicit requested tab, such as a Viewer return
+      // to Student Portal Activities.
+      const requestedTab =
+        new URLSearchParams(window.location.search).get('tab');
+
+      if (requestedTab) {
+        switchToTab(requestedTab);
+      }
+
       // Setup student settings (change password)
       initStudentSettings();
       
@@ -5697,6 +5706,7 @@
       'assignments': 'tabAssignments',
       'library': 'tabLibrary',
       'resources': 'tabResources',
+      'activities': 'tabActivities',
       'grades': 'tabGrades',
       'settings': 'tabSettings'
     };

--- a/tests/student-activities-word-search-contract.test.cjs
+++ b/tests/student-activities-word-search-contract.test.cjs
@@ -1,0 +1,147 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+function read(rel) {
+  return fs.readFileSync(
+    path.join(root, rel),
+    'utf8'
+  );
+}
+
+const studentHtml =
+  read('site/student/index.html');
+
+const studentJs =
+  read('site/web/student-portal-init.js');
+
+const viewerHtml =
+  read('site/viewer/index.html');
+
+const viewerJs =
+  read('site/assets/js/viewer.js');
+
+const viewerCss =
+  read('site/assets/css/viewer.css');
+
+const viewerCompat =
+  read('site/assets/css/viewer-display-compat.css');
+
+const wordSearch =
+  read(
+    'site/presentations/language-arts-toolkit/presentation-03/wordsearch_optimized_classroom (1).html'
+  );
+
+test(
+  'Student Portal exposes Activities in both navigation surfaces',
+  () => {
+    const tabs =
+      studentHtml.match(
+        /data-tab="activities"/g
+      ) || [];
+
+    assert.equal(tabs.length, 2);
+    assert.match(
+      studentHtml,
+      /id="tabActivities"/
+    );
+  }
+);
+
+test(
+  'Activities launches Word Search through Viewer with explicit return',
+  () => {
+    assert.match(
+      studentHtml,
+      /src=%2Fpresentations%2Flanguage-arts-toolkit%2Fpresentation-03%2F/
+    );
+
+    assert.match(
+      studentHtml,
+      /return=%2Fstudent%2F%3Ftab%3Dactivities/
+    );
+
+    assert.match(
+      studentHtml,
+      /activity=1/
+    );
+  }
+);
+
+test(
+  'Student Portal restores Activities from tab query parameter',
+  () => {
+    assert.match(
+      studentJs,
+      /'activities': 'tabActivities'/
+    );
+
+    assert.match(
+      studentJs,
+      /new URLSearchParams\(window\.location\.search\)\.get\('tab'\)/
+    );
+
+    assert.match(
+      studentJs,
+      /switchToTab\(requestedTab\)/
+    );
+  }
+);
+
+test(
+  'Viewer exposes a touch-friendly activity exit',
+  () => {
+    assert.match(
+      viewerHtml,
+      /id="exitActivityBtn"/
+    );
+
+    assert.match(
+      viewerHtml,
+      /← Exit Activity/
+    );
+
+    assert.match(
+      viewerJs,
+      /params\.get\('activity'\) === '1'/
+    );
+
+    assert.match(
+      viewerJs,
+      /language-arts-toolkit\/presentation-03/
+    );
+
+    assert.match(
+      viewerJs,
+      /exitActivityBtn\.addEventListener\('click', handleClose\)/
+    );
+
+    assert.match(
+      viewerCss,
+      /\.viewer-exit-activity\s*\{/
+    );
+
+    assert.match(
+      viewerCss,
+      /min-height:\s*44px/
+    );
+
+    assert.match(
+      viewerCompat,
+      /rc-display-safe \.viewer-exit-activity/
+    );
+  }
+);
+
+test(
+  'Word Search puzzle navigation clearly returns to theme list',
+  () => {
+    assert.match(
+      wordSearch,
+      /id="homeBtn"[^>]*>← All Themes<\/button>/
+    );
+  }
+);

--- a/tests/student-activities-word-search.spec.js
+++ b/tests/student-activities-word-search.spec.js
@@ -1,0 +1,227 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Student Activities / Word Search browser verification.
+ *
+ * Scope:
+ * - same-tab synthetic student session only
+ * - no real student data
+ * - no production APIs
+ * - no Supabase writes
+ * - static local browser server only
+ */
+
+async function makeFunctionCallsHarmless(page) {
+  await page.route('**/.netlify/functions/**', async route => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: false,
+        error: 'Synthetic browser test: server function unavailable'
+      })
+    });
+  });
+}
+
+async function seedSyntheticStudentSession(page) {
+  // Seed once in this browser tab/origin.
+  // We intentionally do NOT use addInitScript so that the test verifies
+  // sessionStorage survives the Viewer round trip naturally.
+  await page.goto('/');
+  await page.evaluate(() => {
+    sessionStorage.setItem('rc_user_role', 'student');
+    sessionStorage.setItem('rc_user_code', 'S010');
+  });
+}
+
+test.describe('Student Activities / Word Search', () => {
+  test('student can open Word Search, use All Themes, and exit back to Activities', async ({ page }) => {
+    await makeFunctionCallsHarmless(page);
+    await seedSyntheticStudentSession(page);
+
+    await page.goto('/student/?tab=activities');
+
+    await expect(
+      page.locator('#studentDashboardView')
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page.locator('#loginView')
+    ).toBeHidden();
+
+    await expect(
+      page.locator('#tabActivities')
+    ).toBeVisible();
+
+    await expect(
+      page.locator('[data-tab="activities"].active')
+    ).toHaveCount(2);
+
+    // Open the student-facing Word Search activity.
+    await page
+      .locator('#tabActivities .st-activity-card')
+      .click();
+
+    await expect(page).toHaveURL(
+      /\/viewer\/\?.*activity=1/
+    );
+
+    const exitActivity =
+      page.locator('#exitActivityBtn');
+
+    await expect(exitActivity).toBeVisible();
+
+    // Word Search is inside the existing Viewer iframe.
+    const wordSearch =
+      page.frameLocator('#contentIframe');
+
+    const firstTheme =
+      wordSearch.locator('.theme-card').first();
+
+    await expect(firstTheme).toBeVisible({
+      timeout: 10000
+    });
+
+    // Enter a puzzle.
+    await firstTheme.click();
+
+    const allThemes =
+      wordSearch.getByRole('button', {
+        name: '← All Themes'
+      });
+
+    await expect(allThemes).toBeVisible();
+
+    // Internal navigation should return to the 30-theme home view.
+    await allThemes.click();
+
+    await expect(
+      wordSearch.locator('#homeView')
+    ).toHaveClass(/active/);
+
+    await expect(
+      wordSearch.locator('.theme-card').first()
+    ).toBeVisible();
+
+    // Simulate the Viewer compatibility state used by classroom displays.
+    await page.evaluate(() => {
+      document.documentElement.classList.add(
+        'rc-display-safe'
+      );
+    });
+
+    // The sidebar is intentionally unavailable in display-safe mode...
+    await expect(
+      page.locator('.tc-sidebar')
+    ).toBeHidden();
+
+    // ...but the new activity exit must remain obvious and usable.
+    await expect(exitActivity).toBeVisible();
+
+    const exitBox =
+      await exitActivity.boundingBox();
+
+    expect(exitBox).not.toBeNull();
+    expect(exitBox.height).toBeGreaterThanOrEqual(44);
+
+    // Exit the activity.
+    await exitActivity.click();
+
+    await expect(page).toHaveURL(
+      /\/student\/\?tab=activities$/
+    );
+
+    // Student should return directly to Activities without being logged out.
+    await expect(
+      page.locator('#studentDashboardView')
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page.locator('#loginView')
+    ).toBeHidden();
+
+    await expect(
+      page.locator('#tabActivities')
+    ).toBeVisible();
+
+    await expect(
+      page.locator('[data-tab="activities"].active')
+    ).toHaveCount(2);
+
+    // Prove the same-tab student session survived Viewer navigation.
+    const session = await page.evaluate(() => ({
+      role: sessionStorage.getItem('rc_user_role'),
+      code: sessionStorage.getItem('rc_user_code')
+    }));
+
+    expect(session).toEqual({
+      role: 'student',
+      code: 'S010'
+    });
+  });
+
+  test('toolkit Word Search also has a usable exit in display-safe mode', async ({ page }) => {
+    await page.goto('/language-arts/toolkit/');
+
+    const wordSearchLink =
+      page.locator(
+        'a[href*="/viewer/"][href*="presentation-03"]'
+      ).filter({
+        hasText: 'Word Search'
+      });
+
+    await expect(wordSearchLink).toBeVisible();
+
+    await wordSearchLink.click();
+
+    await expect(page).toHaveURL(
+      /\/viewer\/\?.*presentation-03/
+    );
+
+    const exitActivity =
+      page.locator('#exitActivityBtn');
+
+    await expect(exitActivity).toBeVisible();
+
+    const wordSearch =
+      page.frameLocator('#contentIframe');
+
+    await expect(
+      wordSearch.locator('.theme-card').first()
+    ).toBeVisible({
+      timeout: 10000
+    });
+
+    // Reproduce the important classroom-display condition.
+    await page.evaluate(() => {
+      document.documentElement.classList.add(
+        'rc-display-safe'
+      );
+    });
+
+    await expect(
+      page.locator('.tc-sidebar')
+    ).toBeHidden();
+
+    await expect(exitActivity).toBeVisible();
+
+    const exitBox =
+      await exitActivity.boundingBox();
+
+    expect(exitBox).not.toBeNull();
+    expect(exitBox.height).toBeGreaterThanOrEqual(44);
+
+    // Because this launch came from the toolkit, Viewer history should
+    // return there rather than dumping the user at the site home page.
+    await exitActivity.click();
+
+    await expect(page).toHaveURL(
+      /\/language-arts\/toolkit\/$/
+    );
+
+    await expect(
+      page.getByText('Word Search', { exact: true })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused **Activities** entry point to the Student Portal and exposes the existing classroom Word Search there without redesigning the portal or changing the activity's core puzzle behavior.

### Student experience

- adds **Activities** to both Student Portal navigation surfaces
- adds a Word Search activity card
- launches Word Search through the existing Viewer
- restores the Activities tab on return
- preserves the same-tab student session across the Viewer round trip

### Viewer / classroom-display behavior

- adds an explicit **← Exit Activity** control
- keeps that exit visible and touch-friendly in display-safe mode
- preserves the intentionally hidden Viewer sidebar in display-safe mode
- existing Language Arts Toolkit access remains intact

### Word Search cleanup

- renames puzzle-level **← Back** to **← All Themes**
- fixes the legacy launcher to use an absolute Word Search redirect, eliminating the iframe 404 exposed by Chromium

## Focused verification

### Structural contract

`node --test tests/student-activities-word-search-contract.test.cjs`

- 5 passed
- 0 failed

### Chromium round-trip

`CI=1 ./node_modules/.bin/playwright test tests/student-activities-word-search.spec.js --project=chromium --reporter=line`

- 2 passed
- 0 failed

Verified:

- Student Portal → Activities → Word Search
- Word Search theme rendering
- puzzle → All Themes
- display-safe sidebar suppression
- touch-sized Exit Activity control
- return to Student Portal Activities
- same-tab student session persistence
- existing Toolkit → Word Search → Toolkit round trip

## Baseline regression evidence

The nearby pre-existing browser suites were also run against an untouched `origin/main` snapshot.

Both the feature branch and untouched `origin/main` produced the same baseline profile:

- 9 failed
- 2 passed
- 1 skipped

Those failures are therefore pre-existing and are not attributed to this slice. They primarily reflect older Student Portal auto-login assumptions and an obsolete Viewer `.app-shell-rail` expectation.

They are intentionally **not** repaired in this PR.

## Scope / non-goals

This PR does not:

- change Supabase schema, RLS, or auth
- change Netlify settings
- add grading or progress persistence
- alter Word Search puzzle data
- canonicalize duplicate legacy Word Search filenames
- redesign the Student Portal or Viewer
- deploy to production

## Remaining verification

Actual Newline Smart TV hardware verification remains a post-deploy check.

## Commit

`a5eed30c` — Add student Word Search activities access
