### PR TITLE
Keep AI Builder goal context in class

### DIFF
--- a/netlify/functions/teacher-ai-builder.js
+++ b/netlify/functions/teacher-ai-builder.js
@@ -111,7 +111,7 @@ function isCriterionConflictSchemaError(result) {
 
 async function fetchActiveGoalsForContext(requestId) {
   var querySuffix =
-    '&active=eq.true&order=code.asc';
+    '&active=eq.true&addressed_in_class=eq.true&order=code.asc';
 
   var enrichedRes =
     await rest(

--- a/tests/criterion-conflict-ai-builder-context.test.cjs
+++ b/tests/criterion-conflict-ai-builder-context.test.cjs
@@ -351,6 +351,13 @@ async function conflictCase() {
 
   assert.ok(
     goalCalls[0].includes(
+      'addressed_in_class=eq.true'
+    ),
+    'AI Builder goal context must include only goals addressed in class'
+  );
+
+  assert.ok(
+    goalCalls[0].includes(
       'target'
     )
   );
@@ -418,6 +425,16 @@ async function schemaFallbackCase() {
   assert.strictEqual(
     goalCalls.length,
     2
+  );
+
+  assert.ok(
+    goalCalls.every(
+      value =>
+        value.includes(
+          'addressed_in_class=eq.true'
+        )
+    ),
+    'both primary and compatibility goal queries must remain in-class-only'
   );
 
   assert.ok(


### PR DESCRIPTION
## Goal

Protect assignment generation before expanding the canonical IEP goal registry.

The source workbook contains current goals that must be captured for completeness even when they are Math, related-service/provider-owned, supporting-only, excluded, or otherwise outside Dan's direct instructional monitoring responsibility.

This change prevents those completeness-only goals from entering AI Builder assignment context.

## Change

AI Builder now requests only goals where:

- `active = true`
- `addressed_in_class = true`

The existing criterion-conflict compatibility fallback uses the same filter.

## Scope

Exactly two files:

- `netlify/functions/teacher-ai-builder.js`
- `tests/criterion-conflict-ai-builder-context.test.cjs`

## Local verification

- exact production base verified
- syntax checks passed
- targeted AI Builder criterion-conflict context regression passed
- explicit in-class-only query assertion added
- compatibility/fallback query verified to retain the same filter
- `git diff --check` passed

## Safety

- no database change
- no schema/RLS/auth change
- no goal import
- no objective import
- no evidence change
- no assignment mapping change
- no deployment performed

This guard must be production-verified before the registry-completeness data import proceeds.
