### PR TITLE
Fix manual objective evidence teacher authentication

### DIFF
--- a/netlify/functions/teacher-manual-objective-evidence.js
+++ b/netlify/functions/teacher-manual-objective-evidence.js
@@ -33,6 +33,10 @@ const {
 );
 
 const {
+  SESSION_SECRET,
+} = process.env;
+
+const {
   normalizeManualObjectiveRequest,
   schoolYearFromObjectiveDate,
   buildManualObjectiveEvidenceRow,
@@ -616,7 +620,7 @@ exports.handler =
     const authResult =
       await requireTeacher(
         event,
-        requestId
+        SESSION_SECRET
       );
 
     if (

--- a/tests/teacher-manual-objective-evidence-registry-endpoint.test.cjs
+++ b/tests/teacher-manual-objective-evidence-registry-endpoint.test.cjs
@@ -132,12 +132,19 @@ const savedKey =
   process.env
     .SUPABASE_SERVICE_ROLE_KEY;
 
+const savedSessionSecret =
+  process.env
+    .SESSION_SECRET;
+
 process.env.SUPABASE_URL =
   'https://example.supabase.test';
 
 process.env
   .SUPABASE_SERVICE_ROLE_KEY =
   'test-service-role';
+
+process.env.SESSION_SECRET =
+  'manual-objective-session-secret';
 
 cacheStub(
   httpAbsolute,
@@ -182,7 +189,16 @@ cacheStub(
 cacheStub(
   authAbsolute,
   {
-    async requireTeacher() {
+    async requireTeacher(
+      _event,
+      secret
+    ) {
+      assert.strictEqual(
+        secret,
+        process.env.SESSION_SECRET,
+        'manual objective endpoint must authenticate with SESSION_SECRET'
+      );
+
       return {
         ok:
           true,
@@ -872,6 +888,18 @@ main()
       process.env
         .SUPABASE_SERVICE_ROLE_KEY =
         savedKey;
+    }
+
+    if (
+      savedSessionSecret ===
+      undefined
+    ) {
+      delete process.env
+        .SESSION_SECRET;
+    } else {
+      process.env
+        .SESSION_SECRET =
+        savedSessionSecret;
     }
 
     delete require.cache[


### PR DESCRIPTION
## Manual Objective Evidence Auth Repair

Production verification after PR #1436 exposed a narrow authentication wiring defect in the manual/binder objective-evidence endpoint.

### Defect

`teacher-manual-objective-evidence.js` called:

`requireTeacher(event, requestId)`

The shared Teacher auth helper requires the second argument to be `SESSION_SECRET`, so a valid signed Teacher session was rejected with HTTP 401 before any objective evidence could be written.

### Repair

- source `SESSION_SECRET` from the server environment
- call `requireTeacher(event, SESSION_SECRET)`
- strengthen the live-registry manual-evidence endpoint regression so the auth stub explicitly verifies the exact secret argument
- restore the prior `SESSION_SECRET` test environment after execution

### Scope

Exactly two files:

- `netlify/functions/teacher-manual-objective-evidence.js`
- `tests/teacher-manual-objective-evidence-registry-endpoint.test.cjs`

### Verification

Passing focused contracts:

- live-registry manual objective evidence permission fence
- manual objective evidence server contract
- manual objective evidence Teacher UI contract
- Teacher roster signed endpoint
- Teacher roster browser boundary
- Teacher Student onboarding contract

Full local `test:unit` proceeds through the auth/objective stack and then reaches the established Mac-local `tc-library-helpers.test.cjs` baseline:

- August school-year label
- Monday same-week label
- cross-month week label

Those three unrelated date-format failures are outside this repair and this commit changes none of their files.

### Safety

- no Supabase schema/RLS/auth changes
- no Netlify configuration changes
- no objective evidence data write
- no parent progress mutation
- no academic grade mutation
- no assignment/submission behavior change
- no Observation Tray behavior change
