### PR TITLE
Preserve date-only evidence calendar dates

### DIFF
--- a/site/student/index.html
+++ b/site/student/index.html
@@ -6808,6 +6808,6 @@
     <script src="/web/rc-modal.js?v=20260418-catalog"></script>
     <script src="/assets/vendor/jszip/jszip.min.js"></script>
     <script src="/assets/vendor/epubjs/epub.min.js"></script>
-    <script defer src="/web/student-portal-init.js?v=20260826"></script>
+    <script defer src="/web/student-portal-init.js?v=20260828-dateonly"></script>
   </body>
 </html>

--- a/site/web/student-portal-init.js
+++ b/site/web/student-portal-init.js
@@ -296,10 +296,29 @@
    */
   function formatDate(dateStr) {
     if (!dateStr) return 'N/A';
+
     try {
-      const date = new Date(dateStr);
+      const raw = String(dateStr).trim();
+
+      // A bare YYYY-MM-DD is a calendar date, not a UTC timestamp.
+      // Parse it at local midnight so negative-offset timezones do not
+      // display the previous calendar day. Full timestamps keep their
+      // existing instant/timezone semantics.
+      const date =
+        /^\d{4}-\d{2}-\d{2}$/.test(raw)
+          ? new Date(`${raw}T00:00:00`)
+          : new Date(raw);
+
       if (isNaN(date.getTime())) return 'N/A';
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+      return date.toLocaleDateString(
+        'en-US',
+        {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric'
+        }
+      );
     } catch (err) {
       return 'N/A';
     }

--- a/tests/student-goal-explanation-ui-contract.test.cjs
+++ b/tests/student-goal-explanation-ui-contract.test.cjs
@@ -46,6 +46,77 @@ console.log(
 
 
 /* -------------------------------------------------------------------------- */
+/* Date-only evidence must remain on its recorded calendar date                */
+/* -------------------------------------------------------------------------- */
+
+const formatDateMatch =
+  studentUi.match(
+    /function formatDate\(dateStr\) \{[\s\S]*?\n {2}\}/
+  );
+
+assert.ok(
+  formatDateMatch,
+  'Student Portal formatDate helper must remain discoverable'
+);
+
+const formatDateForTest =
+  new Function(
+    `return (${formatDateMatch[0]});`
+  )();
+
+const originalTz =
+  process.env.TZ;
+
+try {
+  process.env.TZ =
+    'America/Chicago';
+
+  assert.strictEqual(
+    formatDateForTest(
+      '2026-08-27'
+    ),
+    'Aug 27, 2026',
+    'date-only objective evidence must not drift to Aug 26 in Central Time'
+  );
+
+  assert.strictEqual(
+    formatDateForTest(
+      '2026-08-27T00:00:00.000Z'
+    ),
+    'Aug 26, 2026',
+    'full UTC timestamps must retain normal instant/timezone semantics'
+  );
+
+  assert.strictEqual(
+    formatDateForTest(
+      'not-a-date'
+    ),
+    'N/A',
+    'invalid display dates must retain the existing fallback'
+  );
+} finally {
+  if (
+    originalTz === undefined
+  ) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ =
+      originalTz;
+  }
+}
+
+assert.match(
+  formatDateMatch[0],
+  /T00:00:00/,
+  'date-only display must use an explicit local-midnight parse'
+);
+
+console.log(
+  '✓ date-only evidence stays on its recorded calendar date without changing timestamp semantics'
+);
+
+
+/* -------------------------------------------------------------------------- */
 /* One authoritative quarter-scoped explanation request                       */
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary

Fixes the Student Portal evidence-date display bug where a canonical
date-only value such as `2026-08-27` could render as Aug 26 in Central Time.

## Root cause

JavaScript parses a bare `YYYY-MM-DD` string as UTC midnight.

The server was already preserving the correct canonical evidence date.

## Fix

Student Portal `formatDate()` now distinguishes:

- date-only calendar values (`YYYY-MM-DD`)
- full timestamps

Date-only values are parsed at local midnight.

Full timestamps retain their existing instant/timezone semantics.

## Proof

America/Chicago browser/runtime verification:

- `2026-08-27` → `Aug 27, 2026`
- `2026-08-27T00:00:00.000Z` → `Aug 26, 2026`

This fixes calendar-date drift without changing true timestamp behavior.

## QA

PASS:

- Student Goal Explanation UI contract
- Student Goal Explanation helper contract
- Student Goal Explanation server architecture contract
- school-local date tests
- school-local date integration tests
- JavaScript syntax
- ESLint
- diff whitespace validation
- local Playwright/browser render proof

## Scope

Changed files only:

- `site/web/student-portal-init.js`
- `site/student/index.html`
- `tests/student-goal-explanation-ui-contract.test.cjs`

## Safety

- no database changes
- no schema/RLS/auth changes
- no evidence mutation changes
- no objective scoring changes
- no assignment behavior changes
- no merge performed
- no production deploy performed
