### PR TITLE
DB history: record August 19 migration markers

### DIFF
--- a/supabase/migrations/20260819155526_temp_allow_kragdon_recap_media_upload.sql
+++ b/supabase/migrations/20260819155526_temp_allow_kragdon_recap_media_upload.sql
@@ -1,0 +1,19 @@
+-- MIGRATION-HISTORY MARKER ONLY — NO EXECUTABLE SQL
+--
+-- Production migration version:
+--   20260819155526
+--
+-- Production migration name:
+--   temp_allow_kragdon_recap_media_upload
+--
+-- Historical event:
+--   Production temporarily allowed upload of specific Kragdon recap media
+--   objects. That temporary storage policy was removed minutes later by
+--   migration 20260819155953.
+--
+-- Current-state verification on 2026-08-27 confirmed that the temporary
+-- policy is absent from production.
+--
+-- This local file intentionally performs NO SQL. Its only purpose is to
+-- preserve truthful migration-version history in the repository without
+-- recreating an obsolete temporary permission.

--- a/supabase/migrations/20260819155953_remove_temp_kragdon_recap_media_upload_policy.sql
+++ b/supabase/migrations/20260819155953_remove_temp_kragdon_recap_media_upload_policy.sql
@@ -1,0 +1,18 @@
+-- MIGRATION-HISTORY MARKER ONLY — NO EXECUTABLE SQL
+--
+-- Production migration version:
+--   20260819155953
+--
+-- Production migration name:
+--   remove_temp_kragdon_recap_media_upload_policy
+--
+-- Historical event:
+--   Production removed the temporary Kragdon recap media upload policy
+--   created by migration 20260819155526.
+--
+-- Current-state verification on 2026-08-27 confirmed that the temporary
+-- policy is absent from production.
+--
+-- This local file intentionally performs NO SQL. Its only purpose is to
+-- preserve truthful migration-version history in the repository. The
+-- historical create/drop sequence is not replayed.


### PR DESCRIPTION
## Purpose

Normalize repository migration history for two legitimate production migrations from August 19, 2026.

Production recorded:

- `20260819155526_temp_allow_kragdon_recap_media_upload`
- `20260819155953_remove_temp_kragdon_recap_media_upload_policy`

The first temporarily enabled narrowly scoped Kragdon recap media uploads; the second removed that policy minutes later.

## Current production state

Read-only production verification confirmed the temporary policy is no longer present.

## This PR

Adds two local history-marker migration files using the exact production versions and names.

Both files:

- contain comments only
- contain no executable SQL
- do not recreate the temporary upload permission
- do not change schema, RLS, functions, or data
- exist only to keep truthful local/remote migration-version history aligned

No production migration is applied by this PR.
