### PR TITLE
Fix Add Student signed teacher identity

### DIFF
--- a/netlify/functions/teacher-student-onboard.js
+++ b/netlify/functions/teacher-student-onboard.js
@@ -76,6 +76,15 @@ const CODE_PATTERN =
 
 const MAX_CLASSES = 16;
 
+function isUuid(value) {
+  return (
+    typeof value === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value
+    )
+  );
+}
+
 class OnboardError extends Error {
   constructor(
     statusCode,
@@ -496,29 +505,6 @@ function validateReusableLogin({
       'The existing student login is linked to a different student record.'
     );
   }
-}
-
-async function resolveTeacherId(
-  username
-) {
-  const rows =
-    await queryRows(
-      '/rest/v1/teacher' +
-      '?select=id,username' +
-      `&username=eq.${encodeURIComponent(username)}` +
-      '&limit=2',
-      'Teacher identity'
-    );
-
-  if (
-    rows.length !== 1
-  ) {
-    throw new Error(
-      'Teacher ownership identity could not be resolved'
-    );
-  }
-
-  return rows[0].id;
 }
 
 async function resolveOwnedClasses({
@@ -1017,24 +1003,19 @@ exports.handler =
           request.code,
       });
 
-      const teacherUsername =
-        String(
-          teacherAuth.user
-            ?.username || ''
-        ).trim();
+      const teacherId =
+        teacherAuth.user &&
+        teacherAuth.user.teacherId;
 
-      if (!teacherUsername) {
-        throw new Error(
-          'Teacher username is unavailable'
+      if (!isUuid(teacherId)) {
+        throw new OnboardError(
+          403,
+          'Verified teacher session has no usable teacher identity'
         );
       }
 
-      // Resolve every requested class before the first write.
-      const teacherId =
-        await resolveTeacherId(
-          teacherUsername
-        );
-
+      // Resolve every requested class against the signed teacher identity
+      // before the first write.
       const ownedClasses =
         await resolveOwnedClasses({
           teacherId,

--- a/tests/teacher-student-onboard-contract.test.cjs
+++ b/tests/teacher-student-onboard-contract.test.cjs
@@ -135,11 +135,33 @@ assert.match(
 
 assert.match(
   endpoint,
+  /teacherAuth\.user\.teacherId/
+);
+
+assert.match(
+  endpoint,
+  /isUuid\(teacherId\)/
+);
+
+assert.match(
+  endpoint,
   /resolveOwnedClasses/
 );
 
+assert.ok(
+  !endpoint.includes(
+    'resolveTeacherId'
+  )
+);
+
+assert.ok(
+  !endpoint.includes(
+    '/rest/v1/teacher'
+  )
+);
+
 console.log(
-  '✓ signed teacher ownership and class ownership are explicit'
+  '✓ signed teacherId directly scopes canonical class ownership'
 );
 
 assert.match(

--- a/tests/teacher-student-onboard-handler.test.cjs
+++ b/tests/teacher-student-onboard-handler.test.cjs
@@ -20,6 +20,12 @@ const authPath =
 const realAuth =
   require(authPath);
 
+const SYNTHETIC_TEACHER_ID =
+  '11111111-1111-4111-8111-111111111111';
+
+let signedTeacherId =
+  SYNTHETIC_TEACHER_ID;
+
 require.cache[authPath].exports = {
   ...realAuth,
 
@@ -31,6 +37,9 @@ require.cache[authPath].exports = {
       user: {
         username:
           'synthetic-teacher',
+
+        teacherId:
+          signedTeacherId,
       },
     };
   },
@@ -250,22 +259,6 @@ function makeBackend({
     if (
       call.method === 'GET' &&
       call.path ===
-        '/rest/v1/teacher'
-    ) {
-      return mockResponse(
-        200,
-        [{
-          id:
-            'teacher-1',
-          username:
-            'synthetic-teacher',
-        }]
-      );
-    }
-
-    if (
-      call.method === 'GET' &&
-      call.path ===
         '/rest/v1/classes'
     ) {
       return mockResponse(
@@ -278,7 +271,7 @@ function makeBackend({
           name:
             'Language Arts 1 SC',
           teacher_id:
-            'teacher-1',
+            SYNTHETIC_TEACHER_ID,
         }]
       );
     }
@@ -502,7 +495,7 @@ async function newStudentCase() {
     );
 
   assert.ok(
-    firstWrite >= 4
+    firstWrite >= 3
   );
 
   assert.ok(
@@ -516,6 +509,35 @@ async function newStudentCase() {
           call.method ===
           'GET'
       )
+  );
+
+  assert.equal(
+    backend.calls.some(
+      call =>
+        call.path ===
+          '/rest/v1/teacher'
+    ),
+    false
+  );
+
+  const classRead =
+    backend.calls.find(
+      call =>
+        call.method === 'GET' &&
+        call.path ===
+          '/rest/v1/classes'
+    );
+
+  assert.ok(
+    classRead
+  );
+
+  assert.match(
+    classRead.search,
+    new RegExp(
+      'teacher_id=eq\\.' +
+      SYNTHETIC_TEACHER_ID
+    )
   );
 
   const studentWrite =
@@ -748,6 +770,50 @@ async function reuseExistingLoginCase() {
   );
 }
 
+async function missingSignedTeacherIdCase() {
+  const backend =
+    makeBackend();
+
+  global.fetch =
+    backend.fetchMock;
+
+  signedTeacherId =
+    null;
+
+  try {
+    const result =
+      await handler(
+        onboardingEvent()
+      );
+
+    assert.equal(
+      result.statusCode,
+      403
+    );
+
+    assert.equal(
+      writes(backend).length,
+      0
+    );
+
+    assert.equal(
+      backend.calls.some(
+        call =>
+          call.path ===
+            '/rest/v1/teacher'
+      ),
+      false
+    );
+  } finally {
+    signedTeacherId =
+      SYNTHETIC_TEACHER_ID;
+  }
+
+  console.log(
+    '✓ missing signed teacherId fails closed before writes'
+  );
+}
+
 async function inactiveStudentCase() {
   const backend =
     makeBackend({
@@ -961,6 +1027,7 @@ async function repairedStudentRollbackCase() {
     await newStudentCase();
     await repairMissingLoginCase();
     await reuseExistingLoginCase();
+    await missingSignedTeacherIdCase();
     await inactiveStudentCase();
     await orphanLoginCase();
     await malformedExistingLoginCase();


### PR DESCRIPTION
## Goal

Repair the signed Teacher Add Student POST path so class ownership uses the canonical `teacherId` already present in the verified Teacher Center session.

## Change

- use `teacherAuth.user.teacherId` directly
- validate the signed teacher identity as a UUID
- remove the redundant `/rest/v1/teacher?username=...` lookup
- continue scoping requested classes through `classes.teacher_id`
- fail closed with 403 when the signed teacher identity is missing or malformed
- preserve all existing student/login/enrollment preflight, provisioning, and rollback behavior

## Scope

Exactly 3 files:

- `netlify/functions/teacher-student-onboard.js`
- `tests/teacher-student-onboard-contract.test.cjs`
- `tests/teacher-student-onboard-handler.test.cjs`

No schema, RLS, auth-model, UI, enrollment-model, or password-policy changes.

## QA

- ESLint: PASS — 0 errors; existing warnings only
- Add Student contract QA: PASS
- mocked onboarding transaction QA: PASS
- missing signed `teacherId` fails closed before writes: PASS
- valid existing login preserved with no password mutation: PASS
- rollback behavior: PASS
- nav / asset path checks: PASS
- remaining unit-test chain: PASS
- `git diff --check`: PASS

Known unrelated baselines were separately reproduced:

- inline-script scanner: exact `origin/main` baseline — 2560 violations in 275 files
- local Mac `tc-library-helpers`: exact existing 98-pass / 3-fail date baseline

## Production defect addressed

The previously deployed onboarding endpoint attempted to re-resolve the authenticated teacher through the `teacher` table by username. Production preflight showed that lookup returning HTTP 400. This repair instead uses the already-signed canonical teacher UUID and authorizes classes directly against it.

## Safety

No production data writes were used to test this code change.
No manual deploy was performed.
